### PR TITLE
fix(stage): pass in PriorStage config when using Prior

### DIFF
--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -218,7 +218,7 @@ class HighContentScreeningGui(QMainWindow):
         )
 
         if USE_PRIOR_STAGE:
-            self.stage: squid.abc.AbstractStage = squid.stage.prior.PriorStage(sn=PRIOR_STAGE_SN)
+            self.stage: squid.abc.AbstractStage = squid.stage.prior.PriorStage(sn=PRIOR_STAGE_SN, stage_config=squid.config.get_stage_config())
 
         else:
             self.stage: squid.abc.AbstractStage = squid.stage.cephla.CephlaStage(

--- a/software/squid/stage/prior.py
+++ b/software/squid/stage/prior.py
@@ -7,10 +7,6 @@ import re
 from squid.abc import AbstractStage, Pos, StageStage
 from squid.config import StageConfig
 
-
-# NOTE/TODO(imo): We want to unblock getting the interface code implemented and in use, so to start we only
-# implemented the cephla stage.  As soon as we roll the interface out and get past the point of major refactors
-# to use it (we want to get past that point as fast as possible!), we'll come back to implement this.
 class PriorStage(AbstractStage):
     def __init__(self, sn: str, baudrate: int = 115200, stage_config: StageConfig = None):
         # We are not using StageConfig for Prior stage now. Waiting for further update/clarification of this part


### PR DESCRIPTION
Stages need a config.  We should make the `PriorStage` config non-optional, but for now just make sure to pass it in.