### PR TITLE
fix a issue of laser auto focus

### DIFF
--- a/software/control/core/core.py
+++ b/software/control/core/core.py
@@ -4614,11 +4614,14 @@ class LaserAutofocusController(QObject):
         # Move to first position and measure
         if self.piezo is not None:
             self._move_z(-self.PIXEL_TO_UM_CALIBRATION_DISTANCE/2)
-            time.sleep(MULTIPOINT_PIEZO_DELAY_MS/1000)
         else:
             # TODO: change to _move_z after backlash correction is absorbed into firmware
-            self.stage.move_z(-1.5 * self.PIXEL_TO_UM_CALIBRATION_DISTANCE / 1000)
-            self.stage.move_z(self.PIXEL_TO_UM_CALIBRATION_DISTANCE / 1000)
+            self.stage.move_z(-3.0 * self.PIXEL_TO_UM_CALIBRATION_DISTANCE / 1000)
+            self.microcontroller.wait_till_operation_is_completed()
+            self.stage.move_z(2.0 * self.PIXEL_TO_UM_CALIBRATION_DISTANCE / 1000)
+            self.microcontroller.wait_till_operation_is_completed()
+
+        time.sleep(MULTIPOINT_PIEZO_DELAY_MS / 1000)
 
         result = self._get_laser_spot_centroid()
         if result is None:
@@ -4629,8 +4632,13 @@ class LaserAutofocusController(QObject):
         x0, y0 = result
 
         # Move to second position and measure
-        self._move_z(self.PIXEL_TO_UM_CALIBRATION_DISTANCE/2)
-        time.sleep(MULTIPOINT_PIEZO_DELAY_MS/1000)
+        if self.piezo is not None:
+            self._move_z(self.PIXEL_TO_UM_CALIBRATION_DISTANCE / 2)
+        else:
+            self.stage.move_z(self.PIXEL_TO_UM_CALIBRATION_DISTANCE / 1000)
+            self.microcontroller.wait_till_operation_is_completed()
+
+        time.sleep(MULTIPOINT_PIEZO_DELAY_MS / 1000)
 
         result = self._get_laser_spot_centroid()
         if result is None:

--- a/software/control/utils.py
+++ b/software/control/utils.py
@@ -228,7 +228,7 @@ def find_spot_location(
         "x_window": 20,  # Half-width of centroid window
         "min_peak_width": 10,  # Minimum width of peaks
         "min_peak_distance": 10,  # Minimum distance between peaks
-        "min_peak_prominence": 0.25,  # Minimum peak prominence
+        "min_peak_prominence": 0.2,  # Minimum peak prominence
         "intensity_threshold": 0.1,  # Threshold for intensity filtering
         "spot_spacing": 100,  # Expected spacing between spots
     }


### PR DESCRIPTION
In the older version code, the distance between x0 and x1 is only PIXEL_TO_UM_CALIBRATION_DISTANCE / 2.
But when calculate the pixel_to_um value, use the PIXEL_TO_UM_CALIBRATION_DISTANCE / (x1 - x0).

And I believe there must be better parameters for both one spot or two spots situation.