### PR TITLE
laser autofocus UX improvement

### DIFF
--- a/software/control/core/core.py
+++ b/software/control/core/core.py
@@ -1601,7 +1601,7 @@ class MultiPointWorker(QObject):
             print(f"Acquiring image: ID={file_ID}, Metadata={metadata}")
 
             # laser af characterization mode
-            if LASER_AF_CHARACTERIZATION_MODE:
+            if self.microscope.laserAutofocusController.characterization_mode:
                 image = self.microscope.laserAutofocusController.get_image()
                 saving_path = os.path.join(current_path, file_ID + "_laser af camera" + ".bmp")
                 iio.imwrite(saving_path, image)
@@ -4638,6 +4638,7 @@ class LaserAutofocusController(QObject):
         self.piezo = piezo
         self.objectiveStore = objectiveStore
         self.laserAFSettingManager = laserAFSettingManager
+        self.characterization_mode = LASER_AF_CHARACTERIZATION_MODE
 
         self.is_initialized = False
 

--- a/software/control/core/core.py
+++ b/software/control/core/core.py
@@ -3748,8 +3748,10 @@ class LaserAFSettingManager:
             self.autofocus_configurations[objective] = config.model_copy(update=updates)
 
 
-class ConfigurationManager:
+class ConfigurationManager(QObject):
     """Main configuration manager that coordinates channel and autofocus configurations."""
+
+    signal_profile_loaded = Signal()
 
     def __init__(
         self,
@@ -3799,6 +3801,8 @@ class ConfigurationManager:
                 self.channel_manager.load_configurations(objective)
             if self.laser_af_manager:
                 self.laser_af_manager.load_configurations(objective)
+
+        self.signal_profile_loaded.emit()
 
     def create_new_profile(self, profile_name: str) -> None:
         """Create a new profile using current configurations."""
@@ -4992,8 +4996,8 @@ class LaserAutofocusController(QObject):
 
         return True
 
-    def on_objective_changed(self) -> None:
-        """Handle objective change event.
+    def on_settings_changed(self) -> None:
+        """Handle objective change or profile load event.
 
         This method is called when the objective changes. It resets the initialization
         status and loads the cached configuration for the new objective.

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -1271,7 +1271,12 @@ class HighContentScreeningGui(QMainWindow):
 
         # Stop focus camera live if not on laser focus tab
         if SUPPORT_LASER_AUTOFOCUS:
-            if self.imageDisplayTabs.tabText(index) != "Laser-Based Focus":
+            is_laser_focus_tab = self.imageDisplayTabs.tabText(index) == "Laser-Based Focus"
+
+            if hasattr(self, 'dock_wellSelection'):
+                self.dock_wellSelection.setVisible(not is_laser_focus_tab)
+
+            if not is_laser_focus_tab:
                 self.laserAutofocusSettingWidget.stop_live()
 
     def onWellplateChanged(self, format_):

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -982,6 +982,11 @@ class HighContentScreeningGui(QMainWindow):
             self.wellSelectionWidget.signal_wellSelected.connect(self.wellplateMultiPointWidget.update_well_coordinates)
             self.objectivesWidget.signal_objective_changed.connect(self.wellplateMultiPointWidget.update_coordinates)
 
+        self.configurationManager.signal_profile_loaded.connect(
+            lambda: self.liveControlWidget.update_microscope_mode_by_name(
+                self.liveControlWidget.currentConfiguration.name
+            )
+        )
         self.objectivesWidget.signal_objective_changed.connect(
             lambda: self.liveControlWidget.update_microscope_mode_by_name(
                 self.liveControlWidget.currentConfiguration.name
@@ -990,12 +995,13 @@ class HighContentScreeningGui(QMainWindow):
 
         if SUPPORT_LASER_AUTOFOCUS:
 
-            def connect_objective_changed_laser_af():
-                self.laserAutofocusController.on_objective_changed()
+            def connect_settings_changed_laser_af():
+                self.laserAutofocusController.on_settings_changed()
                 self.laserAutofocusControlWidget.update_init_state()
                 self.laserAutofocusSettingWidget.update_values()
 
-            self.objectivesWidget.signal_objective_changed.connect(connect_objective_changed_laser_af)
+            self.configurationManager.signal_profile_loaded.connect(connect_settings_changed_laser_af)
+            self.objectivesWidget.signal_objective_changed.connect(connect_settings_changed_laser_af)
             self.laserAutofocusSettingWidget.signal_newExposureTime.connect(
                 self.cameraSettingWidget_focus_camera.set_exposure_time
             )

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -1269,6 +1269,11 @@ class HighContentScreeningGui(QMainWindow):
         if hasattr(current_widget, "viewer"):
             current_widget.activate()
 
+        # Stop focus camera live if not on laser focus tab
+        if SUPPORT_LASER_AUTOFOCUS:
+            if self.imageDisplayTabs.tabText(index) != "Laser-Based Focus":
+                self.laserAutofocusSettingWidget.stop_live()
+
     def onWellplateChanged(self, format_):
         if isinstance(format_, QVariant):
             format_ = format_.value()

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -1279,7 +1279,7 @@ class HighContentScreeningGui(QMainWindow):
         if SUPPORT_LASER_AUTOFOCUS:
             is_laser_focus_tab = self.imageDisplayTabs.tabText(index) == "Laser-Based Focus"
 
-            if hasattr(self, 'dock_wellSelection'):
+            if hasattr(self, "dock_wellSelection"):
                 self.dock_wellSelection.setVisible(not is_laser_focus_tab)
 
             if not is_laser_focus_tab:

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -995,13 +995,13 @@ class HighContentScreeningGui(QMainWindow):
 
         if SUPPORT_LASER_AUTOFOCUS:
 
-            def connect_settings_changed_laser_af():
+            def slot_settings_changed_laser_af():
                 self.laserAutofocusController.on_settings_changed()
                 self.laserAutofocusControlWidget.update_init_state()
                 self.laserAutofocusSettingWidget.update_values()
 
-            self.configurationManager.signal_profile_loaded.connect(connect_settings_changed_laser_af)
-            self.objectivesWidget.signal_objective_changed.connect(connect_settings_changed_laser_af)
+            self.configurationManager.signal_profile_loaded.connect(slot_settings_changed_laser_af)
+            self.objectivesWidget.signal_objective_changed.connect(slot_settings_changed_laser_af)
             self.laserAutofocusSettingWidget.signal_newExposureTime.connect(
                 self.cameraSettingWidget_focus_camera.set_exposure_time
             )

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -529,6 +529,11 @@ class LaserAutofocusSettingWidget(QWidget):
             self.liveController.stop_live()
             self.btn_live.setText("Start Live")
             self.run_spot_detection_button.setEnabled(True)
+    
+    def stop_live(self):
+        """Used for stopping live when switching to other tabs"""
+        self.toggle_live(False)
+        self.btn_live.setChecked(False)
 
     def toggle_characterization_mode(self, state):
         self.laserAutofocusController.characterization_mode = state

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -479,7 +479,7 @@ class LaserAutofocusSettingWidget(QWidget):
         characterization_group = QFrame()
         characterization_layout = QHBoxLayout()
         self.characterization_checkbox = QCheckBox("Laser AF Characterization Mode")
-        self.characterization_checkbox.setChecked(False)
+        self.characterization_checkbox.setChecked(self.laserAutofocusController.characterization_mode)
         characterization_layout.addWidget(self.characterization_checkbox)
         characterization_group.setLayout(characterization_layout)
 
@@ -498,7 +498,7 @@ class LaserAutofocusSettingWidget(QWidget):
         self.analog_gain_spinbox.valueChanged.connect(self.update_analog_gain)
         self.apply_button.clicked.connect(self.apply_settings)
         self.run_spot_detection_button.clicked.connect(self.run_spot_detection)
-        self.characterization_checkbox.stateChanged.connect(self.toggle_characterization_mode)
+        self.characterization_checkbox.toggled.connect(self.toggle_characterization_mode)
 
     def _add_spinbox(
         self, layout, label: str, property_name: str, min_val: float, max_val: float, decimals: int
@@ -531,8 +531,7 @@ class LaserAutofocusSettingWidget(QWidget):
             self.run_spot_detection_button.setEnabled(True)
 
     def toggle_characterization_mode(self, state):
-        global LASER_AF_CHARACTERIZATION_MODE
-        LASER_AF_CHARACTERIZATION_MODE = bool(state == Qt.Checked)
+        self.laserAutofocusController.characterization_mode = state
 
     def update_exposure_time(self, value):
         self.signal_newExposureTime.emit(value)

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -530,7 +530,7 @@ class LaserAutofocusSettingWidget(QWidget):
             self.liveController.stop_live()
             self.btn_live.setText("Start Live")
             self.run_spot_detection_button.setEnabled(True)
-    
+
     def stop_live(self):
         """Used for stopping live when switching to other tabs"""
         self.toggle_live(False)

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -373,6 +373,7 @@ class LaserAutofocusSettingWidget(QWidget):
 
         self.spinboxes = {}
         self.init_ui()
+        self.update_calibration_label()
 
     def init_ui(self):
         layout = QVBoxLayout()
@@ -561,6 +562,8 @@ class LaserAutofocusSettingWidget(QWidget):
         if index >= 0:
             self.spot_mode_combo.setCurrentIndex(index)
 
+        self.update_calibration_label()
+
     def apply_settings(self):
         updates = {
             "laser_af_averaging_n": int(self.spinboxes["laser_af_averaging_n"].value()),
@@ -582,7 +585,9 @@ class LaserAutofocusSettingWidget(QWidget):
         self.laserAutofocusController.set_laser_af_properties(updates)
         self.laserAutofocusController.initialize_auto()
         self.signal_apply_settings.emit()
+        self.update_calibration_label()
 
+    def update_calibration_label(self):
         # Show calibration result
         # Clear previous calibration label if it exists
         if hasattr(self, "calibration_label"):


### PR DESCRIPTION
- Automatically turn off focus camera live on switching tab
- Hide well selector on focus camera live tab
- Show calibration value when loaded from cache
- Fix laser af characterization mode
- Ensure update on loading new profiles