### PR TITLE
utils: add a directory creation helper, and use it instad of os.mkdirs

### DIFF
--- a/software/control/core/core.py
+++ b/software/control/core/core.py
@@ -279,7 +279,7 @@ class ImageSaver(QObject):
                 file_ID = int(self.counter % self.max_num_image_per_folder)
                 # create a new folder
                 if file_ID == 0:
-                    os.mkdir(os.path.join(self.base_path, self.experiment_ID, str(folder_ID)))
+                    utils.ensure_directory_exists(os.path.join(self.base_path, self.experiment_ID, str(folder_ID)))
 
                 if image.dtype == np.uint16:
                     # need to use tiff when saving 16 bit images
@@ -328,7 +328,7 @@ class ImageSaver(QObject):
         self.recording_start_time = time.time()
         # create a new folder
         try:
-            os.mkdir(os.path.join(self.base_path, self.experiment_ID))
+            utils.ensure_directory_exists(os.path.join(self.base_path, self.experiment_ID))
             # to do: save configuration
         except:
             pass
@@ -366,7 +366,7 @@ class ImageSaver_Tracking(QObject):
                 file_ID = int(frame_counter % self.max_num_image_per_folder)
                 # create a new folder
                 if file_ID == 0:
-                    os.mkdir(os.path.join(self.base_path, str(folder_ID)))
+                    utils.ensure_directory_exists(os.path.join(self.base_path, str(folder_ID)))
                 if image.dtype == np.uint16:
                     saving_path = os.path.join(
                         self.base_path,
@@ -1526,7 +1526,7 @@ class MultiPointWorker(QObject):
 
         # for each time point, create a new folder
         current_path = os.path.join(self.base_path, self.experiment_ID, str(self.time_point))
-        os.mkdir(current_path)
+        utils.ensure_directory_exists(current_path)
 
         slide_path = os.path.join(self.base_path, self.experiment_ID)
 
@@ -2313,7 +2313,7 @@ class MultiPointController(QObject):
         self.experiment_ID = experiment_ID.replace(" ", "_") + "_" + datetime.now().strftime("%Y-%m-%d_%H-%M-%S.%f")
         self.recording_start_time = time.time()
         # create a new folder
-        os.mkdir(os.path.join(self.base_path, self.experiment_ID))
+        utils.ensure_directory_exists(os.path.join(self.base_path, self.experiment_ID))
         # TODO(imo): If the config has changed since boot, is this still the correct config?
         configManagerThrowaway = ConfigurationManager(self.configurationManager.config_filename)
         configManagerThrowaway.write_configuration_selected(
@@ -2746,7 +2746,7 @@ class TrackingController(QObject):
         self.recording_start_time = time.time()
         # create a new folder
         try:
-            os.mkdir(os.path.join(self.base_path, self.experiment_ID))
+            utils.ensure_directory_exists(os.path.join(self.base_path, self.experiment_ID))
             self.configurationManager.write_configuration(
                 os.path.join(self.base_path, self.experiment_ID) + "/configurations.xml"
             )  # save the configuration for the experiment

--- a/software/control/core_PDAF.py
+++ b/software/control/core_PDAF.py
@@ -176,7 +176,7 @@ class TwoCamerasPDAFCalibrationController(QObject):
         self.recording_start_time = time.time()
         # create a new folder
         try:
-            os.mkdir(os.path.join(self.base_path, self.experiment_ID))
+            utils.ensure_directory_exists(os.path.join(self.base_path, self.experiment_ID))
             if self.configurationManager:
                 self.configurationManager.write_configuration(
                     os.path.join(self.base_path, self.experiment_ID) + "/configurations.xml"

--- a/software/control/core_platereader.py
+++ b/software/control/core_platereader.py
@@ -105,7 +105,7 @@ class PlateReadingWorker(QObject):
 
         # for each time point, create a new folder
         current_path = os.path.join(self.base_path, self.experiment_ID, str(self.time_point))
-        os.mkdir(current_path)
+        utils.ensure_directory_exists(current_path)
 
         # run homing
         self.plateReaderNavigationController.home()

--- a/software/control/core_usbspectrometer.py
+++ b/software/control/core_usbspectrometer.py
@@ -113,7 +113,7 @@ class SpectrumSaver(QObject):
                 file_ID = int(self.counter % self.max_num_file_per_folder)
                 # create a new folder
                 if file_ID == 0:
-                    os.mkdir(os.path.join(self.base_path, self.experiment_ID, str(folder_ID)))
+                    utils.ensure_directory_exists(os.path.join(self.base_path, self.experiment_ID, str(folder_ID)))
 
                 saving_path = os.path.join(self.base_path, self.experiment_ID, str(folder_ID), str(file_ID) + ".csv")
                 np.savetxt(saving_path, data, delimiter=",")

--- a/software/control/utils.py
+++ b/software/control/utils.py
@@ -1,8 +1,14 @@
+import pathlib
+
 import cv2
 from numpy import std, square, mean
 import numpy as np
 from scipy.ndimage import label
 import os
+
+import squid.logging
+
+_log = squid.logging.get_logger("control.utils")
 
 
 def crop_image(image, crop_width, crop_height):
@@ -153,3 +159,9 @@ def interpolate_plane(triple1, triple2, triple3, point):
 def create_done_file(path):
     with open(os.path.join(path, ".done"), "w") as file:
         pass  # This creates an empty file
+
+
+def ensure_directory_exists(raw_string_path: str):
+    path: pathlib.Path = pathlib.Path(raw_string_path)
+    _log.debug(f"Making sure directory '{path}' exists.")
+    path.mkdir(parents=True, exist_ok=True)

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -5,6 +5,7 @@ from typing import Optional
 import squid.logging
 from control.core.core import TrackingController
 from control.microcontroller import Microcontroller
+import control.utils as utils
 from squid.abc import AbstractStage
 
 # set QT_API environment variable
@@ -6076,7 +6077,7 @@ class MultiCameraRecordingWidget(QFrame):
             self.btn_setSavingDir.setEnabled(False)
             experiment_ID = self.lineEdit_experimentID.text()
             experiment_ID = experiment_ID + "_" + datetime.now().strftime("%Y-%m-%d_%H-%M-%S.%f")
-            os.mkdir(os.path.join(self.save_dir_base, experiment_ID))
+            utils.ensure_directory_exists(os.path.join(self.save_dir_base, experiment_ID))
             for channel in self.channels:
                 self.imageSaver[channel].start_new_experiment(os.path.join(experiment_ID, channel), add_timestamp=False)
                 self.streamHandler[channel].start_recording()

--- a/software/tools/script_create_zarr_from_acquisition.py
+++ b/software/tools/script_create_zarr_from_acquisition.py
@@ -13,6 +13,7 @@ from glob import glob
 
 from ome_zarr.writer import write_image
 from ome_zarr.io import parse_url
+import control.utils
 
 lazy_imread = delayed(imread)
 
@@ -207,10 +208,7 @@ def create_zarr_for_single_fov(
     t_to_use=None,
     well=0,
 ):
-    try:
-        os.mkdir(saving_path)
-    except FileExistsError:
-        pass
+    control.utils.ensure_directory_exists(saving_path)
     dimension_data = get_dimensions_for_dataset(dataset_folder_path, sensor_pixel_size_um, objective_magnification)
     scale_xy = dimension_data["pixel_size_um"]
     scale_z = dimension_data["dz"]


### PR DESCRIPTION
This fixes the case of selecting a save path that does not exist.  As long as you have permissions to create all the directories leading to your chosen path, they will be created for you.

Tested by: Setting my save path to `/home/ian/does/not/exist/Downloads` and making sure acquisitions succeed and put the results there.  Before this change, acquisition failed with that save path (which does not exist).  Unit tests also still pass.