### PR TITLE
cameras: None frame error universal, add test and test script

### DIFF
--- a/software/control/camera.py
+++ b/software/control/camera.py
@@ -338,7 +338,7 @@ class DefaultCamera(AbstractCamera):
 
         return self._camera.data_stream[0].acquisition_flag
 
-    def read_camera_frame(self) -> CameraFrame:
+    def read_camera_frame(self) -> Optional[CameraFrame]:
         self._log.debug("Entering read_camera_frame.")
         starting_frame_id = self.get_frame_id()
         if not self.get_is_streaming():

--- a/software/squid/abc.py
+++ b/software/squid/abc.py
@@ -528,7 +528,7 @@ class AbstractCamera(metaclass=abc.ABCMeta):
             raw_frame, rotate_image_angle=self._config.rotate_image_angle, flip_image=self._config.flip
         )
 
-    def read_frame(self) -> np.ndarray:
+    def read_frame(self) -> Optional[np.ndarray]:
         """
         If needed, send a trigger to request a frame.  Then block and wait until the next frame comes in,
         and return it.  The frame that comes back will be rotated/flipped/etc based on this cameras config,
@@ -538,14 +538,21 @@ class AbstractCamera(metaclass=abc.ABCMeta):
 
         NOTE(imo): We might change this to get_frame to be consistent with everything else here, but
         since cameras previously used read_frame this decreases line change noise.
+
+        Might return None if getting a frame timed out, or another error occurred.
         """
-        return self.read_camera_frame().frame
+        full_frame = self.read_camera_frame()
+
+        # read_camera_frame will have already printed an error, so just pass on the none.
+        return full_frame.frame if full_frame else None
 
     @abc.abstractmethod
-    def read_camera_frame(self) -> CameraFrame:
+    def read_camera_frame(self) -> Optional[CameraFrame]:
         """
         This calls read_frame, but also fills in all the information such that you get a CameraFrame.  The
         frame in the CameraFrame will have had _process_raw_frame called on it already.
+
+        Might return None if getting a frame timed out, or another error occurred.
         """
         pass
 

--- a/software/squid/camera/utils.py
+++ b/software/squid/camera/utils.py
@@ -109,7 +109,7 @@ class SimulatedCamera(AbstractCamera):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._frame_id = 1
+        self._frame_id = 0
         self._current_raw_frame = None
         self._current_frame = None
 
@@ -290,7 +290,7 @@ class SimulatedCamera(AbstractCamera):
     @debug_log
     def send_trigger(self, illumination_time: Optional[float] = None):
         (height, width) = self.get_resolution()
-        if self.get_frame_id() == 1:
+        if self.get_frame_id() == 0:
             if self.get_pixel_format() == CameraPixelFormat.MONO8:
                 self._current_raw_frame = np.random.randint(255, size=(height, width), dtype=np.uint8)
                 self._current_raw_frame[height // 2 - 99 : height // 2 + 100, width // 2 - 99 : width // 2 + 100] = 200

--- a/software/squid/config.py
+++ b/software/squid/config.py
@@ -157,6 +157,16 @@ class CameraVariant(enum.Enum):
     TIS = "TIS"
     GXIPY = "GXIPY"
 
+    @staticmethod
+    def from_string(cam_string: str) -> Optional["CameraVariant"]:
+        """
+        Attempts to convert the given string to a camera variant.  This ignores all letter cases.
+        """
+        try:
+            return CameraVariant[cam_string.upper()]
+        except KeyError:
+            return None
+
 
 class CameraPixelFormat(enum.Enum):
     """

--- a/software/tests/squid/test_camera.py
+++ b/software/tests/squid/test_camera.py
@@ -57,6 +57,7 @@ def test_new_roi_for_resolution():
         == expected_down_roi_partial
     )
 
+
 class SimulatedWithTimeouts(SimulatedCamera):
     def __init__(self, timeout_ids: Sequence[int], *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -70,8 +71,14 @@ class SimulatedWithTimeouts(SimulatedCamera):
             return None
         return frame
 
+
 def test_read_frame_on_timeout():
-    sim_cam = SimulatedWithTimeouts(timeout_ids = [3,5,8], camera_config=squid.config.get_camera_config(), hw_trigger_fn=None, hw_set_strobe_delay_ms_fn=None)
+    sim_cam = SimulatedWithTimeouts(
+        timeout_ids=[3, 5, 8],
+        camera_config=squid.config.get_camera_config(),
+        hw_trigger_fn=None,
+        hw_set_strobe_delay_ms_fn=None,
+    )
 
     frames = [sim_cam.read_frame() for _ in range(10)]
 

--- a/software/tests/squid/test_camera.py
+++ b/software/tests/squid/test_camera.py
@@ -1,6 +1,9 @@
+from typing import Optional, Sequence
+
 import squid.camera.utils
 import squid.config
-from squid.abc import AbstractCamera
+from squid.abc import AbstractCamera, CameraFrame
+from squid.camera.utils import SimulatedCamera
 
 
 def test_create_simulated_camera():
@@ -53,3 +56,35 @@ def test_new_roi_for_resolution():
         AbstractCamera.calculate_new_roi_for_resolution(old_resolution, old_roi_partial, new_resolution_down)
         == expected_down_roi_partial
     )
+
+class SimulatedWithTimeouts(SimulatedCamera):
+    def __init__(self, timeout_ids: Sequence[int], *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._timeout_ids = list(timeout_ids)
+
+    def read_camera_frame(self) -> Optional[CameraFrame]:
+        frame = super().read_camera_frame()
+
+        if frame.frame_id in self._timeout_ids:
+            return None
+        return frame
+
+def test_read_frame_on_timeout():
+    sim_cam = SimulatedWithTimeouts(timeout_ids = [3,5,8], camera_config=squid.config.get_camera_config(), hw_trigger_fn=None, hw_set_strobe_delay_ms_fn=None)
+
+    frames = [sim_cam.read_frame() for _ in range(10)]
+
+    def frame_to_idx(frame_id):
+        return frame_id - 1
+
+    assert frames[frame_to_idx(1)] is not None
+    assert frames[frame_to_idx(2)] is not None
+    assert frames[frame_to_idx(3)] is None
+    assert frames[frame_to_idx(4)] is not None
+    assert frames[frame_to_idx(5)] is None
+    assert frames[frame_to_idx(6)] is not None
+    assert frames[frame_to_idx(7)] is not None
+    assert frames[frame_to_idx(8)] is None
+    assert frames[frame_to_idx(9)] is not None
+    assert frames[frame_to_idx(10)] is not None

--- a/software/tools/camera_stress_test.py
+++ b/software/tools/camera_stress_test.py
@@ -87,7 +87,7 @@ def main(args):
 
     camera_type = squid.config.CameraVariant.from_string(args.camera)
     if not camera_type:
-        log.error("Invalid camera type '{}'", args.camera)
+        log.error(f"Invalid camera type '{args.camera}'")
         return 1
 
     default_config = squid.config.get_camera_config()
@@ -165,7 +165,13 @@ if __name__ == "__main__":
     ap.add_argument("--exposure", type=float, help="The exposure time in ms", default=1)
     ap.add_argument("--report_interval", type=int, help="Report every this many frames captured.", default=100)
     ap.add_argument("--verbose", action="store_true", help="Turn on debug logging")
-    ap.add_argument("--camera", type=str, choices=["Hamamatsu", "Toupcam", "Default"], help="The type of camera to create and use for this test.")
+    ap.add_argument(
+        "--camera",
+        type=str,
+        required=True,
+        choices=["hamamatsu", "toupcam", "gxipy"],
+        help="The type of camera to create and use for this test.",
+    )
 
     args = ap.parse_args()
 

--- a/software/tools/camera_stress_test.py
+++ b/software/tools/camera_stress_test.py
@@ -85,11 +85,16 @@ def main(args):
         hw_trigger = None
         strobe_delay_fn = None
 
+    camera_type = squid.config.CameraVariant.from_string(args.camera)
+    if not camera_type:
+        log.error("Invalid camera type '{}'", args.camera)
+        return 1
+
     default_config = squid.config.get_camera_config()
-    forced_hamamatsu_config = default_config.model_copy(update={"camera_type": squid.config.CameraVariant.HAMAMATSU})
+    force_this_camera_config = default_config.model_copy(update={"camera_type": camera_type})
 
     cam = squid.camera.utils.get_camera(
-        forced_hamamatsu_config, False, hw_trigger_fn=hw_trigger, hw_set_strobe_delay_ms_fn=strobe_delay_fn
+        force_this_camera_config, False, hw_trigger_fn=hw_trigger, hw_set_strobe_delay_ms_fn=strobe_delay_fn
     )
 
     stats = Stats()
@@ -116,6 +121,7 @@ def main(args):
     log.info(
         (
             f"Camera Info:\n"
+            f"  Type: {args.camera}\n"
             f"  Resolution: {cam.get_resolution()}\n"
             f"  Exposure Time: {cam.get_exposure_time()} [ms]\n"
             f"  Strobe Time: {cam.get_strobe_time()} [ms]\n"
@@ -138,13 +144,14 @@ def main(args):
     finally:
         log.info("Stopping streaming...")
         cam.stop_streaming()
+        return 0
 
 
 if __name__ == "__main__":
     import argparse
     import sys
 
-    ap = argparse.ArgumentParser(description="hammer a hamamatsu camera to test it.")
+    ap = argparse.ArgumentParser(description="hammer a camera to test it.")
 
     ap.add_argument("--runtime", type=float, help="Time, in s, to run the test for.", default=60)
     ap.add_argument(
@@ -158,6 +165,7 @@ if __name__ == "__main__":
     ap.add_argument("--exposure", type=float, help="The exposure time in ms", default=1)
     ap.add_argument("--report_interval", type=int, help="Report every this many frames captured.", default=100)
     ap.add_argument("--verbose", action="store_true", help="Turn on debug logging")
+    ap.add_argument("--camera", type=str, choices=["Hamamatsu", "Toupcam", "Default"], help="The type of camera to create and use for this test.")
 
     args = ap.parse_args()
 


### PR DESCRIPTION
We inconsistently raised `CameraError` or returned `None` in `read_camera_frame` before.  Now we always return `None` if a read fails, and we handle this case in the `read_frame` historical method.

This is via a bug reported where laser autofocus spot detect would fail on the `self.read_camera_frame().frame` in the `read_frame` implementation.  

Tested By: Unit test, and a script modified to stress test all cameras (not just the hamamatsu).  Also local sim still works.