### PR TITLE
feat(microcontroller): Add a mechanism for automatic serial reconnect, and use it

### DIFF
--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -291,7 +291,9 @@ class HighContentScreeningGui(QMainWindow):
 
     def loadSimulationObjects(self):
         self.log.debug("Loading simulated hardware objects...")
-        self.microcontroller = microcontroller.Microcontroller(existing_serial=microcontroller.SimSerial())
+        self.microcontroller = microcontroller.Microcontroller(
+            serial_device=microcontroller.get_microcontroller_serial_device(simulated=True)
+        )
         # Initialize simulation objects
         if ENABLE_SPINNING_DISK_CONFOCAL:
             self.xlight = serial_peripherals.XLight_Simulation()
@@ -322,7 +324,11 @@ class HighContentScreeningGui(QMainWindow):
     def loadHardwareObjects(self):
         # Initialize hardware objects
         try:
-            self.microcontroller = microcontroller.Microcontroller(version=CONTROLLER_VERSION, sn=CONTROLLER_SN)
+            self.microcontroller = microcontroller.Microcontroller(
+                serial_device=microcontroller.get_microcontroller_serial_device(
+                    version=CONTROLLER_VERSION, sn=CONTROLLER_SN
+                )
+            )
         except Exception:
             self.log.error(f"Error initializing Microcontroller")
             raise

--- a/software/control/microcontroller.py
+++ b/software/control/microcontroller.py
@@ -321,6 +321,7 @@ class MicrocontrollerSerial(AbstractCephlaMicroSerial):
                     MicrocontrollerSerial.exponential_backoff_time(i, MicrocontrollerSerial.INITIAL_RECONNECT_INTERVAL)
                 )
                 try:
+                    self._serial.close()
                     self._serial.open()
                 except SerialException as se:
                     self._log.warning(

--- a/software/control/microcontroller.py
+++ b/software/control/microcontroller.py
@@ -320,11 +320,11 @@ class MicrocontrollerSerial(AbstractCephlaMicroSerial):
     def reconnect(self, attempts: int) -> bool:
         self._log.debug(f"Attempting reconnect to {self._serial.port}.  With max of {attempts} attempts.")
         for i in range(attempts):
-            this_interval = MicrocontrollerSerial.exponential_backoff_time(i, MicrocontrollerSerial.INITIAL_RECONNECT_INTERVAL)
+            this_interval = MicrocontrollerSerial.exponential_backoff_time(
+                i, MicrocontrollerSerial.INITIAL_RECONNECT_INTERVAL
+            )
             if not self.is_open():
-                time.sleep(
-                    this_interval
-                )
+                time.sleep(this_interval)
                 try:
                     try:
                         self._serial.close()
@@ -335,12 +335,13 @@ class MicrocontrollerSerial(AbstractCephlaMicroSerial):
                     if i + 1 == attempts:
                         self._log.error(
                             f"Reconnect to {self._serial.port} failed after {attempts} attempts. Last reconnect interval was {this_interval} [s]",
-                            exc_info=se
+                            exc_info=se,
                         )
                         # This is the last time around the loop, so it'll exit and return self.is_open() as false after this.
                     else:
                         self._log.warning(
-                            f"Couldn't reconnect serial={self._serial.port} @ baud={self._serial.baudrate}.  Attempt {i + 1}/{attempts}.")
+                            f"Couldn't reconnect serial={self._serial.port} @ baud={self._serial.baudrate}.  Attempt {i + 1}/{attempts}."
+                        )
             else:
                 break
 
@@ -967,7 +968,9 @@ class Microcontroller:
 
                     if not self._serial.is_open():
                         if not self._serial.reconnect(attempts=Microcontroller.MAX_RECONNECT_COUNT):
-                            self.log.error("In read loop, serial device failed to reconnect.  Microcontroller is defunct!")
+                            self.log.error(
+                                "In read loop, serial device failed to reconnect.  Microcontroller is defunct!"
+                            )
 
                     continue
 
@@ -1063,7 +1066,6 @@ class Microcontroller:
                     self.new_packet_callback_external(self)
             except Exception as e:
                 self.log.error("Read loop failed, continuing to loop to see if anything can recover.", exc_info=e)
-
 
     def get_pos(self):
         return self.x_pos, self.y_pos, self.z_pos, self.theta_pos

--- a/software/control/microcontroller.py
+++ b/software/control/microcontroller.py
@@ -243,7 +243,7 @@ class SimSerial(AbstractCephlaMicroSerial):
 
 
 class MicrocontrollerSerial(AbstractCephlaMicroSerial):
-    INITIAL_RECONNECT_INTERVAL = 0.1
+    INITIAL_RECONNECT_INTERVAL = 0.5
 
     @staticmethod
     def exponential_backoff_time(attempt_index: int, initial_interval: float) -> float:
@@ -324,7 +324,7 @@ class MicrocontrollerSerial(AbstractCephlaMicroSerial):
                     self._serial.open()
                 except SerialException as se:
                     self._log.warning(
-                        f"Couldn't reconnect serial={self._serial.port} @ baud={self._serial.baudrate}.  Attempt {i + 1}/{attempts}."
+                        f"Couldn't reconnect serial={self._serial.port} @ baud={self._serial.baudrate}.  Attempt {i + 1}/{attempts}.", exc_info=se
                     )
             else:
                 break

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -51,10 +51,11 @@ class Microscope(QObject):
         self.camera.set_software_triggered_acquisition()
 
     def initialize_microcontroller(self, is_simulation):
-        if is_simulation:
-            self.microcontroller = microcontroller.Microcontroller(existing_serial=control.microcontroller.SimSerial())
-        else:
-            self.microcontroller = microcontroller.Microcontroller(version=CONTROLLER_VERSION, sn=CONTROLLER_SN)
+        self.microcontroller = microcontroller.Microcontroller(
+            serial_device=microcontroller.get_microcontroller_serial_device(
+                version=CONTROLLER_VERSION, sn=CONTROLLER_SN, simulated=is_simulation
+            )
+        )
 
         self.home_x_and_y_separately = False
 

--- a/software/tests/control/test_microcontroller.py
+++ b/software/tests/control/test_microcontroller.py
@@ -158,8 +158,12 @@ def test_microcontroller_reconnects_serial():
     micro = get_test_micro()
     serial = micro._serial
 
+    def wait():
+        micro.wait_till_operation_is_completed()
+
     some_pos = 1234
     micro.move_x_to_usteps(some_pos)
+    wait()
     assert_pos_almost_equal((some_pos, 0, 0, 0), micro.get_pos())
 
     # Force closed, then make sure the microcontroller handles reconnecting.  Both in the write and read cases
@@ -169,8 +173,10 @@ def test_microcontroller_reconnects_serial():
 
     time.sleep(1)
     micro.move_y_to_usteps(2 * some_pos)
+    wait()
     assert_pos_almost_equal((some_pos, 2 * some_pos, 0, 0), micro.get_pos())
 
     serial.close()
     micro.move_z_usteps(3 * some_pos)
+    wait()
     assert_pos_almost_equal((some_pos, 2 * some_pos, 3 * some_pos, 0), micro.get_pos())

--- a/software/tests/control/test_microcontroller.py
+++ b/software/tests/control/test_microcontroller.py
@@ -1,6 +1,14 @@
+import time
+
 import pytest
 import control._def
 import control.microcontroller
+
+
+def get_test_micro() -> control.microcontroller.Microcontroller:
+    return control.microcontroller.Microcontroller(
+        serial_device=control.microcontroller.get_microcontroller_serial_device(simulated=True)
+    )
 
 
 def assert_pos_almost_equal(expected, actual):
@@ -10,11 +18,11 @@ def assert_pos_almost_equal(expected, actual):
 
 
 def test_create_simulated_microcontroller():
-    micro = control.microcontroller.Microcontroller(existing_serial=control.microcontroller.SimSerial())
+    micro = get_test_micro()
 
 
 def test_microcontroller_simulated_positions():
-    micro = control.microcontroller.Microcontroller(existing_serial=control.microcontroller.SimSerial())
+    micro = get_test_micro()
 
     micro.move_x_to_usteps(1000)
     micro.wait_till_operation_is_completed()
@@ -97,7 +105,7 @@ def test_microcontroller_simulated_positions():
     reason="This is likely a bug, but I'm not sure yet.  Tracking in https://linear.app/cephla/issue/S-115/microcontroller-relative-and-absolute-position-sign-mismatch"
 )
 def test_microcontroller_absolute_and_relative_match():
-    micro = control.microcontroller.Microcontroller(existing_serial=control.microcontroller.SimSerial())
+    micro = get_test_micro()
 
     def wait():
         micro.wait_till_operation_is_completed()
@@ -144,3 +152,25 @@ def test_microcontroller_absolute_and_relative_match():
     micro.move_z_usteps(-abs_position)
     wait()
     assert_pos_almost_equal((0, 0, 0, 0), micro.get_pos())
+
+
+def test_microcontroller_reconnects_serial():
+    micro = get_test_micro()
+    serial = micro._serial
+
+    some_pos = 1234
+    micro.move_x_to_usteps(some_pos)
+    assert_pos_almost_equal((some_pos, 0, 0, 0), micro.get_pos())
+
+    # Force closed, then make sure the microcontroller handles reconnecting.  Both in the write and read cases
+    # For the read, sleep a bit first since we know we have a reader loop spinning that could blowup if reconnects
+    # don't work properly.
+    serial.close()
+
+    time.sleep(1)
+    micro.move_y_to_usteps(2 * some_pos)
+    assert_pos_almost_equal((some_pos, 2 * some_pos, 0, 0), micro.get_pos())
+
+    serial.close()
+    micro.move_z_usteps(3 * some_pos)
+    assert_pos_almost_equal((some_pos, 2 * some_pos, 3 * some_pos, 0), micro.get_pos())

--- a/software/tests/control/test_microscope.py
+++ b/software/tests/control/test_microscope.py
@@ -2,9 +2,10 @@ import control.microscope
 import squid.stage.cephla
 import squid.config
 from control.microcontroller import Microcontroller, SimSerial
+from tests.control.test_microcontroller import get_test_micro
 
 
 def test_create_simulated_microscope():
-    microcontroller = Microcontroller(existing_serial=SimSerial())
+    microcontroller = get_test_micro()
     stage = squid.stage.cephla.CephlaStage(microcontroller, squid.config.get_stage_config())
     sim_scope = control.microscope.Microscope(stage=stage, is_simulation=True)

--- a/software/tests/squid/test_stage.py
+++ b/software/tests/squid/test_stage.py
@@ -5,17 +5,17 @@ import squid.stage.cephla
 import squid.stage.prior
 import squid.stage.utils
 import squid.config
-from control.microcontroller import Microcontroller, SimSerial
 import squid.abc
+from tests.control.test_microcontroller import get_test_micro
 
 
 def test_create_simulated_stages():
-    microcontroller = Microcontroller(existing_serial=SimSerial())
+    microcontroller = get_test_micro()
     cephla_stage = squid.stage.cephla.CephlaStage(microcontroller, squid.config.get_stage_config())
 
 
 def test_simulated_cephla_stage_ops():
-    microcontroller = Microcontroller(existing_serial=SimSerial())
+    microcontroller = get_test_micro()
     stage: squid.stage.cephla.CephlaStage = squid.stage.cephla.CephlaStage(
         microcontroller, squid.config.get_stage_config()
     )


### PR DESCRIPTION
We know our long running acquisitions can sometimes hang.  We think this is, at least sometimes, due to serial hiccups.  This adds a mechanism for automatic reconnect of our `Microcontroller` serial device.  For now, it does not add this same functionality to all our `serial_peripheral` devices, but doing so should be easy.

This does not handle the cases of a caller specifying a timeout, and the timeout elapsing.  In those cases, the caller is responsible for catching the `TimeoutError` and doing something about it.

Tested by: Running a local sim, and running acquisitions on a real system.  When running on the real system, I unplugged and plugged the microcontroller USB a bunch during acquisitions.  The only time I got it to not resume was when I got an "mcu operation timed out" TimeoutError to get thrown, which is expected - these are the cases when a timeout is specified, it elapses, and we let the caller know (so the caller needs to handle that case).