### PR TITLE
bug fix: edits to manual region shape should not update scan coordinates while on flexible widget

### DIFF
--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -3855,7 +3855,7 @@ class WellplateMultiPointWidget(QFrame):
             self.update_coordinates()
 
     def update_manual_shape(self, shapes_data_mm):
-        if self.parent.recordTabWidget.currentWidget() != self:
+        if hasattr(self.parent, 'recordTabWidget') and self.parent.recordTabWidget.currentWidget() != self:
             return
 
         self.clear_regions()
@@ -3938,7 +3938,7 @@ class WellplateMultiPointWidget(QFrame):
         self.entry_maxZ.blockSignals(False)
 
     def set_live_scan_coordinates(self, x_mm, y_mm):
-        if self.parent.recordTabWidget.currentWidget() != self
+        if hasattr(self.parent, 'recordTabWidget') and self.parent.recordTabWidget.currentWidget() != self:
             return
 
         if self.combobox_shape.currentText() != 'Manual' and self.scanCoordinates.format == 'glass slide':
@@ -3950,7 +3950,7 @@ class WellplateMultiPointWidget(QFrame):
     def set_well_coordinates(self, selected):
         self.well_selected = selected and bool(self.scanCoordinates.get_selected_wells())
 
-        if self.parent.recordTabWidget.currentWidget() == self:
+        if hasattr(self.parent, 'recordTabWidget') and self.parent.recordTabWidget.currentWidget() == self:
             if self.scanCoordinates.format == 'glass slide':
                 x = self.navigationController.x_pos_mm
                 y = self.navigationController.y_pos_mm


### PR DESCRIPTION
- the flexible scan regions are still shown instead of the manual region, even if it is edited/altered and triggers a signal
- manual ROI is only available from wellplateMultiPointWidget and not flexibleMultiPointWidget
- toggle manual/draw mode on 
  - switch to select vertex mode if a shape already exists
  - switch to add polygon mode if no shapes
- toggle manual/draw mode off
  - switch to pan/zoom and leave shapes layer if toggled off