### PR TITLE
Improve Laser-Based Focus display to show results of running laser autofocus 

### DIFF
--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from configparser import ConfigParser
 import json
 import csv
-from control.utils import SpotDetectionMode
 import squid.logging
 from enum import Enum, auto
 
@@ -257,6 +256,23 @@ class ZStageConfig(Enum):
         if mode_str.lower() not in mapping:
             raise ValueError(f"Invalid z_stage_mode. Must be one of: {', '.join(mapping.keys())}")
         return mapping[mode_str.lower()]
+
+
+class SpotDetectionMode(Enum):
+    """Specifies which spot to detect when multiple spots are present.
+
+    SINGLE: Expect and detect single spot
+    DUAL_RIGHT: In dual-spot case, use rightmost spot
+    DUAL_LEFT: In dual-spot case, use leftmost spot
+    MULTI_RIGHT: In multi-spot case, use rightmost spot
+    MULTI_SECOND_RIGHT: In multi-spot case, use spot immediately left of rightmost spot
+    """
+
+    SINGLE = "single"
+    DUAL_RIGHT = "dual_right"
+    DUAL_LEFT = "dual_left"
+    MULTI_RIGHT = "multi_right"
+    MULTI_SECOND_RIGHT = "multi_second_right"
 
 
 PRINT_CAMERA_FPS = True

--- a/software/control/core/core.py
+++ b/software/control/core/core.py
@@ -4698,7 +4698,18 @@ class LaserAutofocusController(QObject):
         self.microcontroller.turn_on_AF_laser()
         self.microcontroller.wait_till_operation_is_completed()
 
-        result = self._get_laser_spot_centroid()
+        spot_detection_params = {
+            "y_window": self.laser_af_properties.laser_af_y_window,
+            "x_window": self.laser_af_properties.laser_af_x_window,
+            "peak_width": self.laser_af_properties.laser_af_min_peak_width,
+            "peak_distance": self.laser_af_properties.laser_af_min_peak_distance,
+            "peak_prominence": self.laser_af_properties.laser_af_min_peak_prominence
+        }
+        result = self.get_laser_spot_centroid(
+            averaging_n=self.laser_af_properties.laser_af_averaging_n,
+            spot_detection_mode=self.laser_af_properties.spot_detection_mode,
+            spot_detection_params=spot_detection_params
+        )
         if result is None:
             self._log.error("Failed to find laser spot during initialization")
             self.microcontroller.turn_off_AF_laser()
@@ -4748,7 +4759,18 @@ class LaserAutofocusController(QObject):
             self.stage.move_z(-1.5 * self.laser_af_properties.pixel_to_um_calibration_distance / 1000)
             self.stage.move_z(self.laser_af_properties.pixel_to_um_calibration_distance / 1000)
 
-        result = self._get_laser_spot_centroid()
+        spot_detection_params = {
+            "y_window": self.laser_af_properties.laser_af_y_window,
+            "x_window": self.laser_af_properties.laser_af_x_window,
+            "peak_width": self.laser_af_properties.laser_af_min_peak_width,
+            "peak_distance": self.laser_af_properties.laser_af_min_peak_distance,
+            "peak_prominence": self.laser_af_properties.laser_af_min_peak_prominence
+        }
+        result = self.get_laser_spot_centroid(
+            averaging_n=self.laser_af_properties.laser_af_averaging_n,
+            spot_detection_mode=self.laser_af_properties.spot_detection_mode,
+            spot_detection_params=spot_detection_params
+        )
         if result is None:
             self._log.error("Failed to find laser spot during calibration (position 1)")
             self.microcontroller.turn_off_AF_laser()
@@ -4760,7 +4782,11 @@ class LaserAutofocusController(QObject):
         self._move_z(self.laser_af_properties.pixel_to_um_calibration_distance)
         time.sleep(MULTIPOINT_PIEZO_DELAY_MS / 1000)
 
-        result = self._get_laser_spot_centroid()
+        result = self.get_laser_spot_centroid(
+            averaging_n=self.laser_af_properties.laser_af_averaging_n,
+            spot_detection_mode=self.laser_af_properties.spot_detection_mode,
+            spot_detection_params=spot_detection_params
+        )
         if result is None:
             self._log.error("Failed to find laser spot during calibration (position 2)")
             self.microcontroller.turn_off_AF_laser()
@@ -4817,7 +4843,18 @@ class LaserAutofocusController(QObject):
         self.microcontroller.wait_till_operation_is_completed()
 
         # get laser spot location
-        result = self._get_laser_spot_centroid()
+        spot_detection_params = {
+            "y_window": self.laser_af_properties.laser_af_y_window,
+            "x_window": self.laser_af_properties.laser_af_x_window,
+            "peak_width": self.laser_af_properties.laser_af_min_peak_width,
+            "peak_distance": self.laser_af_properties.laser_af_min_peak_distance,
+            "peak_prominence": self.laser_af_properties.laser_af_min_peak_prominence
+        }
+        result = self.get_laser_spot_centroid(
+            averaging_n=self.laser_af_properties.laser_af_averaging_n,
+            spot_detection_mode=self.laser_af_properties.spot_detection_mode,
+            spot_detection_params=spot_detection_params
+        )
 
         # turn off the laser
         self.microcontroller.turn_off_AF_laser()
@@ -4908,7 +4945,18 @@ class LaserAutofocusController(QObject):
         self.microcontroller.wait_till_operation_is_completed()
 
         # get laser spot location and image
-        result = self._get_laser_spot_centroid()
+        spot_detection_params = {
+            "y_window": self.laser_af_properties.laser_af_y_window,
+            "x_window": self.laser_af_properties.laser_af_x_window,
+            "peak_width": self.laser_af_properties.laser_af_min_peak_width,
+            "peak_distance": self.laser_af_properties.laser_af_min_peak_distance,
+            "peak_prominence": self.laser_af_properties.laser_af_min_peak_prominence
+        }
+        result = self.get_laser_spot_centroid(
+            averaging_n=self.laser_af_properties.laser_af_averaging_n,
+            spot_detection_mode=self.laser_af_properties.spot_detection_mode,
+            spot_detection_params=spot_detection_params
+        )
         reference_image = self.image
 
         # turn off the laser
@@ -4971,7 +5019,18 @@ class LaserAutofocusController(QObject):
         self.camera.send_trigger()
         current_image = self.camera.read_frame()
         """
-        self._get_laser_spot_centroid()
+        spot_detection_params = {
+            "y_window": self.laser_af_properties.laser_af_y_window,
+            "x_window": self.laser_af_properties.laser_af_x_window,
+            "peak_width": self.laser_af_properties.laser_af_min_peak_width,
+            "peak_distance": self.laser_af_properties.laser_af_min_peak_distance,
+            "peak_prominence": self.laser_af_properties.laser_af_min_peak_prominence
+        }
+        self.get_laser_spot_centroid(
+            averaging_n=self.laser_af_properties.laser_af_averaging_n,
+            spot_detection_mode=self.laser_af_properties.spot_detection_mode,
+            spot_detection_params=spot_detection_params
+        )
         current_image = self.image
 
         self.microcontroller.turn_off_AF_laser()
@@ -5005,7 +5064,12 @@ class LaserAutofocusController(QObject):
 
         return True
 
-    def _get_laser_spot_centroid(self) -> Optional[Tuple[float, float]]:
+    def get_laser_spot_centroid(
+        self,
+        averaging_n: int,
+        spot_detection_mode: SpotDetectionMode,
+        spot_detection_params: dict
+    ) -> Optional[Tuple[float, float]]:
         """Get the centroid location of the laser spot.
 
         Averages multiple measurements to improve accuracy. The number of measurements
@@ -5021,7 +5085,7 @@ class LaserAutofocusController(QObject):
         tmp_x = 0
         tmp_y = 0
 
-        for i in range(self.laser_af_properties.laser_af_averaging_n):
+        for i in range(averaging_n):
             try:
                 # send camera trigger
                 if self.liveController.trigger_mode == TriggerMode.SOFTWARE:
@@ -5033,17 +5097,15 @@ class LaserAutofocusController(QObject):
                 # read camera frame
                 image = self.camera.read_frame()
                 if image is None:
-                    self._log.warning(f"Failed to read frame {i+1}/{self.laser_af_properties.laser_af_averaging_n}")
+                    self._log.warning(f"Failed to read frame {i+1}/{averaging_n}")
                     continue
 
                 self.image = image  # store for debugging # TODO: add to return instead of storing
 
                 # calculate centroid
-                result = utils.find_spot_location(image, mode=self.laser_af_properties.spot_detection_mode)
+                result = utils.find_spot_location(image, mode=spot_detection_mode, params=spot_detection_params)
                 if result is None:
-                    self._log.warning(
-                        f"No spot detected in frame {i+1}/{self.laser_af_properties.laser_af_averaging_n}"
-                    )
+                    self._log.warning(f"No spot detected in frame {i+1}/{averaging_n}")
                     continue
 
                 x, y = result
@@ -5052,9 +5114,7 @@ class LaserAutofocusController(QObject):
                 successful_detections += 1
 
             except Exception as e:
-                self._log.error(
-                    f"Error processing frame {i+1}/{self.laser_af_properties.laser_af_averaging_n}: {str(e)}"
-                )
+                self._log.error(f"Error processing frame {i+1}/{averaging_n}: {str(e)}")
                 continue
 
         # optionally display the image

--- a/software/control/core/core.py
+++ b/software/control/core/core.py
@@ -5077,12 +5077,12 @@ class LaserAutofocusController(QObject):
 
                 # calculate centroid
                 spot_detection_params = {
-                    "y_window": self.laser_af_properties.laser_af_y_window,
-                    "x_window": self.laser_af_properties.laser_af_x_window,
-                    "peak_width": self.laser_af_properties.laser_af_min_peak_width,
-                    "peak_distance": self.laser_af_properties.laser_af_min_peak_distance,
-                    "peak_prominence": self.laser_af_properties.laser_af_min_peak_prominence,
-                    "spot_spacing": self.laser_af_properties.laser_af_spot_spacing
+                    "y_window": self.laser_af_properties.y_window,
+                    "x_window": self.laser_af_properties.x_window,
+                    "peak_width": self.laser_af_properties.min_peak_width,
+                    "peak_distance": self.laser_af_properties.min_peak_distance,
+                    "peak_prominence": self.laser_af_properties.min_peak_prominence,
+                    "spot_spacing": self.laser_af_properties.spot_spacing
                 }
                 result = utils.find_spot_location(image, mode=self.laser_af_properties.spot_detection_mode, params=spot_detection_params)
                 if result is None:

--- a/software/control/core/core.py
+++ b/software/control/core/core.py
@@ -3023,7 +3023,6 @@ class ImageDisplayWindow(QMainWindow):
         liveController=None,
         contrastManager=None,
         window_title="",
-        draw_crosshairs=False,
         show_LUT=False,
         autoLevels=False,
     ):
@@ -3080,7 +3079,6 @@ class ImageDisplayWindow(QMainWindow):
         self.ptRect2 = None
         self.DrawCirc = False
         self.centroid = None
-        self.DrawCrossHairs = False
         self.image_offset = np.array([0, 0])
 
         ## Layout

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -1007,7 +1007,9 @@ class HighContentScreeningGui(QMainWindow):
             self.laserAutofocusSettingWidget.signal_apply_settings.connect(
                 self.laserAutofocusControlWidget.update_init_state
             )
-
+            self.laserAutofocusSettingWidget.signal_laser_spot_location.connect(
+                self.imageDisplayWindow_focus.mark_spot
+            )
             self.laserAutofocusSettingWidget.update_exposure_time(
                 self.laserAutofocusSettingWidget.exposure_spinbox.value()
             )

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -1016,6 +1016,9 @@ class HighContentScreeningGui(QMainWindow):
             self.laserAutofocusSettingWidget.update_analog_gain(
                 self.laserAutofocusSettingWidget.analog_gain_spinbox.value()
             )
+            self.laserAutofocusController.signal_cross_correlation.connect(
+                self.laserAutofocusSettingWidget.show_cross_correlation_result
+            )
 
             self.streamHandler_focus_camera.signal_new_frame_received.connect(
                 self.liveController_focus_camera.on_new_frame

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -301,7 +301,7 @@ class HighContentScreeningGui(QMainWindow):
                 for_displacement_measurement=True,
             )
             self.imageDisplayWindow_focus = core.ImageDisplayWindow(
-                draw_crosshairs=True, show_LUT=False, autoLevels=False
+                show_LUT=False, autoLevels=False
             )
             self.displacementMeasurementController = core_displacement_measurement.DisplacementMeasurementController()
             self.laserAutofocusController = core.LaserAutofocusController(
@@ -641,18 +641,18 @@ class HighContentScreeningGui(QMainWindow):
             self.laserAutofocusControlWidget: widgets.LaserAutofocusControlWidget = widgets.LaserAutofocusControlWidget(
                 self.laserAutofocusController
             )
-            self.imageDisplayWindow_focus = core.ImageDisplayWindow(draw_crosshairs=True)
+            self.imageDisplayWindow_focus = core.ImageDisplayWindow()
 
         self.imageDisplayTabs = QTabWidget()
         if self.live_only_mode:
             if ENABLE_TRACKING:
                 self.imageDisplayWindow = core.ImageDisplayWindow(
-                    self.liveController, self.contrastManager, draw_crosshairs=True
+                    self.liveController, self.contrastManager
                 )
                 self.imageDisplayWindow.show_ROI_selector()
             else:
                 self.imageDisplayWindow = core.ImageDisplayWindow(
-                    self.liveController, self.contrastManager, draw_crosshairs=True, show_LUT=True, autoLevels=True
+                    self.liveController, self.contrastManager, show_LUT=True, autoLevels=True
                 )
             self.imageDisplayTabs = self.imageDisplayWindow.widget
             self.napariMosaicDisplayWidget = None
@@ -713,12 +713,12 @@ class HighContentScreeningGui(QMainWindow):
         else:
             if ENABLE_TRACKING:
                 self.imageDisplayWindow = core.ImageDisplayWindow(
-                    self.liveController, self.contrastManager, draw_crosshairs=True
+                    self.liveController, self.contrastManager
                 )
                 self.imageDisplayWindow.show_ROI_selector()
             else:
                 self.imageDisplayWindow = core.ImageDisplayWindow(
-                    self.liveController, self.contrastManager, draw_crosshairs=True, show_LUT=True, autoLevels=True
+                    self.liveController, self.contrastManager, show_LUT=True, autoLevels=True
                 )
             self.imageDisplayTabs.addTab(self.imageDisplayWindow.widget, "Live View")
 

--- a/software/control/utils.py
+++ b/software/control/utils.py
@@ -12,7 +12,16 @@ from scipy.ndimage import label
 from scipy import signal
 import os
 from typing import Optional, Tuple
-from enum import Enum, auto
+
+from control._def import (
+    LASER_AF_Y_WINDOW,
+    LASER_AF_X_WINDOW,
+    LASER_AF_MIN_PEAK_WIDTH,
+    LASER_AF_MIN_PEAK_DISTANCE,
+    LASER_AF_MIN_PEAK_PROMINENCE,
+    LASER_AF_SPOT_SPACING,
+    SpotDetectionMode,
+)
 import squid.logging
 
 _log = squid.logging.get_logger("control.utils")
@@ -174,23 +183,6 @@ def ensure_directory_exists(raw_string_path: str):
     path.mkdir(parents=True, exist_ok=True)
 
 
-class SpotDetectionMode(Enum):
-    """Specifies which spot to detect when multiple spots are present.
-
-    SINGLE: Expect and detect single spot
-    DUAL_RIGHT: In dual-spot case, use rightmost spot
-    DUAL_LEFT: In dual-spot case, use leftmost spot
-    MULTI_RIGHT: In multi-spot case, use rightmost spot
-    MULTI_SECOND_RIGHT: In multi-spot case, use spot immediately left of rightmost spot
-    """
-
-    SINGLE = "single"
-    DUAL_RIGHT = "dual_right"
-    DUAL_LEFT = "dual_left"
-    MULTI_RIGHT = "multi_right"
-    MULTI_SECOND_RIGHT = "multi_second_right"
-
-
 def find_spot_location(
     image: np.ndarray,
     mode: SpotDetectionMode = SpotDetectionMode.SINGLE,
@@ -224,13 +216,13 @@ def find_spot_location(
 
     # Default parameters
     default_params = {
-        "y_window": 96,  # Half-height of y-axis crop
-        "x_window": 20,  # Half-width of centroid window
-        "min_peak_width": 10,  # Minimum width of peaks
-        "min_peak_distance": 10,  # Minimum distance between peaks
-        "min_peak_prominence": 0.25,  # Minimum peak prominence
+        "y_window": LASER_AF_Y_WINDOW,  # Half-height of y-axis crop
+        "x_window": LASER_AF_X_WINDOW,  # Half-width of centroid window
+        "min_peak_width": LASER_AF_MIN_PEAK_WIDTH,  # Minimum width of peaks
+        "min_peak_distance": LASER_AF_MIN_PEAK_DISTANCE,  # Minimum distance between peaks
+        "min_peak_prominence": LASER_AF_MIN_PEAK_PROMINENCE,  # Minimum peak prominence
         "intensity_threshold": 0.1,  # Threshold for intensity filtering
-        "spot_spacing": 100,  # Expected spacing between spots
+        "spot_spacing": LASER_AF_SPOT_SPACING,  # Expected spacing between spots
     }
 
     if params is not None:

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -622,6 +622,17 @@ class LaserAutofocusSettingWidget(QWidget):
                 # Create and add new error label
                 self.spot_detection_error_label = QLabel("Spot detection failed!")
                 self.layout().addWidget(self.spot_detection_error_label)
+    
+    def show_cross_correlation_result(self, value):
+        """Show cross-correlation value from validating laser af images"""
+        # Clear previous correlation label if it exists
+        if hasattr(self, "correlation_label"):
+            self.correlation_label.deleteLater()
+
+        # Create and add new correlation label
+        self.correlation_label = QLabel()
+        self.correlation_label.setText(f"Cross-correlation: {value:.3f}")
+        self.layout().addWidget(self.correlation_label)
 
 
 class SpinningDiskConfocalWidget(QWidget):

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -474,9 +474,18 @@ class LaserAutofocusSettingWidget(QWidget):
         settings_layout.addWidget(self.apply_button)
         settings_group.setLayout(settings_layout)
 
+        # Add Laser AF Characterization Mode checkbox
+        characterization_group = QFrame()
+        characterization_layout = QHBoxLayout()
+        self.characterization_checkbox = QCheckBox("Laser AF Characterization Mode")
+        self.characterization_checkbox.setChecked(False)
+        characterization_layout.addWidget(self.characterization_checkbox)
+        characterization_group.setLayout(characterization_layout)
+
         # Add to main layout
         layout.addWidget(live_group)
         layout.addWidget(settings_group)
+        layout.addWidget(characterization_group)
         self.setLayout(layout)
 
         if not self.stretch:
@@ -488,6 +497,7 @@ class LaserAutofocusSettingWidget(QWidget):
         self.analog_gain_spinbox.valueChanged.connect(self.update_analog_gain)
         self.apply_button.clicked.connect(self.apply_settings)
         self.run_spot_detection_button.clicked.connect(self.run_spot_detection)
+        self.characterization_checkbox.stateChanged.connect(self.toggle_characterization_mode)
 
     def _add_spinbox(
         self, layout, label: str, property_name: str, min_val: float, max_val: float, decimals: int
@@ -518,6 +528,10 @@ class LaserAutofocusSettingWidget(QWidget):
             self.liveController.stop_live()
             self.btn_live.setText("Start Live")
             self.run_spot_detection_button.setEnabled(True)
+    
+    def toggle_characterization_mode(self, state):
+        global LASER_AF_CHARACTERIZATION_MODE
+        LASER_AF_CHARACTERIZATION_MODE = state
 
     def update_exposure_time(self, value):
         self.signal_newExposureTime.emit(value)

--- a/software/main_hcs.py
+++ b/software/main_hcs.py
@@ -22,7 +22,6 @@ from configparser import ConfigParser
 from control.widgets import ConfigEditorBackwardsCompatible
 from control._def import CACHED_CONFIG_FILE_PATH
 from control._def import USE_TERMINAL_CONSOLE
-from control._def import SUPPORT_LASER_AUTOFOCUS
 import control.utils
 
 


### PR DESCRIPTION
- Fixed passing params for spot detection. Previously it's using default params
- Show crosshair on spot centroid location
- Display cross-correlation result
- Checkbox for turning on / off laser af characterization mode