### PR TITLE
gui: acquisitions: prevent acquisitions from starting if there is not enough disk space

### DIFF
--- a/software/control/camera_toupcam.py
+++ b/software/control/camera_toupcam.py
@@ -571,7 +571,7 @@ class Camera(object):
         else:
             # TODO(imo): Propagate these errors in some way and handle
             if self.is_streaming == False:
-                self.logger.error("trigger not sent - camera is not streaming")
+                self.log.error("trigger not sent - camera is not streaming")
             else:
                 pass
 

--- a/software/control/utils.py
+++ b/software/control/utils.py
@@ -404,3 +404,22 @@ def get_available_disk_space(directory: pathlib.Path) -> int:
     (total, used, free) = shutil.disk_usage(directory)
 
     return free
+
+
+def get_directory_disk_usage(directory: pathlib.Path) -> int:
+    """
+    Returns the total disk size used by the contents of this directory in bytes.
+
+    Cribbed from the interwebs here: https://stackoverflow.com/a/1392549
+    """
+    total_size = 0
+    if isinstance(directory, str):
+        directory = pathlib.Path(directory)
+    for dirpath, _, filenames in os.walk(directory.absolute()):
+        for f in filenames:
+            fp = os.path.join(dirpath, f)
+            # skip if it is symbolic link
+            if not os.path.islink(fp):
+                total_size += os.path.getsize(fp)
+
+    return total_size

--- a/software/control/utils.py
+++ b/software/control/utils.py
@@ -395,6 +395,9 @@ def get_available_disk_space(directory: pathlib.Path) -> int:
 
     Raises: ValueError if directory is not a directory, or doesn't exist.  PermissionError if you do not have access.
     """
+    if not isinstance(directory, pathlib.Path):
+        directory = pathlib.Path(directory)
+
     if not directory.exists():
         raise ValueError(f"Cannot check for free space in '{directory}' because it does not exist.")
 

--- a/software/control/utils.py
+++ b/software/control/utils.py
@@ -1,12 +1,11 @@
 import inspect
-import os
 import pathlib
+import shutil
 import sys
-from typing import Optional
 
 import cv2
 import git
-from numpy import std, square, mean
+from numpy import square, mean
 import numpy as np
 from scipy.ndimage import label
 from scipy import signal
@@ -388,3 +387,20 @@ def get_squid_repo_state_description() -> Optional[str]:
     except git.GitError as e:
         _log.warning(f"Failed to get script git repo info: {e}")
         return None
+
+
+def get_available_disk_space(directory: pathlib.Path) -> int:
+    """
+    Returns the available disk space, in bytes, for files created as children of the given directory.
+
+    Raises: ValueError if directory is not a directory, or doesn't exist.  PermissionError if you do not have access.
+    """
+    if not directory.exists():
+        raise ValueError(f"Cannot check for free space in '{directory}' because it does not exist.")
+
+    if not directory.is_dir():
+        raise ValueError(f"Path must be a directory, but '{directory}' is not.")
+
+    (total, used, free) = shutil.disk_usage(directory)
+
+    return free

--- a/software/control/utils_acquisition.py
+++ b/software/control/utils_acquisition.py
@@ -1,0 +1,60 @@
+"""
+Contains helper functions for use in acquisitions such as saving images, converting
+images, etc.
+"""
+
+import os
+
+import numpy as np
+import cv2
+import imageio
+
+import control._def
+from control.utils_config import ChannelMode
+
+
+def save_image(image: np.array, file_id: str, save_directory: str, config: ChannelMode, is_color: bool) -> np.array:
+    if image.dtype == np.uint16:
+        saving_path = os.path.join(save_directory, file_id + "_" + str(config.name).replace(" ", "_") + ".tiff")
+    else:
+        saving_path = os.path.join(
+            save_directory,
+            file_id + "_" + str(config.name).replace(" ", "_") + "." + control._def.Acquisition.IMAGE_FORMAT,
+        )
+
+    if is_color:
+        if "BF LED matrix" in config.name:
+            if control._def.MULTIPOINT_BF_SAVING_OPTION == "RGB2GRAY":
+                image = cv2.cvtColor(image, cv2.COLOR_RGB2GRAY)
+            elif control._def.MULTIPOINT_BF_SAVING_OPTION == "Green Channel Only":
+                image = image[:, :, 1]
+
+    if control._def.SAVE_IN_PSEUDO_COLOR:
+        image = return_pseudo_colored_image(image, config)
+
+    imageio.imwrite(saving_path, image)
+
+    return image
+
+
+def grayscale_to_rgb(image: np.array, hex_color):
+    rgb_ratios = np.array([(hex_color >> 16) & 0xFF, (hex_color >> 8) & 0xFF, hex_color & 0xFF]) / 255
+    rgb = np.stack([image] * 3, axis=-1) * rgb_ratios
+    return rgb.astype(image.dtype)
+
+
+def return_pseudo_colored_image(image: np.array, config):
+    if "405 nm" in config.name:
+        image = grayscale_to_rgb(image, control._def.CHANNEL_COLORS_MAP["405"]["hex"])
+    elif "488 nm" in config.name:
+        image = grayscale_to_rgb(image, control._def.CHANNEL_COLORS_MAP["488"]["hex"])
+    elif "561 nm" in config.name:
+        image = grayscale_to_rgb(image, control._def.CHANNEL_COLORS_MAP["561"]["hex"])
+    elif "638 nm" in config.name:
+        image = grayscale_to_rgb(image, control._def.CHANNEL_COLORS_MAP["638"]["hex"])
+    elif "730 nm" in config.name:
+        image = grayscale_to_rgb(image, control._def.CHANNEL_COLORS_MAP["730"]["hex"])
+    else:
+        image = np.stack([image] * 3, axis=-1)
+
+    return image

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -49,8 +49,8 @@ def error_dialog(message: str, title: str = "Error"):
 def check_space_available_with_error_dialog(
     multi_point_controller: MultiPointController, logger: logging.Logger, factor_of_safecty: float = 1.03
 ) -> bool:
-    # To check how much disk space is required, we need to have the MultiPointController all configured.  So
-    # we need to do that all the way down here.
+    # To check how much disk space is required, we need to have the MultiPointController all configured.  That is
+    # a precondition of this function.
     save_directory = multi_point_controller.base_path
     available_disk_space = utils.get_available_disk_space(save_directory)
     space_required = factor_of_safecty * multi_point_controller.get_estimated_acquisition_disk_storage()
@@ -3012,15 +3012,14 @@ class FlexibleMultiPointWidget(QFrame):
             self.multipointController.set_use_piezo(self.checkbox_usePiezo.isChecked())
             self.multipointController.set_af_flag(self.checkbox_withAutofocus.isChecked())
             self.multipointController.set_reflection_af_flag(self.checkbox_withReflectionAutofocus.isChecked())
-            save_directory = self.lineEdit_savingDir.text()
-            self.multipointController.set_base_path(save_directory)
+            self.multipointController.set_base_path(self.lineEdit_savingDir.text())
             self.multipointController.set_use_fluidics(False)
             self.multipointController.set_selected_configurations(
                 (item.text() for item in self.list_configurations.selectedItems())
             )
             self.multipointController.start_new_experiment(self.lineEdit_experimentID.text())
 
-            if not check_space_available_with_error_dialog(self.multipointController, self._log, save_directory):
+            if not check_space_available_with_error_dialog(self.multipointController, self._log):
                 self._log.error("Failed to start acquisition.  Not enough disk space available.")
                 self.btn_startAcquisition.setChecked(False)
                 return

--- a/software/tests/control/test_MultiPointController.py
+++ b/software/tests/control/test_MultiPointController.py
@@ -1,0 +1,48 @@
+import tests.control.gui_test_stubs as gts
+import pytest
+
+
+def test_multi_point_controller_image_count_calculation(qtbot):
+    mpc = gts.get_test_multi_point_controller()
+
+    all_configuration_names = [
+        config.name
+        for config in mpc.channelConfigurationManager.get_configurations(mpc.objectiveStore.current_objective)
+    ]
+    nz = 2
+    nt = 3
+    assert len(all_configuration_names) > 0
+    all_config_count = len(all_configuration_names)
+
+    mpc.set_NZ(nz)
+    mpc.set_Nt(nt)
+    mpc.set_selected_configurations(all_configuration_names[0:1])
+    mpc.scanCoordinates.clear_regions()
+
+    assert mpc.get_acquisition_image_count() == 0
+
+    # Add a single region with 1 fov
+    # NOTE: If the coordinates below aren't in the valid range for our stage, it silently fails to add regions.
+    x_min = mpc.stage.get_config().X_AXIS.MIN_POSITION + 0.01
+    y_min = mpc.stage.get_config().Y_AXIS.MIN_POSITION + 0.01
+    z_mid = (mpc.stage.get_config().Z_AXIS.MAX_POSITION - mpc.stage.get_config().Z_AXIS.MIN_POSITION) / 2.0
+    mpc.scanCoordinates.add_flexible_region(1, x_min, y_min, z_mid, 1, 1, 0)
+
+    assert mpc.get_acquisition_image_count() == (nt * nz * 1 * 1)
+
+    # Add 9 more regions with a single fov
+    for i in range(1, 10):
+        x_st = x_min + i
+        y_st = y_min + i
+        mpc.scanCoordinates.add_flexible_region(i + 2, x_st, y_st, z_mid, 1, 1, 0)
+
+    assert mpc.get_acquisition_image_count() == (nt * nz * 10 * 1)
+
+    # Select all the configurations
+    mpc.set_selected_configurations(all_configuration_names)
+    assert mpc.get_acquisition_image_count() == (nt * nz * 10 * all_config_count)
+
+    # Add a multiple FOV region with 5 in each of x and y dirs.
+    mpc.scanCoordinates.add_flexible_region(123, x_min + 11, y_min + 11, z_mid, 5, 5, 0)
+
+    assert mpc.get_acquisition_image_count() == (nt * nz * (10 + 25) * all_config_count)

--- a/software/tests/control/test_MultiPointController.py
+++ b/software/tests/control/test_MultiPointController.py
@@ -1,10 +1,12 @@
 import tests.control.gui_test_stubs as gts
 import pytest
+import control._def
 
 
 def test_multi_point_controller_image_count_calculation(qtbot):
     mpc = gts.get_test_multi_point_controller()
 
+    control._def.MERGE_CHANNELS = False
     all_configuration_names = [
         config.name
         for config in mpc.channelConfigurationManager.get_configurations(mpc.objectiveStore.current_objective)
@@ -45,4 +47,60 @@ def test_multi_point_controller_image_count_calculation(qtbot):
     # Add a multiple FOV region with 5 in each of x and y dirs.
     mpc.scanCoordinates.add_flexible_region(123, x_min + 11, y_min + 11, z_mid, 5, 5, 0)
 
-    assert mpc.get_acquisition_image_count() == (nt * nz * (10 + 25) * all_config_count)
+    final_number_of_fov = nt * nz * (10 + 25)
+    assert mpc.get_acquisition_image_count() == final_number_of_fov * all_config_count
+
+    # When we merge, there's an extra image per fov (where we merge all the configs for that fov).
+    control._def.MERGE_CHANNELS = True
+    assert mpc.get_acquisition_image_count() == final_number_of_fov * (all_config_count + 1)
+
+
+def test_multi_point_controller_disk_space_esimate(qtbot):
+    mpc = gts.get_test_multi_point_controller()
+
+    control._def.MERGE_CHANNELS = False
+    all_configuration_names = [
+        config.name
+        for config in mpc.channelConfigurationManager.get_configurations(mpc.objectiveStore.current_objective)
+    ]
+    nz = 2
+    nt = 3
+    assert len(all_configuration_names) > 0
+    all_config_count = len(all_configuration_names)
+
+    mpc.set_NZ(nz)
+    mpc.set_Nt(nt)
+    mpc.set_selected_configurations(all_configuration_names[0:1])
+    mpc.scanCoordinates.clear_regions()
+
+    # No images -> no bytes needed
+    assert mpc.get_estimated_acquisition_disk_storage() == 0
+
+    # Add a single region with 1 fov
+    # NOTE: If the coordinates below aren't in the valid range for our stage, it silently fails to add regions.
+    x_min = mpc.stage.get_config().X_AXIS.MIN_POSITION + 0.01
+    y_min = mpc.stage.get_config().Y_AXIS.MIN_POSITION + 0.01
+    z_mid = (mpc.stage.get_config().Z_AXIS.MAX_POSITION - mpc.stage.get_config().Z_AXIS.MIN_POSITION) / 2.0
+    mpc.scanCoordinates.add_flexible_region(1, x_min, y_min, z_mid, 1, 1, 0)
+
+    # Add 9 more regions with a single fov
+    for i in range(1, 10):
+        x_st = x_min + i
+        y_st = y_min + i
+        mpc.scanCoordinates.add_flexible_region(i + 2, x_st, y_st, z_mid, 1, 1, 0)
+
+    # Select all the configurations
+    mpc.set_selected_configurations(all_configuration_names)
+    # Add a multiple FOV region with 5 in each of x and y dirs.
+    mpc.scanCoordinates.add_flexible_region(123, x_min + 11, y_min + 11, z_mid, 5, 5, 0)
+
+    final_number_of_fov = nt * nz * (10 + 25)
+    # It is tricky to calculate the exact value here, but since we are capturing >3000 images it should at least
+    # be in the multi-GB range.
+    assert mpc.get_estimated_acquisition_disk_storage() > 1e9
+
+    # When we merge, there's an extra image per fov (where we merge all the configs for that fov).
+    before_size = mpc.get_estimated_acquisition_disk_storage()
+    control._def.MERGE_CHANNELS = True
+    after_size = mpc.get_estimated_acquisition_disk_storage()
+    assert after_size > before_size

--- a/software/tests/control/test_MultiPointController.py
+++ b/software/tests/control/test_MultiPointController.py
@@ -73,8 +73,8 @@ def test_multi_point_controller_disk_space_esimate(qtbot):
     mpc.set_selected_configurations(all_configuration_names[0:1])
     mpc.scanCoordinates.clear_regions()
 
-    # No images -> no bytes needed
-    assert mpc.get_estimated_acquisition_disk_storage() == 0
+    # No images -> no bytes needed (except admin bytes, which is < 200kB)
+    assert mpc.get_estimated_acquisition_disk_storage() < 200 * 1024
 
     # Add a single region with 1 fov
     # NOTE: If the coordinates below aren't in the valid range for our stage, it silently fails to add regions.

--- a/software/tests/control/test_utils.py
+++ b/software/tests/control/test_utils.py
@@ -1,5 +1,7 @@
 import control.utils
 import tests.tools
+import pathlib
+import tempfile
 
 
 def test_squid_repo_info():
@@ -9,7 +11,7 @@ def test_squid_repo_info():
 
 import numpy as np
 import pytest
-from control.utils import find_spot_location, SpotDetectionMode
+from control.utils import find_spot_location, SpotDetectionMode, get_available_disk_space
 
 
 def create_test_image(spot_positions, image_size=(480, 640), spot_size=20):
@@ -117,3 +119,20 @@ def test_debug_plot(tmp_path):
         image = create_test_image([(320, 240)])
         # This should create plots but not raise any errors
         find_spot_location(image, debug_plot=True)
+
+
+def test_get_available_disk_space():
+    temp_dir = pathlib.Path(tempfile.mkdtemp())
+
+    assert get_available_disk_space(temp_dir) > 0
+
+    some_non_dir_file = temp_dir / "test_file"
+    some_non_dir_file.touch()
+
+    with pytest.raises(ValueError):
+        get_available_disk_space(some_non_dir_file)
+
+    some_non_dir_file.unlink(missing_ok=True)
+    temp_dir.rmdir()
+    with pytest.raises(ValueError):
+        get_available_disk_space(temp_dir)


### PR DESCRIPTION
This adds in tools for:
  1. Checking how many images an acquisition will use
  2. Checking how much disk space an acquisition will use
  3. For both flexible and well multi point acquisition widgets, using those tools to prevent acquisitions from starting if there isn't enough memory.

Separately, we want to add the disk usage info to the ui after an acquisition starts.  That will be done in a follow up PR.

Tested By: Unit tests for the helpers, and testing different acquisition to make sure small ones succeed and large ones do not start.