### PR TITLE
fix(tests): microscope init test fix, other argument change fixes

### DIFF
--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -58,9 +58,12 @@ class Microscope(QObject):
         self.home_x_and_y_separately = False
 
     def initialize_core_components(self):
-        self.configurationManager = core.ConfigurationManager(filename="./channel_configurations.xml")
+        self.configurationManager = core.ConfigurationManager(
+            channel_manager=core.ChannelConfigurationManager(),
+            laser_af_manager=core.LaserAFSettingManager() if SUPPORT_LASER_AUTOFOCUS else None,
+        )
         self.objectiveStore = core.ObjectiveStore()
-        self.streamHandler = core.StreamHandler(display_resolution_scaling=DEFAULT_DISPLAY_CROP / 100)
+        self.streamHandler = core.StreamHandler()
         self.liveController = core.LiveController(self.camera, self.microcontroller, self.configurationManager, self)
         self.autofocusController = core.AutoFocusController(
             self.camera, self.stage, self.liveController, self.microcontroller

--- a/software/tests/control/test_MultiPointWorker.py
+++ b/software/tests/control/test_MultiPointWorker.py
@@ -1,6 +1,3 @@
-import control.core.core
-from control._def import *
-
 import tests.control.gui_test_stubs as gts
 
 

--- a/software/tests/tools.py
+++ b/software/tests/tools.py
@@ -12,6 +12,7 @@ import matplotlib
 import control.camera
 import control.microcontroller
 import squid.stage
+import squid.stage.cephla
 from control.microcontroller import Microcontroller
 from control.piezo import PiezoStage
 from squid.config import get_stage_config


### PR DESCRIPTION
Most of the fixes here are just changed object structures, not actual bugs.  But the `microscope.py` initialization issues are real and would prevent `microscope.py` from working as expected.

Tested by: More unit tests pass now.  There's still 1 test that segfaults on a `QApplication.processEvents()` call, but not because of changes here.