### PR TITLE
feat: improve piezo stage control

### DIFF
--- a/software/configurations/configuration_HCS_v2.ini
+++ b/software/configurations/configuration_HCS_v2.ini
@@ -249,3 +249,8 @@ channel6_gain = False
 _channel6_gain_options = [True, False]
 channel7_gain = True
 _channel7_gain_options = [True, False]
+
+[Z_STAGE_CONFIG]
+z_stage_mode = stepper_only
+_z_stage_mode_options = [stepper_only, piezo_only, stepper_and_piezo]
+Z_MOTOR_CONFIG = STEPPER

--- a/software/configurations/configuration_Squid+.ini
+++ b/software/configurations/configuration_Squid+.ini
@@ -246,3 +246,7 @@ _channel6_gain_options = [True, False]
 channel7_gain = True
 _channel7_gain_options = [True, False]
 
+[Z_STAGE_CONFIG]
+z_stage_mode = stepper_only
+_z_stage_mode_options = [stepper_only, piezo_only, stepper_and_piezo]
+Z_MOTOR_CONFIG = STEPPER

--- a/software/configurations/configuration_Squid+_H117_ORCA.ini
+++ b/software/configurations/configuration_Squid+_H117_ORCA.ini
@@ -258,3 +258,7 @@ _channel6_gain_options = [True, False]
 channel7_gain = True
 _channel7_gain_options = [True, False]
 
+[Z_STAGE_CONFIG]
+z_stage_mode = piezo_only
+_z_stage_mode_options = [stepper_only, piezo_only, stepper_and_piezo]
+Z_MOTOR_CONFIG = PIEZO

--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -7,6 +7,7 @@ import json
 import csv
 from control.utils import SpotDetectionMode
 import squid.logging
+from enum import Enum, auto
 
 log = squid.logging.get_logger(__name__)
 
@@ -239,6 +240,23 @@ class CAMERA_CONFIG:
     ROI_OFFSET_Y_DEFAULT = 0
     ROI_WIDTH_DEFAULT = 3104
     ROI_HEIGHT_DEFAULT = 2084
+
+class ZStageConfig(Enum):
+    STEPPER_ONLY = auto()
+    PIEZO_ONLY = auto()
+    STEPPER_AND_PIEZO = auto()
+
+    @classmethod
+    def from_string(cls, mode_str: str) -> 'ZStageConfig':
+        mapping = {
+            'stepper_only': cls.STEPPER_ONLY,
+            'piezo_only': cls.PIEZO_ONLY,
+            'stepper_and_piezo': cls.STEPPER_AND_PIEZO
+        }
+        if mode_str.lower() not in mapping:
+            raise ValueError(f"Invalid z_stage_mode. Must be one of: {', '.join(mapping.keys())}")
+        return mapping[mode_str.lower()]
+
 
 
 PRINT_CAMERA_FPS = True

--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -241,22 +241,22 @@ class CAMERA_CONFIG:
     ROI_WIDTH_DEFAULT = 3104
     ROI_HEIGHT_DEFAULT = 2084
 
+
 class ZStageConfig(Enum):
     STEPPER_ONLY = auto()
     PIEZO_ONLY = auto()
     STEPPER_AND_PIEZO = auto()
 
     @classmethod
-    def from_string(cls, mode_str: str) -> 'ZStageConfig':
+    def from_string(cls, mode_str: str) -> "ZStageConfig":
         mapping = {
-            'stepper_only': cls.STEPPER_ONLY,
-            'piezo_only': cls.PIEZO_ONLY,
-            'stepper_and_piezo': cls.STEPPER_AND_PIEZO
+            "stepper_only": cls.STEPPER_ONLY,
+            "piezo_only": cls.PIEZO_ONLY,
+            "stepper_and_piezo": cls.STEPPER_AND_PIEZO,
         }
         if mode_str.lower() not in mapping:
             raise ValueError(f"Invalid z_stage_mode. Must be one of: {', '.join(mapping.keys())}")
         return mapping[mode_str.lower()]
-
 
 
 PRINT_CAMERA_FPS = True
@@ -761,7 +761,7 @@ CACHED_CONFIG_FILE_PATH = None
 
 # Piezo configuration items
 Z_MOTOR_CONFIG = "STEPPER"  # "STEPPER", "STEPPER + PIEZO", "PIEZO", "LINEAR"
-ENABLE_OBJECTIVE_PIEZO = "PIEZO" in Z_MOTOR_CONFIG
+HAS_OBJECTIVE_PIEZO = "PIEZO" in Z_MOTOR_CONFIG
 
 # the value of OBJECTIVE_PIEZO_CONTROL_VOLTAGE_RANGE is 2.5 or 5
 OBJECTIVE_PIEZO_CONTROL_VOLTAGE_RANGE = 5
@@ -769,7 +769,7 @@ OBJECTIVE_PIEZO_RANGE_UM = 300
 OBJECTIVE_PIEZO_HOME_UM = 20
 OBJECTIVE_PIEZO_FLIP_DIR = False
 
-MULTIPOINT_USE_PIEZO_FOR_ZSTACKS = ENABLE_OBJECTIVE_PIEZO
+MULTIPOINT_USE_PIEZO_FOR_ZSTACKS = HAS_OBJECTIVE_PIEZO
 MULTIPOINT_PIEZO_DELAY_MS = 20
 MULTIPOINT_PIEZO_UPDATE_DISPLAY = True
 
@@ -869,7 +869,7 @@ A1_Y_PIXEL = WELLPLATE_FORMAT_SETTINGS[WELLPLATE_FORMAT]["a1_y_pixel"]  # coordi
 ##########################################################
 
 # objective piezo
-if ENABLE_OBJECTIVE_PIEZO == False:
+if HAS_OBJECTIVE_PIEZO == False:
     MULTIPOINT_USE_PIEZO_FOR_ZSTACKS = False
 
 # saving path

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -225,6 +225,7 @@ class HighContentScreeningGui(QMainWindow):
                     "OBJECTIVE_PIEZO_FLIP_DIR": OBJECTIVE_PIEZO_FLIP_DIR,
                 },
             )
+            self.piezo.home()
         else:
             self.piezo = None
 

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -304,6 +304,7 @@ class HighContentScreeningGui(QMainWindow):
                 self.camera_focus,
                 self.liveController_focus_camera,
                 self.stage,
+                self.piezo,
                 look_for_cache=False,
             )
 

--- a/software/control/piezo.py
+++ b/software/control/piezo.py
@@ -1,0 +1,39 @@
+from typing import Optional
+from control.microcontroller import Microcontroller
+
+
+class PiezoStage:
+    def __init__(self, microcontroller: Microcontroller, config: dict):
+        self._mc = microcontroller
+        self._config = config
+        self._current_position_um = 0
+        self._home_position_um = config.get("OBJECTIVE_PIEZO_HOME_UM", 20)
+        self._range_um = config.get("OBJECTIVE_PIEZO_RANGE_UM", 300)
+        self._control_voltage_range = config.get("OBJECTIVE_PIEZO_CONTROL_VOLTAGE_RANGE", 5)
+        self._flip_direction = config.get("OBJECTIVE_PIEZO_FLIP_DIR", False)
+
+    def move_to(self, position_um: float) -> None:
+        """Move piezo to absolute position in micrometers"""
+        if not 0 <= position_um <= self._range_um:
+            raise ValueError(f"Position {position_um}um outside valid range 0-{self._range_um}um")
+        self._mc.set_piezo_um(position_um)
+        self._current_position_um = position_um
+
+    def move_relative(self, delta_um: float) -> None:
+        """Move piezo by relative amount in micrometers"""
+        new_pos = self._current_position_um + delta_um
+        self.move_to(new_pos)
+
+    def home(self) -> None:
+        """Move piezo to home position"""
+        self.move_to(self._home_position_um)
+
+    @property
+    def position(self) -> float:
+        """Current position in micrometers"""
+        return self._current_position_um
+
+    @property
+    def range_um(self) -> float:
+        """Maximum range in micrometers"""
+        return self._range_um

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -1136,12 +1136,15 @@ class PiezoWidget(QFrame):
         self.slider = QSlider(Qt.Horizontal, self)
         self.slider.setMinimum(0)
         self.slider.setMaximum(int(OBJECTIVE_PIEZO_RANGE_UM * 100))  # Multiplied by 100 for 0.01 precision
+        self.slider.setValue(int(OBJECTIVE_PIEZO_HOME_UM * 100))
 
         self.spinBox = QDoubleSpinBox(self)
         self.spinBox.setRange(0.0, OBJECTIVE_PIEZO_RANGE_UM)
         self.spinBox.setDecimals(2)
-        self.spinBox.setSingleStep(0.01)
+        self.spinBox.setSingleStep(1)
         self.spinBox.setSuffix(" μm")
+        self.spinBox.setKeyboardTracking(False)
+        self.spinBox.setValue(OBJECTIVE_PIEZO_HOME_UM)
 
         # Row 3: Home Button
         self.home_btn = QPushButton(f" Set to {OBJECTIVE_PIEZO_HOME_UM} μm ", self)

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -2216,7 +2216,7 @@ class FlexibleMultiPointWidget(QFrame):
             grid_af.addWidget(self.checkbox_withReflectionAutofocus)
         # grid_af.addWidget(self.checkbox_genAFMap)  # we are not using auto-focus map for now
         grid_af.addWidget(self.checkbox_useFocusMap)
-        if ENABLE_OBJECTIVE_PIEZO:
+        if HAS_OBJECTIVE_PIEZO:
             grid_af.addWidget(self.checkbox_usePiezo)
         grid_af.addWidget(self.checkbox_set_z_range)
         if ENABLE_STITCHER:
@@ -3332,7 +3332,7 @@ class WellplateMultiPointWidget(QFrame):
             options_layout.addWidget(self.checkbox_withReflectionAutofocus)
         # options_layout.addWidget(self.checkbox_genAFMap)  # We are not using AF map now
         options_layout.addWidget(self.checkbox_useFocusMap)
-        if ENABLE_OBJECTIVE_PIEZO:
+        if HAS_OBJECTIVE_PIEZO:
             options_layout.addWidget(self.checkbox_usePiezo)
         options_layout.addWidget(self.checkbox_set_z_range)
         if ENABLE_STITCHER:

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -1987,7 +1987,7 @@ class FlexibleMultiPointWidget(QFrame):
         self.entry_deltaZ = QDoubleSpinBox()
         self.entry_deltaZ.setMinimum(0)
         self.entry_deltaZ.setMaximum(1000)
-        self.entry_deltaZ.setSingleStep(0.2)
+        self.entry_deltaZ.setSingleStep(0.1)
         self.entry_deltaZ.setValue(Acquisition.DZ)
         self.entry_deltaZ.setDecimals(3)
         self.entry_deltaZ.setSuffix(" μm")
@@ -2516,8 +2516,11 @@ class FlexibleMultiPointWidget(QFrame):
                 )
 
     def set_deltaZ(self, value):
-        mm_per_ustep = 1.0 / self.stage.get_config().Z_AXIS.convert_real_units_to_ustep(1.0)
-        deltaZ = round(value / 1000 / mm_per_ustep) * mm_per_ustep * 1000
+        if self.checkbox_usePiezo.isChecked():
+            deltaZ = value
+        else:
+            mm_per_ustep = 1.0 / self.stage.get_config().Z_AXIS.convert_real_units_to_ustep(1.0)
+            deltaZ = round(value / 1000 / mm_per_ustep) * mm_per_ustep * 1000
         self.entry_deltaZ.setValue(deltaZ)
         self.multipointController.set_deltaZ(deltaZ)
 
@@ -3164,7 +3167,7 @@ class WellplateMultiPointWidget(QFrame):
         self.entry_deltaZ = QDoubleSpinBox()
         self.entry_deltaZ.setMinimum(0)
         self.entry_deltaZ.setMaximum(1000)
-        self.entry_deltaZ.setSingleStep(0.2)
+        self.entry_deltaZ.setSingleStep(0.1)
         self.entry_deltaZ.setValue(Acquisition.DZ)
         self.entry_deltaZ.setDecimals(3)
         # self.entry_deltaZ.setEnabled(False)
@@ -3818,8 +3821,11 @@ class WellplateMultiPointWidget(QFrame):
         self.base_path_is_set = True
 
     def set_deltaZ(self, value):
-        mm_per_ustep = 1.0 / self.stage.get_config().Z_AXIS.convert_real_units_to_ustep(1.0)
-        deltaZ = round(value / 1000 / mm_per_ustep) * mm_per_ustep * 1000
+        if self.checkbox_usePiezo.isChecked():
+            deltaZ = value
+        else:
+            mm_per_ustep = 1.0 / self.stage.get_config().Z_AXIS.convert_real_units_to_ustep(1.0)
+            deltaZ = round(value / 1000 / mm_per_ustep) * mm_per_ustep * 1000
         self.entry_deltaZ.setValue(deltaZ)
         self.multipointController.set_deltaZ(deltaZ)
 

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -1210,9 +1210,9 @@ class PiezoWidget(QFrame):
     def adjust_position(self, up):
         increment = self.increment_spinBox.value()
         if up:
-            self.slider_value = min(OBJECTIVE_PIEZO_RANGE_UM, self.slider_value + increment)
+            self.slider_value = min(OBJECTIVE_PIEZO_RANGE_UM, self.spinBox.value() + increment)
         else:
-            self.slider_value = max(0, self.slider_value - increment)
+            self.slider_value = max(0, self.spinBox.value() - increment)
         self.update_spinBox()
         self.update_slider()
         self.update_piezo_position()


### PR DESCRIPTION
Major changes:
- Add dedicated PiezoStage class to encapsulate piezo functionality
- Add Z stage configuration system with three modes (stepper_only, piezo_only, stepper_and_piezo)
- Use piezo for laser autofocus when available (closed-loop control)
- Rename ENABLE_OBJECTIVE_PIEZO to HAS_OBJECTIVE_PIEZO for clarity

Technical improvements:
- Add type hints and docstrings to piezo-related code
- Add range validation for piezo movements
- Add configuration options for piezo parameters
- Centralize piezo control logic in one class

Configuration changes:
- Add Z_STAGE_CONFIG section to .ini files
- Add z_stage_mode option with three modes
- Maintain backward compatibility with Z_MOTOR_CONFIG