### PR TITLE
testing: add xvfb-run so we have a proper x environment, and remove a trailing processEvents call

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       # Some of our tests are headless gui tests, but we still need a proper virtual display
       # environment.  We use xvfb for this.
       - name: Install xvfb (for gui testing environment)
-        run: sudo apt install -y xvfb
+        run: sudo apt update && sudo apt install -y xvfb
       - name: Checkout the Squid repo
         uses: actions/checkout@v4
       - name: Run the setup script for Ubuntu 22.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,10 @@ jobs:
           large-packages: true
           docker-images: true
           swap-storage: true
+      # Some of our tests are headless gui tests, but we still need a proper virtual display
+      # environment.  We use xvfb for this.
+      - name: Install xvfb (for gui testing environment)
+        run: sudo apt install -y xvfb
       - name: Checkout the Squid repo
         uses: actions/checkout@v4
       - name: Run the setup script for Ubuntu 22.04
@@ -35,5 +39,5 @@ jobs:
         run: cp configurations/configuration_Squid+.ini .
         working-directory: ./software
       - name: Run the tests
-        run: python3 -m pytest
+        run: xvfb-run python3 -m pytest
         working-directory: ./software

--- a/software/control/core/core.py
+++ b/software/control/core/core.py
@@ -2545,7 +2545,6 @@ class MultiPointController(QObject):
         self.acquisitionFinished.emit()
         if not self.abort_acqusition_requested:
             self.signal_stitcher.emit(os.path.join(self.base_path, self.experiment_ID))
-        QApplication.processEvents()
 
     def request_abort_aquisition(self):
         self.abort_acqusition_requested = True


### PR DESCRIPTION
The `processEvents` call is at the end of a callback method, so it really doesn't do anything (we immediately give control back to Qt after).  But it was causing segfaults in the abort acquisition test (which might be another problem?).

Also we were getting aborted test runs on our workflows.  I think it's because we don't have a proper x environemnt.  xvfb gives us that.

Tested by: Unit tests