### PR TITLE
microcontroller: fix reset cmd_id bug

### DIFF
--- a/software/control/microcontroller.py
+++ b/software/control/microcontroller.py
@@ -83,11 +83,14 @@ class Microcontroller:
         self.serial.close()
 
     def reset(self):
-        self._cmd_id = 0
         cmd = bytearray(self.tx_buffer_length)
         cmd[1] = CMD_SET.RESET
-        self.send_command(cmd)
         self.log.debug("reset the microcontroller")
+        self.send_command(cmd)
+        # On the microcontroller side, reset forces the command Id back to 0
+        # so any responses will look like they are for command id 0.  Force that
+        # here.
+        self._cmd_id = 0
 
     def initialize_drivers(self):
         self._cmd_id = 0


### PR DESCRIPTION
The reset command sets the microcontroller-side command id to 0 (see [here](https://github.com/Cephla-Lab/Squid/blob/master/firmware/octopi_firmware_v2/main_controller_teensy41/main_controller_teensy41.ino#L1563)).  This means after a reset, the command progress responses from the micro have ID == 0 regardless of the id we sent.  

As it was, we'd send ID=1 for a `reset()`, and so `reset` would always time out.

This fixes this by manually forcing the post-send id we're expecting to 0.