### PR TITLE
acquistions: when we abort, do not let another start until previous is finished

### DIFF
--- a/software/control/core/core.py
+++ b/software/control/core/core.py
@@ -34,7 +34,7 @@ try:
 except:
     pass
 
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 from queue import Queue
 from threading import Thread, Lock
 from pathlib import Path
@@ -2195,6 +2195,8 @@ class MultiPointController(QObject):
         self.liveController = liveController
         self.autofocusController = autofocusController
         self.configurationManager = configurationManager
+        self.multiPointWorker: Optional[MultiPointWorker] = None
+        self.thread: Optional[QThread] = None
         self.NX = 1
         self.NY = 1
         self.NZ = 1
@@ -2236,6 +2238,11 @@ class MultiPointController(QObject):
         except:
             pass
         self.z_stacking_config = Z_STACKING_CONFIG
+
+    def acquisition_in_progress(self):
+        if self.thread and self.thread.isRunning() and self.multiPointWorker:
+            return True
+        return False
 
     def set_use_piezo(self, checked):
         print("Use Piezo:", checked)

--- a/software/control/core/core.py
+++ b/software/control/core/core.py
@@ -2247,7 +2247,7 @@ class MultiPointController(QObject):
     def set_use_piezo(self, checked):
         print("Use Piezo:", checked)
         self.use_piezo = checked
-        if hasattr(self, "multiPointWorker"):
+        if self.multiPointWorker:
             self.multiPointWorker.update_use_piezo(checked)
 
     def set_z_stacking_config(self, z_stacking_config_index):

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -2551,7 +2551,8 @@ class FlexibleMultiPointWidget(QFrame):
             return
         if pressed:
             if self.multipointController.acquisition_in_progress():
-                self._log.warn("Acquisition in progress or aborting, cannot start another yet.")
+                self._log.warning("Acquisition in progress or aborting, cannot start another yet.")
+                self.btn_startAcquisition.setChecked(False)
                 return
 
             # @@@ to do: add a widgetManger to enable and disable widget
@@ -3701,7 +3702,8 @@ class WellplateMultiPointWidget(QFrame):
 
         if pressed:
             if self.multipointController.acquisition_in_progress():
-                self._log.warn("Acquisition in progress or aborting, cannot start another yet.")
+                self._log.warning("Acquisition in progress or aborting, cannot start another yet.")
+                self.btn_startAcquisition.setChecked(False)
                 return
             self.setEnabled_all(False)
             self.is_current_acquisition_widget = True

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -2550,6 +2550,10 @@ class FlexibleMultiPointWidget(QFrame):
             msg.exec_()
             return
         if pressed:
+            if self.multipointController.acquisition_in_progress():
+                self._log.warn("Acquisition in progress or aborting, cannot start another yet.")
+                return
+
             # @@@ to do: add a widgetManger to enable and disable widget
             # @@@ to do: emit signal to widgetManager to disable other widgets
             self.is_current_acquisition_widget = True  # keep track of what widget started the acquisition
@@ -3696,6 +3700,9 @@ class WellplateMultiPointWidget(QFrame):
             return
 
         if pressed:
+            if self.multipointController.acquisition_in_progress():
+                self._log.warn("Acquisition in progress or aborting, cannot start another yet.")
+                return
             self.setEnabled_all(False)
             self.is_current_acquisition_widget = True
 


### PR DESCRIPTION
This was a bug whereby if you aborted, and then spammed the start button, you could cause the ui to crash.

This stops this from happening by checking to see if the worker thread is still running.  If it is, we don't allow another to start.

Tested by: running on the Prior system.