### PR TITLE
interface: start pulling out the stage concept

### DIFF
--- a/software/squid/abc.py
+++ b/software/squid/abc.py
@@ -13,7 +13,8 @@ class Pos(pydantic.BaseModel):
     x_mm: float
     y_mm: float
     z_mm: float
-    theta_rad: float
+    # NOTE/TODO(imo): If essentially none of our stages have a theta, this is probably fine.  But If it's a mix we probably want a better way of handling the "maybe has theta" case.
+    theta_rad: Optional[float]
 
 class StageStage(pydantic.BaseModel):
     busy: bool
@@ -81,7 +82,7 @@ class AbstractStage(metaclass=abc.ABCMeta):
         pass
 
     def get_config(self) -> StageConfig:
-        pass
+        return self._config
 
     def wait_for_idle(self, timeout_s):
         start_time = time.time()

--- a/software/squid/abc.py
+++ b/software/squid/abc.py
@@ -1,0 +1,98 @@
+import abc
+import time
+from typing import Optional
+
+import pydantic
+
+import squid.logging
+from squid.config import AxisConfig, StageConfig
+from squid.exceptions import SquidTimeout
+
+
+class Pos(pydantic.BaseModel):
+    x_mm: float
+    y_mm: float
+    z_mm: float
+    theta_rad: float
+
+class StageStage(pydantic.BaseModel):
+    busy: bool
+
+class AbstractStage(metaclass=abc.ABCMeta):
+    def __init__(self, stage_config: StageConfig):
+        self._config = stage_config
+        self._log = squid.logging.get_logger(self.__class__.__name__)
+
+    @abc.abstractmethod
+    def move_x(self, rel_mm: float, blocking: bool=True):
+        pass
+
+    @abc.abstractmethod
+    def move_y(self, rel_mm: float, blocking: bool=True):
+        pass
+
+    @abc.abstractmethod
+    def move_z(self, rel_mm: float, blocking: bool=True):
+        pass
+
+    @abc.abstractmethod
+    def move_x_to(self, abs_mm: float, blocking: bool=True):
+        pass
+
+    @abc.abstractmethod
+    def move_y_to(self, abs_mm: float, blocking: bool=True):
+        pass
+
+    @abc.abstractmethod
+    def move_z_to(self, abs_mm: float, blocking: bool=True):
+        pass
+
+    # TODO(imo): We need a stop or halt or something along these lines
+    # @abc.abstractmethod
+    # def stop(self, blocking: bool=True):
+    #     pass
+
+    @abc.abstractmethod
+    def get_pos(self) -> Pos:
+        pass
+
+    @abc.abstractmethod
+    def get_state(self) -> StageStage:
+        pass
+
+    @abc.abstractmethod
+    def home(self, x: bool, y: bool, z: bool, theta: bool, blocking: bool=True):
+        pass
+
+    @abc.abstractmethod
+    def zero(self, x: bool, y: bool, z: bool, theta: bool, blocking: bool=True):
+        pass
+
+    @abc.abstractmethod
+    def set_limits(self,
+                   x_pos_mm: Optional[float] = None,
+                   x_neg_mm: Optional[float] = None,
+                   y_pos_mm: Optional[float] = None,
+                   y_neg_mm: Optional[float] = None,
+                   z_pos_mm: Optional[float] = None,
+                   z_neg_mm: Optional[float] = None,
+                   theta_pos_rad: Optional[float] = None,
+                   theta_neg_rad: Optional[float] = None):
+        pass
+
+    def get_config(self) -> StageConfig:
+        pass
+
+    def wait_for_idle(self, timeout_s):
+        start_time = time.time()
+        while time.time() < start_time + timeout_s:
+            if not self.get_state().busy:
+                return
+            # Sleep some small amount of time so we can yield to other threads if needed
+            # while waiting.
+            time.sleep(0.001)
+
+        error_message = f"Timed out waiting after {timeout_s:0.3f} [s]"
+        self._log.error(error_message)
+
+        raise SquidTimeout(error_message)

--- a/software/squid/config.py
+++ b/software/squid/config.py
@@ -1,0 +1,117 @@
+import enum
+import math
+
+import pydantic
+
+import control._def as _def
+
+class DirectionSign(enum.IntEnum):
+    DIRECTION_SIGN_POSITIVE = 1
+    DIRECTION_SIGN_NEGATIVE = -1
+
+class AxisConfig(pydantic.BaseModel):
+    MOVEMENT_SIGN: DirectionSign
+    USE_ENCODER: bool
+    ENCODER_SIGN: DirectionSign
+    # If this is a linear axis, this is the distance the axis must move to see 1 encoder step.  If this
+    # is a rotary axis, this is the radians travelled by the axis to see 1 encoder step.
+    ENCODER_STEP_SIZE: float
+    FULL_STEPS_PER_REV: float
+
+    # For linear axes, this is the mm traveled by the axis when 1 full step is taken by the motor.  For rotary
+    # axes, this is the rad traveled by the axis when 1 full step is taken by the motor.
+    SCREW_PITCH: float
+
+    # The number of microsteps per full step the axis uses (or should use if we can set it).
+    # If MICROSTEPS_PER_STEP == 8, and SCREW_PITCH=2, then in 8 commanded steps the motor will do 1 full
+    # step and so will travel a distance of 2.
+    MICROSTEPS_PER_STEP: float
+
+    # The Max speed the axis is allowed to travel in denoted in its native units.  This means mm/s for
+    # linear axes, and radians/s for rotary axes.
+    MAX_SPEED: float
+    MAX_ACCELERATION: float
+
+    # The min and maximum position of this axis in its native units.  This means mm for linear axes, and
+    # radians for rotary.  `inf` is allowed (for something like a continuous rotary axis)
+    MIN_POSITION: float
+    MAX_POSITION: float
+
+    def convert_to_real_units(self, usteps: float):
+        if self.USE_ENCODER:
+            # TODO(imo): Do we need ENCODER_SIGN here too?
+            return usteps * self.MOVEMENT_SIGN.value * self.ENCODER_STEP_SIZE
+        else:
+            return usteps * self.MOVEMENT_SIGN.value * self.SCREW_PITCH / (self.MICROSTEPS_PER_STEP * self.FULLSTEPS_PER_REV)
+
+    def convert_real_units_to_ustep(self, real_unit: float):
+        return real_unit / (self.MOVEMENT_SIGN.value * self.SCREW_PITCH / (self.MICROSTEPS_PER_STEP * self.FULLSTEPS_PER_REV))
+
+class StageConfig(pydantic.BaseModel):
+    X_AXIS: AxisConfig
+    Y_AXIS: AxisConfig
+    Z_AXIS: AxisConfig
+    THETA_AXIS: AxisConfig
+
+# NOTE(imo): This is temporary until we can just pass in instances of AxisConfig wherever we need it.  Having
+# this getter for the temporary singleton will help with the refactor once we can get rid of it.
+_stage_config = StageConfig(
+    X_AXIS=AxisConfig(
+        MOVEMENT_SIGN=_def.STAGE_MOVEMENT_SIGN_X,
+        USE_ENCODER=_def.USE_ENCODER_X,
+        ENCODER_SIGN=_def.ENCODER_POS_SIGN_X,
+        ENCODER_STEP_SIZE=_def.ENCODER_STEP_SIZE_X_MM,
+        FULL_STEPS_PER_REV=_def.FULLSTEPS_PER_REV_X,
+        SCREW_PITCH=_def.SCREW_PITCH_X_MM,
+        MICROSTEPS_PER_STEP=_def.MICROSTEPPING_DEFAULT_X,
+        MAX_SPEED=_def.MAX_VELOCITY_X_mm,
+        MAX_ACCELERATION=_def.MAX_ACCELERATION_X_mm,
+        MIN_POSITION=0,  # NOTE(imo): Min and Max need adjusting.  They are arbitrary right now!
+        MAX_POSITION=10
+    ),
+    Y_AXIS=AxisConfig(
+        MOVEMENT_SIGN=_def.STAGE_MOVEMENT_SIGN_Y,
+        USE_ENCODER=_def.USE_ENCODER_Y,
+        ENCODER_SIGN=_def.ENCODER_POS_SIGN_Y,
+        ENCODER_STEP_SIZE=_def.ENCODER_STEP_SIZE_Y_MM,
+        FULL_STEPS_PER_REV=_def.FULLSTEPS_PER_REV_Y,
+        SCREW_PITCH=_def.SCREW_PITCH_Y_MM,
+        MICROSTEPS_PER_STEP=_def.MICROSTEPPING_DEFAULT_Y,
+        MAX_SPEED=_def.MAX_VELOCITY_Y_mm,
+        MAX_ACCELERATION=_def.MAX_ACCELERATION_Y_mm,
+        MIN_POSITION=0,  # NOTE(imo): Min and Max need adjusting.  They are arbitrary right now!
+        MAX_POSITION=10
+    ),
+    Z_AXIS=AxisConfig(
+        MOVEMENT_SIGN=_def.STAGE_MOVEMENT_SIGN_Z,
+        USE_ENCODER=_def.USE_ENCODER_Z,
+        ENCODER_SIGN=_def.ENCODER_POS_SIGN_Z,
+        ENCODER_STEP_SIZE=_def.ENCODER_STEP_SIZE_Z_MM,
+        FULL_STEPS_PER_REV=_def.FULLSTEPS_PER_REV_Z,
+        SCREW_PITCH=_def.SCREW_PITCH_Z_MM,
+        MICROSTEPS_PER_STEP=_def.MICROSTEPPING_DEFAULT_Z,
+        MAX_SPEED=_def.MAX_VELOCITY_Z_mm,
+        MAX_ACCELERATION=_def.MAX_ACCELERATION_Z_mm,
+        MIN_POSITION=0,  # NOTE(imo): Min and Max need adjusting.  They are arbitrary right now!
+        MAX_POSITION=1
+    ),
+    THETA_AXIS=AxisConfig(
+        MOVEMENT_SIGN=_def.STAGE_MOVEMENT_SIGN_THETA,
+        USE_ENCODER=_def.USE_ENCODER_THETA,
+        ENCODER_SIGN=_def.ENCODER_POS_SIGN_THETA,
+        ENCODER_STEP_SIZE=_def.ENCODER_STEP_SIZE_THETA,
+        FULL_STEPS_PER_REV=_def.FULLSTEPS_PER_REV_THETA,
+        SCREW_PITCH=2.0*math.pi/_def.FULLSTEPS_PER_REV_THETA ,
+        MICROSTEPS_PER_STEP=_def.MICROSTEPPING_DEFAULT_Y,
+        MAX_SPEED=2.0 * math.pi / 4,  # NOTE(imo): I arbitrarily guessed this at 4 sec / rev, so it probably needs adjustment.
+        MAX_ACCELERATION=_def.MAX_ACCELERATION_X_mm,
+        MIN_POSITION=0,  # NOTE(imo): Min and Max need adjusting.  They are arbitrary right now!
+        MAX_POSITION=2.0 * math.pi / 4
+    )
+)
+
+"""
+Returns the StageConfig that existed at process startup.
+"""
+def get_stage_config():
+    return _stage_config

--- a/software/squid/exceptions.py
+++ b/software/squid/exceptions.py
@@ -1,0 +1,5 @@
+class SquidError(RuntimeError):
+    pass
+
+class SquidTimeout(SquidError, TimeoutError):
+    pass

--- a/software/squid/stage/cephla.py
+++ b/software/squid/stage/cephla.py
@@ -1,0 +1,151 @@
+import math
+from typing import Optional
+
+import control.microcontroller
+import control._def as _def
+from squid.abc import AbstractStage, Pos, StageStage
+from squid.config import StageConfig
+
+
+class CephlaStage(AbstractStage):
+    @staticmethod
+    def _calc_move_timeout(distance, max_speed):
+        # We arbitrarily guess that if a move takes 3x the naive "infinite acceleration" time, then it
+        # probably timed out.  But always use a minimum timeout of at least 3 seconds.
+        #
+        # Also protect against divide by zero.
+        return max((3, 3 * abs(distance) / min(0.1, abs(max_speed))))
+
+    def __init__(self, microcontroller: control.microcontroller.Microcontroller, stage_config: StageConfig):
+        super().__init__(stage_config)
+        self._microcontroller = microcontroller
+
+    def move_x(self, rel_mm: float, blocking: bool = True):
+        self._microcontroller.move_x_usteps(self._config.X_AXIS.convert_real_units_to_ustep(rel_mm))
+        if blocking:
+            self._microcontroller.wait_till_operation_is_completed(
+                self._calc_move_timeout(rel_mm, self.get_config().X_AXIS.MAX_SPEED))
+
+    def move_y(self, rel_mm: float, blocking: bool = True):
+        self._microcontroller.move_y_usteps(self._config.Y_AXIS.convert_real_units_to_ustep(rel_mm))
+        if blocking:
+            self._microcontroller.wait_till_operation_is_completed(
+                self._calc_move_timeout(rel_mm, self.get_config().Y_AXIS.MAX_SPEED))
+
+    def move_z(self, rel_mm: float, blocking: bool = True):
+        self._microcontroller.move_z_usteps(self._config.Z_AXIS.convert_real_units_to_ustep(rel_mm))
+        if blocking:
+            self._microcontroller.wait_till_operation_is_completed(
+                self._calc_move_timeout(rel_mm, self.get_config().Z_AXIS.MAX_SPEED))
+
+    def move_x_to(self, abs_mm: float, blocking: bool = True):
+        self._microcontroller.move_x_to_usteps(self._config.X_AXIS.convert_real_units_to_ustep(abs_mm))
+        if blocking:
+            self._microcontroller.wait_till_operation_is_completed(
+                self._calc_move_timeout(abs_mm - self.get_pos().x, self.get_config().X_AXIS.MAX_SPEED))
+
+    def move_y_to(self, abs_mm: float, blocking: bool = True):
+        self._microcontroller.move_y_to_usteps(self._config.Y_AXIS.convert_real_units_to_ustep(abs_mm))
+        if blocking:
+            self._microcontroller.wait_till_operation_is_completed(
+                self._calc_move_timeout(abs_mm - self.get_pos().y, self.get_config().Y_AXIS.MAX_SPEED))
+
+    def move_z_to(self, abs_mm: float, blocking: bool = True):
+        if blocking:
+            self._microcontroller.wait_till_operation_is_completed(
+                self._calc_move_timeout(abs_mm - self.get_pos().z, self.get_config().Z_AXIS.MAX_SPEED))
+
+    def get_pos(self) -> Pos:
+        pos_usteps = self._microcontroller.get_pos()
+        x_mm = self._config.X_AXIS.convert_to_real_units(pos_usteps[0])
+        y_mm = self._config.Y_AXIS.convert_to_real_units(pos_usteps[1])
+        z_mm = self._config.Z_AXIS.convert_to_real_units(pos_usteps[2])
+        theta_rad = self._config.THETA_AXIS.convert_to_real_units(pos_usteps[3])
+
+        return Pos(x_mm=x_mm, y_mm=y_mm, z_mm=z_mm, theta_rad=theta_rad)
+
+    def get_state(self) -> StageStage:
+        return StageStage(busy=self._microcontroller.is_busy())
+
+    def home(self, x: bool, y: bool, z: bool, theta: bool, blocking: bool = True):
+        # NOTE(imo): Arbitrarily use max speed / 5 for homing speed.  It'd be better to have it exactly!
+        x_timeout = self._calc_move_timeout(
+            self.get_config().X_AXIS.MAX_POSITION - self.get_config().X_AXIS.MIN_POSITION,
+            self.get_config().X_AXIS.MAX_SPEED / 5.0)
+        y_timeout = self._calc_move_timeout(
+            self.get_config().Y_AXIS.MAX_POSITION - self.get_config().Y_AXIS.MIN_POSITION,
+            self.get_config().Y_AXIS.MAX_SPEED / 5.0)
+        z_timeout = self._calc_move_timeout(
+            self.get_config().Z_AXIS.MAX_POSITION - self.get_config().Z_AXIS.MIN_POSITION,
+            self.get_config().Z_AXIS.MAX_SPEED / 5.0)
+        theta_timeout = self._calc_move_timeout(2.0 * math.pi, self.get_config().THETA_AXIS.MAX_SPEED / 5.0)
+        if x and y:
+            self._microcontroller.home_xy()
+        elif x:
+            self._microcontroller.home_x()
+        elif y:
+            self._microcontroller.home_y()
+        if blocking:
+            self._microcontroller.wait_till_operation_is_completed(max(x_timeout, y_timeout))
+
+        if z:
+            self._microcontroller.home_z()
+        if blocking:
+            self._microcontroller.wait_till_operation_is_completed(z_timeout)
+
+        if theta:
+            self._microcontroller.home_theta()
+        if blocking:
+            self._microcontroller.wait_till_operation_is_completed(theta_timeout)
+
+    def zero(self, x: bool, y: bool, z: bool, theta: bool, blocking: bool = True):
+        if x:
+            self._microcontroller.zero_x()
+        if blocking:
+            self._microcontroller.wait_till_operation_is_completed()
+
+        if y:
+            self._microcontroller.zero_y()
+        if blocking:
+            self._microcontroller.wait_till_operation_is_completed()
+
+        if z:
+            self._microcontroller.zero_z()
+        if blocking:
+            self._microcontroller.wait_till_operation_is_completed()
+
+        if theta:
+            self._microcontroller.zero_theta()
+        if blocking:
+            self._microcontroller.wait_till_operation_is_completed()
+
+    def set_limits(self, x_pos_mm: Optional[float] = None, x_neg_mm: Optional[float] = None,
+                   y_pos_mm: Optional[float] = None, y_neg_mm: Optional[float] = None, z_pos_mm: Optional[float] = None,
+                   z_neg_mm: Optional[float] = None, theta_pos_rad: Optional[float] = None,
+                   theta_neg_rad: Optional[float] = None):
+        if x_pos_mm is not None:
+            self._microcontroller.set_lim(_def.LIMIT_CODE.X_POSITIVE,
+                                          self._config.X_AXIS.convert_real_units_to_ustep(x_pos_mm))
+
+        if x_neg_mm is not None:
+            self._microcontroller.set_lim(_def.LIMIT_CODE.X_NEGATIVE,
+                                          self._config.X_AXIS.convert_real_units_to_ustep(x_neg_mm))
+
+        if y_pos_mm is not None:
+            self._microcontroller.set_lim(_def.LIMIT_CODE.Y_POSITIVE,
+                                          self._config.Y_AXIS.convert_real_units_to_ustep(y_pos_mm))
+
+        if y_neg_mm is not None:
+            self._microcontroller.set_lim(_def.LIMIT_CODE.Y_NEGATIVE,
+                                          self._config.Y_AXIS.convert_real_units_to_ustep(y_neg_mm))
+
+        if z_pos_mm is not None:
+            self._microcontroller.set_lim(_def.LIMIT_CODE.Z_POSITIVE,
+                                          self._config.Z_AXIS.convert_real_units_to_ustep(z_pos_mm))
+
+        if z_neg_mm is not None:
+            self._microcontroller.set_lim(_def.LIMIT_CODE.Z_NEGATIVE,
+                                          self._config.Z_AXIS.convert_real_units_to_ustep(z_neg_mm))
+
+        if theta_neg_rad or theta_pos_rad:
+            raise ValueError("Setting limits for the theta axis is not supported on the CephlaStage")

--- a/software/squid/stage/prior.py
+++ b/software/squid/stage/prior.py
@@ -12,7 +12,7 @@ class PriorStage(AbstractStage):
         self._not_impl()
 
     def _not_impl(self):
-        raise NotImplemented("The Prior Stage is not yet implemented!")
+        raise NotImplementedError("The Prior Stage is not yet implemented!")
 
     def move_x(self, rel_mm: float, blocking: bool = True):
         self._not_impl()

--- a/software/squid/stage/prior.py
+++ b/software/squid/stage/prior.py
@@ -1,0 +1,54 @@
+from typing import Optional
+
+from squid.abc import AbstractStage, Pos, StageStage
+from squid.config import StageConfig
+
+
+# NOTE/TODO(imo): We want to unblock getting the interface code implemented and in use, so to start we only
+# implemented the cephla stage.  As soon as we roll the interface out and get past the point of major refactors
+# to use it (we want to get past that point as fast as possible!), we'll come back to implement this.
+class PriorStage(AbstractStage):
+    def __init__(self, stage_config: StageConfig):
+        self._not_impl()
+
+    def _not_impl(self):
+        raise NotImplemented("The Prior Stage is not yet implemented!")
+
+    def move_x(self, rel_mm: float, blocking: bool = True):
+        self._not_impl()
+
+    def move_y(self, rel_mm: float, blocking: bool = True):
+        self._not_impl()
+
+    def move_z(self, rel_mm: float, blocking: bool = True):
+        self._not_impl()
+
+    def move_x_to(self, abs_mm: float, blocking: bool = True):
+        self._not_impl()
+
+    def move_y_to(self, abs_mm: float, blocking: bool = True):
+        self._not_impl()
+
+    def move_z_to(self, abs_mm: float, blocking: bool = True):
+        self._not_impl()
+
+    def get_pos(self) -> Pos:
+        self._not_impl()
+
+    def get_state(self) -> StageStage:
+        self._not_impl()
+
+    def home(self, x: bool, y: bool, z: bool, theta: bool, blocking: bool = True):
+        self._not_impl()
+
+    def zero(self, x: bool, y: bool, z: bool, theta: bool, blocking: bool = True):
+        self._not_impl()
+
+    def set_limits(self, x_pos_mm: Optional[float] = None, x_neg_mm: Optional[float] = None,
+                   y_pos_mm: Optional[float] = None, y_neg_mm: Optional[float] = None, z_pos_mm: Optional[float] = None,
+                   z_neg_mm: Optional[float] = None, theta_pos_rad: Optional[float] = None,
+                   theta_neg_rad: Optional[float] = None):
+        self._not_impl()
+
+    def get_config(self) -> StageConfig:
+        return super().get_config()

--- a/software/squid/stage/utils.py
+++ b/software/squid/stage/utils.py
@@ -1,0 +1,46 @@
+from typing import Optional
+import os
+
+import squid.logging
+from squid.abc import Pos
+from squid.config import StageConfig
+
+_log = squid.logging.get_logger(__package__)
+_DEFAULT_CACHE_PATH = "cache/last_coords.txt"
+"""
+Attempts to load a cached stage position and return it.
+"""
+def get_cached_position(cache_path=_DEFAULT_CACHE_PATH) -> Optional[Pos]:
+    if not os.path.isfile(cache_path):
+        _log.debug(f"Cache file '{cache_path}' not found, no cached pos found.")
+        return None
+    with open(cache_path, "r") as f:
+        for line in f:
+            try:
+                x, y, z = line.strip("\n").strip().split(",")
+                x = float(x)
+                y = float(y)
+                z = float(z)
+                return Pos(x_mm=x, y_mm=y, z_mm=z, theta_rad=None)
+            except RuntimeError as e:
+                raise e
+                pass
+    return None
+
+"""
+Write out the current x, y, z position, in mm, so we can use it later as a cached position.
+"""
+def cache_position(pos: Pos, stage_config: StageConfig, cache_path=_DEFAULT_CACHE_PATH):
+    x_min = stage_config.X_AXIS.MIN_POSITION
+    x_max = stage_config.X_AXIS.MAX_POSITION
+    y_min = stage_config.Y_AXIS.MIN_POSITION
+    y_max = stage_config.Y_AXIS.MAX_POSITION
+    z_min = stage_config.Z_AXIS.MIN_POSITION
+    z_max = stage_config.Z_AXIS.MAX_POSITION
+    if not (x_min <= pos.x_mm <= x_max and
+            y_min <= pos.y_mm <= y_max and
+            z_min <= pos.z_mm <= z_max):
+        raise ValueError(f"Position {pos} is not cacheable because it is outside of the min/max of at least one axis. x_range=({x_min}, {x_max}), y_range=({y_min}, {y_max}), z_range=({z_min}, {z_max})")
+    with open(cache_path, "w") as f:
+        _log.debug(f"Writing position={pos} to cache path='{cache_path}'")
+        f.write(",".join([str(pos.x_mm), str(pos.y_mm), str(pos.z_mm)]))

--- a/software/tests/squid/test_config.py
+++ b/software/tests/squid/test_config.py
@@ -1,0 +1,35 @@
+import pytest
+
+import squid.config
+from squid.config import AxisConfig
+
+
+def test_axis_config():
+    stage_config = squid.config.get_stage_config()
+    # micro step conversion round tripping
+    trials = (1.0, 0.001, 2.2, 3.123456)
+
+    # Test with easy to reason about axis config, then with real ones
+    easy_config = stage_config.X_AXIS
+    easy_config.ENCODER_SIGN = 1
+    easy_config.USE_ENCODER = False
+    # 400 steps -> 1 mm (2*200 = 1 rev, 1 rev == 1 mm)
+    easy_config.SCREW_PITCH = 1.0
+    easy_config.MICROSTEPS_PER_STEP = 2
+    easy_config.FULL_STEPS_PER_REV = 200
+
+    def round_trip_mm(config: AxisConfig, mm):
+        # Round tripping should match within 1 ustep
+        usteps = config.convert_real_units_to_ustep(mm)
+        mm_round_tripped = config.convert_to_real_units(usteps)
+        eps = abs(config.convert_to_real_units(1))
+        assert mm_round_tripped == pytest.approx(mm, abs=eps)
+
+    for trial in trials:
+        round_trip_mm(easy_config, trial)
+
+    for trial in trials:
+        round_trip_mm(stage_config.X_AXIS, trial)
+        round_trip_mm(stage_config.Y_AXIS, trial)
+        round_trip_mm(stage_config.Z_AXIS, trial)
+        round_trip_mm(stage_config.THETA_AXIS, trial)

--- a/software/tests/squid/test_stage.py
+++ b/software/tests/squid/test_stage.py
@@ -1,0 +1,34 @@
+import pytest
+import tempfile
+
+import squid.stage.cephla
+import squid.stage.prior
+import squid.stage.utils
+import squid.config
+from control.microcontroller import Microcontroller, SimSerial
+import squid.abc
+
+def test_create_simulated_stages():
+    microcontroller = Microcontroller(existing_serial=SimSerial())
+    cephla_stage = squid.stage.cephla.CephlaStage(microcontroller, squid.config.get_stage_config())
+
+    with pytest.raises(NotImplementedError):
+        prior_stage = squid.stage.prior.PriorStage(squid.config.get_stage_config())
+
+def test_simulated_cephla_stage_ops():
+    microcontroller = Microcontroller(existing_serial=SimSerial())
+    stage: squid.stage.cephla.CephlaStage = squid.stage.cephla.CephlaStage(microcontroller, squid.config.get_stage_config())
+
+    assert stage.get_pos() == squid.abc.Pos(x_mm=0.0, y_mm=0.0, z_mm=0.0, theta_rad=0.0)
+
+
+def test_position_caching():
+    (unused_temp_fd, temp_cache_path) = tempfile.mkstemp(".cache", "squid_testing_")
+
+    # Use 6 figures after the decimal so we test that we can capture nanometers
+    p = squid.abc.Pos(x_mm=11.111111, y_mm=22.222222, z_mm=1.333333, theta_rad=None)
+    squid.stage.utils.cache_position(pos=p, stage_config=squid.config.get_stage_config(), cache_path=temp_cache_path)
+
+    p_read = squid.stage.utils.get_cached_position(cache_path=temp_cache_path)
+
+    assert p_read == p


### PR DESCRIPTION
This is starting work on the "X, Y, Z Motion stage" task in https://www.notion.so/cephla/Headless-Mode-and-Scripting-Design-1452dfbf6ae480c3b444ee0847f532a5 .

It's gonna be a tricky one - we have stage-like code in a lot of places.  But the net result is that we will end up deleting a ton of tricky code (eg: all the unit conversion stuff) from a bunch of places, and instead have it all focused in one location.

The hard part isn't the stage implementation, it's finding all the places we do stage-like stuff, fixing them, and making sure nothing is broken in the process.