### PR TITLE
fix(lint action): Fail linting action if formatting would have happened

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -14,5 +14,5 @@ jobs:
           python-version: "3.13"
       - uses: psf/black@stable
         with:
-          options: "--config software/pyproject.toml"
+          options: "--config software/pyproject.toml --check --verbose"
           src: "./software/"


### PR DESCRIPTION
We weren't using `--check` before, so this adds it.  This will make the linting actions fail if the changes aren't properly formatted.

Tested by: This should fail the linting action!  If it does because of required formatting, then this is good to go.