### PR TITLE
fix(acquisition abort): Aborting acquisitions midway left the ui in an invalid state

### DIFF
--- a/software/control/core/core.py
+++ b/software/control/core/core.py
@@ -1491,6 +1491,7 @@ class MultiPointWorker(QObject):
                 # wait until it's time to do the next acquisition
                 while time.time() < self.timestamp_acquisition_started + self.time_point * self.dt:
                     if self.multiPointController.abort_acqusition_requested:
+                        self._log.debug("In run wait loop, abort_acquisition_requested=True")
                         break
                     time.sleep(0.05)
 
@@ -2181,7 +2182,7 @@ class MultiPointController(QObject):
         parent=None,
     ):
         QObject.__init__(self)
-
+        self._log = squid.logging.get_logger(self.__class__.__name__)
         self.camera = camera
         if DO_FLUORESCENCE_RTP:
             self.processingHandler = ProcessingHandler()
@@ -2535,6 +2536,7 @@ class MultiPointController(QObject):
         self.thread.start()
 
     def _on_acquisition_completed(self):
+        self._log.debug("MultiPointController._on_acquisition_completed called")
         # restore the previous selected mode
         if self.gen_focus_map:
             self.autofocusController.clear_focus_map()

--- a/software/control/core/core.py
+++ b/software/control/core/core.py
@@ -4,6 +4,7 @@ import sys
 
 from control.microcontroller import Microcontroller
 from squid.abc import AbstractStage
+import squid.logging
 
 # qt libraries
 os.environ["QT_API"] = "pyqt5"
@@ -1468,6 +1469,7 @@ class MultiPointWorker(QObject):
         while self.time_point < self.Nt:
             # check if abort acquisition has been requested
             if self.multiPointController.abort_acqusition_requested:
+                self._log.debug("In run, abort_acquisition_requested=True")
                 break
 
             self.run_single_time_point()
@@ -3218,6 +3220,7 @@ class NavigationViewer(QFrame):
 
     def __init__(self, objectivestore, sample="glass slide", invertX=False, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self._log = squid.logging.get_logger(self.__class__.__name__)
         self.setFrameStyle(QFrame.Panel | QFrame.Raised)
         self.sample = sample
         self.objectiveStore = objectivestore
@@ -3493,6 +3496,7 @@ class NavigationViewer(QFrame):
             x_mm = (mouse_point.x() - self.origin_x_pixel) * self.mm_per_pixel
             y_mm = (mouse_point.y() - self.origin_y_pixel) * self.mm_per_pixel
 
+            self._log.debug(f"Got double click at (x_mm, y_mm) = {x_mm, y_mm}")
             self.signal_coordinates_clicked.emit(x_mm, y_mm)
 
         except Exception as e:

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -1251,6 +1251,7 @@ class HighContentScreeningGui(QMainWindow):
         self.wellSelectionWidget.setVisible(show)
 
     def toggleAcquisitionStart(self, acquisition_started):
+        self.log.debug(f"toggleAcquisitionStarted({acquisition_started=})")
         if acquisition_started:
             self.log.info("STARTING ACQUISITION")
             if self.is_live_scan_grid_on:  # disconnect live scan grid during acquisition

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -2397,6 +2397,7 @@ class FlexibleMultiPointWidget(QFrame):
         self.entry_NZ.setValue(nz)
 
     def update_region_progress(self, current_fov, num_fovs):
+        self._log.debug(f"Updating region progress for {current_fov=}, {num_fovs=}")
         self.progress_bar.setMaximum(num_fovs)
         self.progress_bar.setValue(current_fov)
 
@@ -2425,6 +2426,7 @@ class FlexibleMultiPointWidget(QFrame):
             self.eta_timer.start(1000)  # Update every 1000 ms (1 second)
 
     def update_acquisition_progress(self, current_region, num_regions, current_time_point):
+        self.debug(f"updating acquisition progress for {current_region=}, {num_regions=}, {current_time_point=}...")
         self.current_region = current_region
         self.current_time_point = current_time_point
 

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -2427,7 +2427,9 @@ class FlexibleMultiPointWidget(QFrame):
             self.eta_timer.start(1000)  # Update every 1000 ms (1 second)
 
     def update_acquisition_progress(self, current_region, num_regions, current_time_point):
-        self._log.debug(f"updating acquisition progress for {current_region=}, {num_regions=}, {current_time_point=}...")
+        self._log.debug(
+            f"updating acquisition progress for {current_region=}, {num_regions=}, {current_time_point=}..."
+        )
         self.current_region = current_region
         self.current_time_point = current_time_point
 
@@ -2987,7 +2989,9 @@ class FlexibleMultiPointWidget(QFrame):
             self._log.debug(self.location_list)
 
     def acquisition_is_finished(self):
-        self._log.debug(f"In FlexibleMultiPointWidget, got acquisition_is_finished with {self.is_current_acquisition_widget=}")
+        self._log.debug(
+            f"In FlexibleMultiPointWidget, got acquisition_is_finished with {self.is_current_acquisition_widget=}"
+        )
 
         if not self.is_current_acquisition_widget:
             return  # Skip if this wasn't the widget that started acquisition
@@ -3756,7 +3760,9 @@ class WellplateMultiPointWidget(QFrame):
             self.multipointController.request_abort_aquisition()
 
     def acquisition_is_finished(self):
-        self._log.debug(f"In WellMultiPointWidget, got acquisition_is_finished with {self.is_current_acquisition_widget=}")
+        self._log.debug(
+            f"In WellMultiPointWidget, got acquisition_is_finished with {self.is_current_acquisition_widget=}"
+        )
         if not self.is_current_acquisition_widget:
             return  # Skip if this wasn't the widget that started acquisition
 


### PR DESCRIPTION
`34713ec14805b441a1cee7dbeb2c13c337035d31` added the `self.is_current_acquisition_widget` concept on our acquisition widgets.  This was set to `= False` in two places for each - one in the `toggle_acquisition` and another in `acquisition_finished`.  The `toggle_acquisition` always ran first (it sent the signal that eventually resulted in `acquisition_finished` getting called), which means that the code in `acquisition_finished` was always skipped via the `if` guard checking for `is_current_acquisition_widget`.

It's not clear if we need `is_current_acquisition_widget` since it's new-ish, but for now leave it and just make it so `acquisition_finished` is the only `= False` setter of that flag.

Tested by: running local acquisitions.  Before this, the stage control + acquisition widgets would get wedged in disabled state if you aborted an acquisition midway.  Now, they don't and you can continue using the UI.