### PR TITLE
logging&utils: add helper for getting squid repo state, log state on startup

### DIFF
--- a/software/main_hcs.py
+++ b/software/main_hcs.py
@@ -22,8 +22,11 @@ from configparser import ConfigParser
 from control.widgets import ConfigEditorBackwardsCompatible, ConfigEditorForAcquisitions
 from control._def import CACHED_CONFIG_FILE_PATH
 from control._def import USE_TERMINAL_CONSOLE
+import control.utils
+
 if USE_TERMINAL_CONSOLE:
     from control.console import ConsoleThread
+
 
 def show_config(cfp, configpath, main_gui):
     config_widget = ConfigEditorBackwardsCompatible(cfp, configpath, main_gui)
@@ -51,6 +54,8 @@ if __name__ == "__main__":
     if not squid.logging.add_file_logging(f"{squid.logging.get_default_log_directory()}/main_hcs.log"):
         log.error("Couldn't setup logging to file!")
         sys.exit(1)
+
+    log.info(f"Squid Repository State: {control.utils.get_squid_repo_state_description()}")
 
     legacy_config = False
     cf_editor_parser = ConfigParser()

--- a/software/tests/control/test_utils.py
+++ b/software/tests/control/test_utils.py
@@ -1,0 +1,6 @@
+import control.utils
+
+
+def test_squid_repo_info():
+    # At least make sure we get something and that it calls without issue.
+    assert control.utils.get_squid_repo_state_description()


### PR DESCRIPTION
This is important for us to be able to track down user submitted bugs.  Right now, it's impossible to know what code they're running if they send the sha1 with their report.

Tested by: Unit test, and making sure that running main_hcs results in the correct printed sha1 locally.