### PR TITLE
feat: enforce laser autofocus reference requirement

### DIFF
--- a/software/control/core/core.py
+++ b/software/control/core/core.py
@@ -4683,7 +4683,6 @@ class LaserAutofocusController(QObject):
         1. Finds the laser spot on full sensor
         2. Sets up ROI around the spot
         3. Calibrates pixel-to-um conversion using two z positions
-        4. Sets initial reference position
 
         Returns:
             bool: True if initialization successful, False if any step fails
@@ -4711,12 +4710,16 @@ class LaserAutofocusController(QObject):
         self.microcontroller.turn_off_AF_laser()
         self.microcontroller.wait_till_operation_is_completed()
 
+        # Clear reference
+        self.has_reference = False
+        self.reference_crop = None
+
         # Set up ROI around spot
         config = self.laser_af_properties.model_copy(
             update={
                 "x_offset": x - self.laser_af_properties.width / 2,
                 "y_offset": y - self.laser_af_properties.height / 2,
-                "x_reference": x,
+                "has_reference": False,
             }
         )
         self._log.info(f"Laser spot location on the full sensor is ({int(x)}, {int(y)})")

--- a/software/control/utils_config.py
+++ b/software/control/utils_config.py
@@ -33,6 +33,7 @@ class LaserAFConfig(BaseModel):
     width: int = LASER_AF_CROP_WIDTH
     height: int = LASER_AF_CROP_HEIGHT
     pixel_to_um: float = 1
+    has_reference: bool = False
     x_reference: float = 0.0
     laser_af_averaging_n: int = LASER_AF_AVERAGING_N
     displacement_success_window_um: float = (

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -6784,6 +6784,7 @@ class LaserAutofocusControlWidget(QFrame):
         super().__init__(*args, **kwargs)
         self.laserAutofocusController = laserAutofocusController
         self.add_components()
+        self.update_init_state()
         self.setFrameStyle(QFrame.Panel | QFrame.Raised)
 
     def add_components(self):
@@ -6840,7 +6841,7 @@ class LaserAutofocusControlWidget(QFrame):
 
         # make connections
         self.btn_initialize.clicked.connect(self.init_controller)
-        self.btn_set_reference.clicked.connect(self.laserAutofocusController.set_reference)
+        self.btn_set_reference.clicked.connect(self.on_set_reference_clicked)
         self.btn_measure_displacement.clicked.connect(self.laserAutofocusController.measure_displacement)
         self.btn_move_to_target.clicked.connect(self.move_to_target)
         self.laserAutofocusController.signal_displacement_um.connect(self.label_displacement.setNum)
@@ -6849,17 +6850,24 @@ class LaserAutofocusControlWidget(QFrame):
         self.laserAutofocusController.initialize_auto()
         if self.laserAutofocusController.is_initialized:
             self.btn_set_reference.setEnabled(True)
-            self.btn_measure_displacement.setEnabled(True)
-            self.btn_move_to_target.setEnabled(True)
+            self.btn_measure_displacement.setEnabled(False)
+            self.btn_move_to_target.setEnabled(False)
 
     def update_init_state(self):
         self.btn_initialize.setChecked(self.laserAutofocusController.is_initialized)
         self.btn_set_reference.setEnabled(self.laserAutofocusController.is_initialized)
-        self.btn_measure_displacement.setEnabled(self.laserAutofocusController.is_initialized)
-        self.btn_move_to_target.setEnabled(self.laserAutofocusController.is_initialized)
+        self.btn_measure_displacement.setEnabled(self.laserAutofocusController.has_reference)
+        self.btn_move_to_target.setEnabled(self.laserAutofocusController.has_reference)
 
     def move_to_target(self, target_um):
         self.laserAutofocusController.move_to_target(self.entry_target.value())
+
+    def on_set_reference_clicked(self):
+        """Handle set reference button click"""
+        success = self.laserAutofocusController.set_reference()
+        if success:
+            self.btn_measure_displacement.setEnabled(True)
+            self.btn_move_to_target.setEnabled(True)
 
 
 class WellplateFormatWidget(QWidget):


### PR DESCRIPTION
1. Add reference state tracking:
   - Add has_reference flag to LaserAutofocusController
   - Add has_reference to LaserAFConfig for persistence
   - [to add] reference_crop storage for cross-correlation checks

2. Update LaserAutofocusControlWidget UI:
   - Disable measure/move buttons until reference is set
   - Enable buttons only after successful reference set
   - Update button states based on controller's has_reference state

3. Add validation for multipoint acquisition:
   - Check for reference before allowing laser AF acquisition
   - Show warning dialog if acquisition attempted without reference
   - Re-enable UI if validation fails

This ensures proper laser autofocus usage by:
- Preventing measure/move operations without reference
- Maintaining reference state across sessions
- Providing clear user feedback about reference requirements