### PR TITLE
NavigationViewer and NavigationWidget bugs: fixed draw current fov, fixed move to signal from double click on well

### DIFF
--- a/software/control/core/core.py
+++ b/software/control/core/core.py
@@ -3024,14 +3024,12 @@ class NavigationViewer(QFrame):
         self.update_display_properties(sample)
         self.draw_current_fov(self.x_mm, self.y_mm)
 
-    def draw_fov_current_location(self, pos: squid.abc.Pos):
-        if not pos:
+    def draw_fov_current_location(self, x_mm, y_mm):
+        if x_mm is None and y_mm is None:
             if self.x_mm is None and self.y_mm is None:
                 return
             self.draw_current_fov(self.x_mm, self.y_mm)
         else:
-            x_mm = pos.x_mm
-            y_mm = pos.y_mm
             self.draw_current_fov(x_mm, y_mm)
             self.x_mm = x_mm
             self.y_mm = y_mm


### PR DESCRIPTION
fix updates to current FOV in navigationViewer
- signal was emitting pos object but we were expecting (x_mm, y_mm)

fix MovementUpdater
- remove lamda in signal_wellSelectedPos connection
- replace with method def move_to_mm(self, x_mm, y_mm)
- add self.movement_update_timer.start()

move to cached position on startup, regardless of HOMING flags