### PR TITLE
signal cleanup: remove redundant signals, streamline acquisition signal and slot logic

### DIFF
--- a/software/control/core.py
+++ b/software/control/core.py
@@ -2554,7 +2554,7 @@ class MultiPointController(QObject):
         self.z_stacking_config = Z_STACKING_CONFIG
 
     def set_use_piezo(self, checked):
-        print("set use_piezo to", checked)
+        print("Use Piezo:", checked)
         self.use_piezo = checked
         if hasattr(self, 'multiPointWorker'):
             self.multiPointWorker.update_use_piezo(checked)
@@ -3470,8 +3470,6 @@ class ImageDisplayWindow(QMainWindow):
 class NavigationViewer(QFrame):
 
     signal_coordinates_clicked = Signal(float, float)  # Will emit x_mm, y_mm when clicked
-    signal_update_live_scan_grid = Signal(float, float)
-    signal_update_well_coordinates = Signal(bool)
 
     def __init__(self, objectivestore, sample = 'glass slide', invertX = False, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -3491,7 +3489,6 @@ class NavigationViewer(QFrame):
         self.acquisition_size = Acquisition.CROP_HEIGHT
         self.x_mm = None
         self.y_mm = None
-        self.acquisition_started = False
         self.image_paths = {
             'glass slide': 'images/slide carrier_828x662.png',
             '4 glass slide': 'images/4 slide carrier_1509x1010.png',
@@ -3588,13 +3585,7 @@ class NavigationViewer(QFrame):
     def on_objective_changed(self):
         self.clear_overlay()
         self.update_fov_size()
-        if self.x_mm is not None and self.y_mm is not None:
-            if 'glass slide'in self.sample:
-                self.signal_update_live_scan_grid.emit(self.x_mm, self.y_mm)
-            self.draw_current_fov(self.x_mm, self.y_mm)
-
-    def on_acquisition_start(self, acquisition_started):
-        self.acquisition_started = acquisition_started
+        self.draw_current_fov(self.x_mm, self.y_mm)
 
     def update_wellplate_settings(self, sample_format, a1_x_mm, a1_y_mm, a1_x_pixel, a1_y_pixel, well_size_mm, well_spacing_mm, number_of_skip, rows, cols):
         if isinstance(sample_format, QVariant):
@@ -3646,10 +3637,6 @@ class NavigationViewer(QFrame):
             self.x_mm = x_mm
             self.y_mm = y_mm
 
-    def draw_scan_grid(self, x_mm, y_mm):
-        if 'glass slide' in self.sample and not self.acquisition_started:
-            self.signal_update_live_scan_grid.emit(x_mm, y_mm)
-
     def get_FOV_pixel_coordinates(self, x_mm, y_mm):
         if self.sample == 'glass slide':
             current_FOV_top_left = (
@@ -3698,12 +3685,6 @@ class NavigationViewer(QFrame):
         self.background_image = self.background_image_copy.copy()
         self.background_item.setImage(self.background_image)
         self.draw_current_fov(self.x_mm, self.y_mm)
-
-    def update_slide(self):
-        self.background_image = self.background_image_copy.copy()
-        self.background_item.setImage(self.background_image)
-        self.draw_current_fov(self.x_mm, self.y_mm)
-        self.signal_update_well_coordinates.emit(True)
 
     def clear_overlay(self):
         self.scan_overlay.fill(0)

--- a/software/control/core.py
+++ b/software/control/core.py
@@ -3514,7 +3514,7 @@ class NavigationViewer(QFrame):
         self.graphics_widget = pg.GraphicsLayoutWidget()
         self.graphics_widget.setBackground("w")
 
-        self.view = self.graphics_widget.addViewBox(invertX=invertX, invertY=True)
+        self.view = self.graphics_widget.addViewBox(invertX=not INVERTED_OBJECTIVE, invertY=True)
         self.view.setAspectLocked(True)
 
         self.grid = QVBoxLayout()
@@ -3567,15 +3567,11 @@ class NavigationViewer(QFrame):
             self.mm_per_pixel = 0.084665
             self.origin_x_pixel = 50
             self.origin_y_pixel = 0
-            self.view.invertX(False)
-            self.view.invertY(True)
         else:
             self.location_update_threshold_mm = 0.05
             self.mm_per_pixel = 0.084665
             self.origin_x_pixel = self.a1_x_pixel - (self.a1_x_mm)/self.mm_per_pixel
             self.origin_y_pixel = self.a1_y_pixel - (self.a1_y_mm)/self.mm_per_pixel
-            self.view.invertX(False)
-            self.view.invertY(True)
         self.update_fov_size()
 
     def update_fov_size(self):

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -876,10 +876,10 @@ class HighContentScreeningGui(QMainWindow):
             dialog.exec_()
 
     def onTabChanged(self, index):
-        is_flexible = (index == self.recordTabWidget.indexOf(self.flexibleMultiPointWidget)) if ENABLE_FLEXIBLE_MULTIPOINT else False
-        is_scan_grid = (index == self.recordTabWidget.indexOf(self.wellplateMultiPointWidget)) if ENABLE_WELLPLATE_MULTIPOINT else False
+        is_flexible_acquisition = (index == self.recordTabWidget.indexOf(self.flexibleMultiPointWidget)) if ENABLE_FLEXIBLE_MULTIPOINT else False
+        is_wellplate_acquisition = (index == self.recordTabWidget.indexOf(self.wellplateMultiPointWidget)) if ENABLE_WELLPLATE_MULTIPOINT else False
 
-        if is_scan_grid:
+        if is_wellplate_acquisition:
             if self.wellplateMultiPointWidget.combobox_shape.currentText() == 'Manual':
                 # trigger manual shape update
                 if self.wellplateMultiPointWidget.manual_shapes:
@@ -889,12 +889,12 @@ class HighContentScreeningGui(QMainWindow):
                 self.navigationViewer.clear_overlay()
                 self.wellSelectionWidget.onSelectionChanged()
 
-        elif is_flexible:
+        elif is_flexible_acquisition:
             # trigger flexible regions update
             self.wellplateMultiPointWidget.clear_regions()
             self.flexibleMultiPointWidget.update_fov_positions()
 
-        self.toggleWellSelector(is_scan_grid and self.wellSelectionWidget.format != 'glass slide')
+        self.toggleWellSelector(is_wellplate_acquisition and self.wellSelectionWidget.format != 'glass slide')
         acquisitionWidget = self.recordTabWidget.widget(index)
         if ENABLE_STITCHER:
             self.toggleStitcherWidget(acquisitionWidget.checkbox_stitchOutput.isChecked())
@@ -1022,8 +1022,8 @@ class HighContentScreeningGui(QMainWindow):
             self.liveControlWidget.toggle_autolevel(not acquisition_started)
 
         # hide well selector during acquisition
-        is_scan_grid = (current_index == self.recordTabWidget.indexOf(self.wellplateMultiPointWidget)) if ENABLE_WELLPLATE_MULTIPOINT else False
-        if is_scan_grid and self.wellSelectionWidget.format != 'glass slide':
+        is_wellplate_acquisition = (current_index == self.recordTabWidget.indexOf(self.wellplateMultiPointWidget)) if ENABLE_WELLPLATE_MULTIPOINT else False
+        if is_wellplate_acquisition and self.wellSelectionWidget.format != 'glass slide':
             self.toggleWellSelector(not acquisition_started)
 
         # display acquisition progress bar during acquisition

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -882,8 +882,13 @@ class HighContentScreeningGui(QMainWindow):
         self.toggleWellSelector(is_scan_grid and self.wellSelectionWidget.format != 'glass slide')
         
         if is_scan_grid:
-            self.navigationViewer.clear_overlay()
-            self.wellSelectionWidget.onSelectionChanged()
+            if self.wellplateMultiPointWidget.combobox_shape.currentText() == 'Manual':
+                if self.wellplateMultiPointWidget.manual_shapes:
+                    # Preserve manual shapes by triggering manual shape update
+                    self.wellplateMultiPointWidget.update_manual_shape(self.wellplateMultiPointWidget.manual_shapes)
+            else:
+                self.navigationViewer.clear_overlay()
+                self.wellSelectionWidget.onSelectionChanged()
         else:
             self.wellplateMultiPointWidget.clear_regions()
 
@@ -893,7 +898,6 @@ class HighContentScreeningGui(QMainWindow):
         if ENABLE_STITCHER:
             self.toggleStitcherWidget(acquisitionWidget.checkbox_stitchOutput.isChecked())
         acquisitionWidget.emit_selected_channels()
-
 
     def resizeCurrentTab(self, tabWidget):
         current_widget = tabWidget.currentWidget()

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -637,6 +637,7 @@ class HighContentScreeningGui(QMainWindow):
 
         if ENABLE_FLEXIBLE_MULTIPOINT:
             self.flexibleMultiPointWidget.signal_acquisition_started.connect(self.toggleAcquisitionStart)
+            # self.flexibleMultiPointWidget.signal_z_stacking.connect(self.multipointController.set_z_stacking_config)
             if ENABLE_STITCHER:
                 self.flexibleMultiPointWidget.signal_stitcher_widget.connect(self.toggleStitcherWidget)
                 self.flexibleMultiPointWidget.signal_acquisition_channels.connect(self.stitcherWidget.updateRegistrationChannels)
@@ -644,6 +645,7 @@ class HighContentScreeningGui(QMainWindow):
 
         if ENABLE_WELLPLATE_MULTIPOINT:
             self.wellplateMultiPointWidget.signal_acquisition_started.connect(self.toggleAcquisitionStart)
+            # self.wellplateMultiPointWidget.signal_z_stacking.connect(self.multipointController.set_z_stacking_config)
             if ENABLE_STITCHER:
                 self.wellplateMultiPointWidget.signal_stitcher_widget.connect(self.toggleStitcherWidget)
                 self.wellplateMultiPointWidget.signal_acquisition_channels.connect(self.stitcherWidget.updateRegistrationChannels)
@@ -668,7 +670,6 @@ class HighContentScreeningGui(QMainWindow):
         self.multipointController.signal_register_current_fov.connect(self.navigationViewer.register_fov)
         self.multipointController.signal_current_configuration.connect(self.liveControlWidget.set_microscope_mode)
         self.multipointController.signal_z_piezo_um.connect(self.piezoWidget.update_displacement_um_display)
-        self.wellplateMultiPointWidget.signal_z_stacking.connect(self.multipointController.set_z_stacking_config)
 
         self.recordTabWidget.currentChanged.connect(self.onTabChanged)
         if not self.live_only_mode:
@@ -704,9 +705,7 @@ class HighContentScreeningGui(QMainWindow):
         self.wellSelectionWidget.signal_wellSelectedPos.connect(self.navigationController.move_to)
         if ENABLE_WELLPLATE_MULTIPOINT:
             self.wellSelectionWidget.signal_wellSelected.connect(self.wellplateMultiPointWidget.set_well_coordinates)
-
             self.objectivesWidget.signal_objective_changed.connect(self.wellplateMultiPointWidget.update_coordinates)
-            self.wellplateMultiPointWidget.signal_update_navigation_viewer.connect(self.navigationViewer.draw_fov_current_location)
 
         if SUPPORT_LASER_AUTOFOCUS:
             self.liveControlWidget_focus_camera.signal_newExposureTime.connect(self.cameraSettingWidget_focus_camera.set_exposure_time)
@@ -823,7 +822,7 @@ class HighContentScreeningGui(QMainWindow):
                     self.napari_connections['napariMosaicDisplayWidget'].extend([
                         (self.wellplateMultiPointWidget.signal_acquisition_channels, self.napariMosaicDisplayWidget.initChannels),
                         (self.wellplateMultiPointWidget.signal_acquisition_shape, self.napariMosaicDisplayWidget.initLayersShape),
-                        (self.wellplateMultiPointWidget.signal_draw_shape, self.napariMosaicDisplayWidget.enable_shape_drawing),
+                        (self.wellplateMultiPointWidget.signal_draw_manual_shape, self.napariMosaicDisplayWidget.enable_shape_drawing),
                         (self.napariMosaicDisplayWidget.signal_shape_drawn, self.wellplateMultiPointWidget.update_manual_shape)
                     ])
 

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -993,10 +993,12 @@ class HighContentScreeningGui(QMainWindow):
 
     def toggleAcquisitionStart(self, acquisition_started):
         if acquisition_started:
+            print("STARTING ACQUISITION")
             if self.is_live_scan_grid_on:
                 self.navigationController.scanGridPos.disconnect(self.wellplateMultiPointWidget.set_live_scan_coordinates)
                 self.is_live_scan_grid_on = False
         else:
+            print("FINISHED ACQUISITION")
             if not self.is_live_scan_grid_on:
                 self.navigationController.scanGridPos.connect(self.wellplateMultiPointWidget.set_live_scan_coordinates)
                 self.is_live_scan_grid_on = True

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -822,7 +822,7 @@ class HighContentScreeningGui(QMainWindow):
                     self.napari_connections['napariMosaicDisplayWidget'].extend([
                         (self.wellplateMultiPointWidget.signal_acquisition_channels, self.napariMosaicDisplayWidget.initChannels),
                         (self.wellplateMultiPointWidget.signal_acquisition_shape, self.napariMosaicDisplayWidget.initLayersShape),
-                        (self.wellplateMultiPointWidget.signal_draw_manual_shape, self.napariMosaicDisplayWidget.enable_shape_drawing),
+                        (self.wellplateMultiPointWidget.signal_manual_shape_mode, self.napariMosaicDisplayWidget.enable_shape_drawing),
                         (self.napariMosaicDisplayWidget.signal_shape_drawn, self.wellplateMultiPointWidget.update_manual_shape)
                     ])
 

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -4373,17 +4373,16 @@ class WellplateMultiPointWidget(QFrame):
         if not self.is_current_acquisition_widget:
             return  # Skip if this wasn't the widget that started acquisition
 
-        self.signal_acquisition_started.emit(False)  # Emit signal before clearing flag
+        self.signal_acquisition_started.emit(False)
+        self.is_current_acquisition_widget = False
         self.btn_startAcquisition.setChecked(False)
 
         if self.combobox_shape.currentText() == 'Manual':
             self.signal_manual_shape_mode.emit(True)
-            self.update_manual_shape(self.manual_shapes)
         else:
             self.set_well_coordinates(self.well_selected)
 
         self.setEnabled_all(True)
-        self.is_current_acquisition_widget = False  # Clear flag last
 
     def setEnabled_all(self, enabled):
         for widget in self.findChildren(QWidget):

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -3395,7 +3395,7 @@ class WellplateMultiPointWidget(QFrame):
     signal_acquisition_shape = Signal(int, float) # acquisition Nz, dz
     signal_stitcher_z_levels = Signal(int) # live Nz
     signal_stitcher_widget = Signal(bool) # start stitching
-    signal_draw_manual_shape = Signal(bool) # draw manual shape on mosaic display
+    signal_manual_shape_mode = Signal(bool) # enable manual shape layer on mosaic display
     # signal_z_stacking = Signal(int)
 
 
@@ -3856,9 +3856,9 @@ class WellplateMultiPointWidget(QFrame):
     def on_set_shape(self):
         shape = self.combobox_shape.currentText()
         if shape == 'Manual':
-            self.signal_draw_manual_shape.emit(True)
+            self.signal_manual_shape_mode.emit(True)
         else:
-            self.signal_draw_manual_shape.emit(False)
+            self.signal_manual_shape_mode.emit(False)
             self.update_coverage_from_scan_size()
             self.update_coordinates()
 
@@ -4363,7 +4363,7 @@ class WellplateMultiPointWidget(QFrame):
         self.btn_startAcquisition.setChecked(False)
         self.set_well_coordinates(self.well_selected)
         if self.combobox_shape.currentText() == 'Manual':
-            self.signal_draw_manual_shape.emit(True)
+            self.signal_manual_shape_mode.emit(True)
         self.setEnabled_all(True)
 
     def setEnabled_all(self, enabled):


### PR DESCRIPTION
### 1) unify update and clear slide
- removed from NavigationViewer
    - update_slide() 
    - signal_update_well_coordinates = Signal(bool)
- same as clear slide, since scan grid overlay is now separate image item
    - removed update slide from HighContentScreeningGui


### 2)  simplify scan grid signals
- removed from NavigationViewer
    - draw_scan_grid() 
    - signal_update_live_scan_grid = Signal(float, float)
    - self.acquisition_started
- instead directly connect navigationController to wellplateMultipointWidget to draw to NavigationViewer instead of going from navigationController through NavigationViewer to signal wellplateMultipointWidget to draw to NavigationViewer
    - self.navigationController.scanGridPos.connect(self.wellplateMultiPointWidget.set_live_scan_coordinates)  


### 3) track live scan grid signal
- added self.is_live_scan_grid_on in HighContentScreeningGui
    - can disconnect if not 'glass slide'
    - can check if signal is connected/disconnected before connecting/disconnecting 
- removed on_acquisition_start from NavigationViewer
    - can disconnect/reconnect signal directly during acquisition 

### 4) z stacking signals in MultiPointWidgets
- commented out signal_z_stacking logic from HighContentScreeningGui

### 5) added slide position signals to disable/enable start acquisition button (copied from legacy widget to flexible and wellplate multiPointWidgets)
- integrated
  - signal_slide_scanning_position_reached
  - signal_slide_loading_position_reached

### 6) added self.is_current_acquisition_widget to flexible and wellplate multiPointWidgets
- fixed acquisition_is_finished 
    - only widget that toggled acquisition does cleanup routine
    - prevents us from running both acquisition_is_finished methods (from each multiPointWidget) when multiPointController emits "finished acquisition" signal.

### 7) WellSelectionWidget  
- update slot updateWellplateSettings
- edited onSelectionChanged 
    - removed redundant call to get_selected_cells in WellSelectionWidget

### 8) fix updates to manual shapes when switching acquisition widget tabs
- call clear and update scan grid regions accordingly if is_wellplate_acquisition or if is_flexible_acquisition 