### PR TITLE
logging: add a helper for registering a rotating file log that captures all output regardless of stdout log level

### DIFF
--- a/software/main_hcs.py
+++ b/software/main_hcs.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
 
     if args.verbose:
         log.info("Turning on debug logging.")
-        squid.logging.set_log_level(logging.DEBUG)
+        squid.logging.set_stdout_log_level(logging.DEBUG)
 
     if not squid.logging.add_file_logging(f"{squid.logging.get_default_log_directory()}/main_hcs.log"):
         log.error("Couldn't setup logging to file!")

--- a/software/main_hcs.py
+++ b/software/main_hcs.py
@@ -43,6 +43,10 @@ if __name__ == "__main__":
         log.info("Turning on debug logging.")
         squid.logging.set_log_level(logging.DEBUG)
 
+    if not squid.logging.add_file_logging(f"{squid.logging.get_default_log_directory()}/main_hcs.log"):
+        log.error("Couldn't setup logging to file!")
+        sys.exit(1)
+
     legacy_config = False
     cf_editor_parser = ConfigParser()
     config_files = glob.glob('.' + '/' + 'configuration*.ini')

--- a/software/main_malaria.py
+++ b/software/main_malaria.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.verbose:
-        squid.logging.set_log_level(logging.DEBUG)
+        squid.logging.set_stdout_log_level(logging.DEBUG)
 
     legacy_config = False
     cf_editor_parser = ConfigParser()

--- a/software/squid/logging.py
+++ b/software/squid/logging.py
@@ -64,7 +64,7 @@ log = get_logger(__name__)
 
 def set_stdout_log_level(level):
     """
-    All squid code should use this set_log_level method, and the corresponding squid.logging.get_logger,
+    All squid code should use this set_stdout_log_level method, and the corresponding squid.logging.get_logger,
     to control squid-only logging.
 
     This does not modify the log level of loggers outside the squid logger hierarchy! If global logging control

--- a/software/squid/logging.py
+++ b/software/squid/logging.py
@@ -41,9 +41,11 @@ _COLOR_STREAM_HANDLER.setFormatter(_CustomFormatter())
 
 # Make sure the squid root logger has all the handlers we want setup.  We could move this into a helper so it
 # isn't done at the module level, but not needing to remember to call some helper to setup formatting is nice.
-# Also set the default logging level to INFO
+# Also set the default logging level to INFO on the stream handler, but DEBUG on the root logger so we can have
+# other loggers at different levels.
+_COLOR_STREAM_HANDLER.setLevel(py_logging.INFO)
 py_logging.getLogger(_squid_root_logger_name).addHandler(_COLOR_STREAM_HANDLER)
-py_logging.getLogger(_squid_root_logger_name).setLevel(py_logging.INFO)
+py_logging.getLogger(_squid_root_logger_name).setLevel(py_logging.DEBUG)
 
 
 def get_logger(name: Optional[str] = None) -> py_logging.Logger:
@@ -60,27 +62,22 @@ def get_logger(name: Optional[str] = None) -> py_logging.Logger:
 
 log = get_logger(__name__)
 
-def set_log_level(level):
+def set_stdout_log_level(level):
     """
     All squid code should use this set_log_level method, and the corresponding squid.logging.get_logger,
     to control squid-only logging.
 
     This does not modify the log level of loggers outside the squid logger hierarchy! If global logging control
-    is needed the normal logging package tools can be used instead.
+    is needed the normal logging package tools can be used instead.  It also leaves FileHandler log levels such that
+    they can always be outputting everything (regardless of what we set the stdout log level to)
     """
     squid_root_logger = get_logger()
-    squid_root_logger.setLevel(level)
 
-    # There's no `getAllChildren` method on the logger or its manager, so we just grab the manager
-    # for our root logger and then check all other loggers to see if they start with our root logger prefix
-    # to find all the squid specific logger.
-    for (name, logger) in squid_root_logger.manager.loggerDict.items():
-        # The logging module uses the PlaceHolder object for nodes in the hierarchy that
-        # have children, but no associated loggers.  EG if we create a logger at
-        # squid.control.gui_hcs but not at squid.control, then the logger for squid.control
-        # exists but is a PlaceHolder (until someone explicitly requests it).
-        if name.startswith(_squid_root_logger_name) and isinstance(logger, py_logging.Logger):
-            logger.setLevel(level)
+    for handler in squid_root_logger.handlers:
+        # We always want the file handlers to capture everything, so don't touch them.
+        if isinstance(handler, logging.FileHandler):
+            continue
+        handler.setLevel(level)
 
 
 def register_crash_handler(handler, call_existing_too=True):

--- a/software/tests/squid/test_logging.py
+++ b/software/tests/squid/test_logging.py
@@ -1,3 +1,6 @@
+import logging
+import tempfile
+
 import squid.logging
 
 def test_root_logger():
@@ -13,3 +16,35 @@ def test_children_loggers():
 
     assert child_a_logger.name == f"{squid.logging._squid_root_logger_name}.{child_a}"
     assert child_b_logger.name == f"{squid.logging._squid_root_logger_name}.{child_a}.{child_b}"
+
+def test_file_loggers():
+    log_file_name = tempfile.mktemp()
+
+    def line_count():
+        with open(log_file_name, "r") as fh:
+            return len(list(fh))
+
+    def contains(string):
+        with open(log_file_name, "r") as fh:
+            for l in fh:
+                if string in l:
+                    return True
+        return False
+
+    assert squid.logging.add_file_logging(log_file_name)
+    assert not squid.logging.add_file_logging(log_file_name)
+
+    initial_line_count = line_count()
+    log = squid.logging.get_logger("log test")
+    squid.logging.set_stdout_log_level(logging.DEBUG)
+
+    log.debug("debug msg")
+    debug_ling_count = line_count()
+    assert debug_ling_count > initial_line_count
+
+    squid.logging.set_stdout_log_level(logging.INFO)
+
+    a_debug_message = "another message but when stdout is at INFO"
+    log.debug(a_debug_message)
+    assert line_count() > debug_ling_count
+    assert contains(a_debug_message)


### PR DESCRIPTION
This makes it so we can start logging to a file, and have users send the file upon crashing.  It's setup such that, regardless of `set_stdout_log_level`, all logs down to `DEBUG` go to the file.

Tested by: Unit tests, and running `main_hcs.py` with and without `--verbose` and making sure that log output appears in stdout and the log file as expected.