### PR TITLE
StreamHandler: allow providing an accept fn, and use it for the live controller

### DIFF
--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -233,11 +233,11 @@ class HighContentScreeningGui(QMainWindow):
             channel_manager=self.channelConfigurationManager, laser_af_manager=self.laserAFSettingManager
         )
         self.contrastManager = core.ContrastManager()
-        self.streamHandler = core.StreamHandler()
 
         self.liveController = core.LiveController(
             self.camera, self.microcontroller, self.illuminationController, parent=self
         )
+        self.streamHandler = core.StreamHandler(accept_new_frame_fn=lambda: self.liveController.is_live)
 
         self.slidePositionController = core.SlidePositionController(
             self.stage, self.liveController, is_for_wellplate=True
@@ -286,7 +286,6 @@ class HighContentScreeningGui(QMainWindow):
         )
 
         if SUPPORT_LASER_AUTOFOCUS:
-            self.streamHandler_focus_camera = core.StreamHandler()
             self.liveController_focus_camera = core.LiveController(
                 self.camera_focus,
                 self.microcontroller,
@@ -294,6 +293,7 @@ class HighContentScreeningGui(QMainWindow):
                 control_illumination=False,
                 for_displacement_measurement=True,
             )
+            self.streamHandler_focus_camera = core.StreamHandler(accept_new_frame_fn=lambda: self.liveController_focus_camera.is_live)
             self.imageDisplayWindow_focus = core.ImageDisplayWindow(show_LUT=False, autoLevels=False)
             self.displacementMeasurementController = core_displacement_measurement.DisplacementMeasurementController()
             self.laserAutofocusController = core.LaserAutofocusController(

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -103,12 +103,11 @@ class Microscope(QObject):
             self.channelConfigurationManager, self.laserAFSettingManager
         )
 
-        self.streamHandler = core.StreamHandler()
         self.liveController = core.LiveController(self.camera, self.microcontroller, None, self)
+        self.streamHandler = core.StreamHandler(accept_new_frame_fn=lambda: self.liveController.is_live)
         self.slidePositionController = core.SlidePositionController(self.stage, self.liveController)
 
         if SUPPORT_LASER_AUTOFOCUS:
-            self.streamHandler_focus_camera = core.StreamHandler()
             self.liveController_focus_camera = core.LiveController(
                 self.camera_focus,
                 self.microcontroller,
@@ -117,6 +116,7 @@ class Microscope(QObject):
                 control_illumination=False,
                 for_displacement_measurement=True,
             )
+            self.streamHandler_focus_camera = core.StreamHandler(accept_new_frame_fn=lambda: self.liveController_focus_camera.is_live)
             self.displacementMeasurementController = core_displacement_measurement.DisplacementMeasurementController()
             self.laserAutofocusController = core.LaserAutofocusController(
                 self.microcontroller,

--- a/software/squid/abc.py
+++ b/software/squid/abc.py
@@ -379,9 +379,6 @@ class AbstractCamera(metaclass=abc.ABCMeta):
         """
         if not self._frame_callbacks_enabled:
             return
-        if not self.get_is_streaming():
-            self._log.debug("Received propagate frame after streaming stopped, not propagating.")
-            return
         for _, cb in self._frame_callbacks:
             cb(camera_frame)
 

--- a/software/squid/abc.py
+++ b/software/squid/abc.py
@@ -379,6 +379,9 @@ class AbstractCamera(metaclass=abc.ABCMeta):
         """
         if not self._frame_callbacks_enabled:
             return
+        if not self.get_is_streaming():
+            self._log.debug("Received propagate frame after streaming stopped, not propagating.")
+            return
         for _, cb in self._frame_callbacks:
             cb(camera_frame)
 


### PR DESCRIPTION
The live controller was receiving half-illuminated frames after stopping live mode.  This gives us a mechanism for telling the StreamHandler to ignore frames if a boolean function does not return true, and then we use it everywhere.

Tested by: On system testing.