### PR TITLE
gitignore: add .idea/ directories.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *.pyc 
 *.xml
+**/.idea/


### PR DESCRIPTION
See title.  This just adds to the .gitignore.

Tested by: `git status` no longer shows `.idea` directories.