### PR TITLE
microcontroller: for simulation, use a stub serial device instead of copy/pasted implementation

### DIFF
--- a/software/control/gui.py
+++ b/software/control/gui.py
@@ -47,7 +47,7 @@ class OctopiGUI(QMainWindow):
         # load objects
         if is_simulation:
             self.camera = camera.Camera_Simulation(rotate_image_angle=ROTATE_IMAGE_ANGLE,flip_image=FLIP_IMAGE)
-            self.microcontroller = microcontroller.Microcontroller_Simulation()
+            self.microcontroller = microcontroller.Microcontroller(existing_serial=microcontroller.SimSerial())
         else:
             try:
                 self.camera = camera.Camera(rotate_image_angle=ROTATE_IMAGE_ANGLE,flip_image=FLIP_IMAGE)

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -179,7 +179,7 @@ class HighContentScreeningGui(QMainWindow):
             self.emission_filter_wheel = serial_peripherals.FilterController_Simulation(115200, 8, serial.PARITY_NONE, serial.STOPBITS_ONE)
         if USE_OPTOSPIN_EMISSION_FILTER_WHEEL:
             self.emission_filter_wheel = serial_peripherals.Optospin_Simulation(SN=None)
-        self.microcontroller = microcontroller.Microcontroller_Simulation()
+        self.microcontroller = microcontroller.Microcontroller(existing_serial=microcontroller.SimSerial())
 
     def loadHardwareObjects(self):
         # Initialize hardware objects

--- a/software/control/gui_malaria.py
+++ b/software/control/gui_malaria.py
@@ -31,7 +31,7 @@ class MalariaGUI(QMainWindow):
         # load objects
         if is_simulation:
             self.camera = camera.Camera_Simulation(rotate_image_angle=ROTATE_IMAGE_ANGLE,flip_image=FLIP_IMAGE)
-            self.microcontroller = microcontroller.Microcontroller_Simulation()
+            self.microcontroller = microcontroller.Microcontroller(existing_serial=microcontroller.SimSerial())
         else:
             try:
                 self.camera = camera.Camera(rotate_image_angle=ROTATE_IMAGE_ANGLE,flip_image=FLIP_IMAGE)
@@ -44,7 +44,7 @@ class MalariaGUI(QMainWindow):
                 self.microcontroller = microcontroller.Microcontroller(version=CONTROLLER_VERSION)
             except:
                 self.log.error("Microcontroller not detected, using simulated microcontroller")
-                self.microcontroller = microcontroller.Microcontroller_Simulation()
+                self.microcontroller = microcontroller.Microcontroller(existing_serial=microcontroller.SimSerial())
 
         # reset the MCU
         self.microcontroller.reset()


### PR DESCRIPTION
Before, the `Microcontroller_Simulation` implementation was a bunch of copy/pasted code from the `Microcontroller` simulation.  This wasn't ideal because we needed to keep them in sync for simulation to reflect reality, and since we needed to have some small differences (eg: no reader thread) we weren't testing the actual `Microcontroller` code paths in simulation mode.

this moves the simulation stub down one level to `Serial`, and sets it up so we can have custom simulated serial implementations in the future that, for instance, can keep track of positions and act more like the real firmware.