### PR TITLE
MovementUpdater: update FOV position and position_after_move signals and slots

### DIFF
--- a/software/control/core/core.py
+++ b/software/control/core/core.py
@@ -3389,17 +3389,14 @@ class NavigationViewer(QFrame):
         self.update_display_properties(sample)
         self.draw_current_fov(self.x_mm, self.y_mm)
 
-    def draw_fov_current_location(self, pos: squid.abc.Pos):
+    def draw_fov_current_position(self, pos: squid.abc.Pos):
         if not pos:
-            if self.x_mm is None and self.y_mm is None:
+            if self.x_mm is None or self.y_mm is None:
                 return
-            self.draw_current_fov(self.x_mm, self.y_mm)
         else:
-            x_mm = pos.x_mm
-            y_mm = pos.y_mm
-            self.draw_current_fov(x_mm, y_mm)
-            self.x_mm = x_mm
-            self.y_mm = y_mm
+            self.x_mm = pos.x_mm
+            self.y_mm = pos.y_mm
+        self.draw_current_fov(self.x_mm, self.y_mm)
 
     def get_FOV_pixel_coordinates(self, x_mm, y_mm):
         if self.sample == "glass slide":


### PR DESCRIPTION
### fixed issues position update signals:

#### welplateMultiPointWIdget.update_live_coordinates(self, pos: squid.abc.Pos):
- connect to MovementUpdater.position_after_move signal (now receives Pos object instead of x_mm, y_mm floats)
- slot for drawing and getting the scanCoordinates for the live scan grid (only when sample is glass slide and not flexible acquisition)

#### navigationViewer.draw_fov_current_position(self, pos: squid.abc.Pos) 
- connect to MovementUpdater.position signal (instead of MovementUpdater.position_after_move)
- slot for drawing the live stage fov position

#### move to cached position after boot
- moving to the cached position on startup no longer hidden behind HOMING flags
- correctly init_z (in MultiPointWidgets) after moving to the cached pos