### PR TITLE
widgets: camera control: fix pixel format

### DIFF
--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -986,7 +986,7 @@ class CameraSettingsWidget(QFrame):
             self.dropdown_pixelFormat.setCurrentText(self.camera.get_pixel_format().name)
         else:
             print("setting camera's default pixel format")
-            self.camera.set_pixel_format(DEFAULT_PIXEL_FORMAT)
+            self.camera.set_pixel_format(CameraPixelFormat.from_string(DEFAULT_PIXEL_FORMAT))
             self.dropdown_pixelFormat.setCurrentText(DEFAULT_PIXEL_FORMAT)
         self.dropdown_pixelFormat.setSizePolicy(QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed))
         # to do: load and save pixel format in configurations
@@ -1032,7 +1032,7 @@ class CameraSettingsWidget(QFrame):
         # connection
         self.entry_exposureTime.valueChanged.connect(self.camera.set_exposure_time)
         self.entry_analogGain.valueChanged.connect(self.set_analog_gain_if_supported)
-        self.dropdown_pixelFormat.currentTextChanged.connect(self.camera.set_pixel_format)
+        self.dropdown_pixelFormat.currentTextChanged.connect(lambda s: self.camera.set_pixel_format(CameraPixelFormat.from_string(s)))
         self.entry_ROI_offset_x.valueChanged.connect(self.set_ROI_offset)
         self.entry_ROI_offset_y.valueChanged.connect(self.set_ROI_offset)
         self.entry_ROI_height.valueChanged.connect(self.set_Height)

--- a/software/squid/config.py
+++ b/software/squid/config.py
@@ -185,6 +185,9 @@ class CameraPixelFormat(enum.Enum):
             CameraPixelFormat.BAYER_RG12,
         )
 
+    @staticmethod
+    def from_string(pixel_format_string):
+        return CameraPixelFormat[pixel_format_string]
 
 class RGBValue(pydantic.BaseModel):
     r: float


### PR DESCRIPTION
This fixes a bug in the handling of camera pixel format setting in our camera widget.

Tested by: On system testing.