### PR TITLE
microcontroller: ignored packets with bad checksums, scan input buffer

### DIFF
--- a/software/control/microcontroller.py
+++ b/software/control/microcontroller.py
@@ -1059,7 +1059,7 @@ class Microcontroller:
                         # NOTE(imo): Before April 2025, we didn't send the crc from the micro.  This is
                         # here to support firmware that still sends 0 as the checksum.  This means for
                         # the firmware that does support checksums, we can get fooled by zeros!
-                        if checksum == maybe_msg[-1] or checksum == 0:
+                        if checksum == maybe_msg[-1] or maybe_msg[-1] == 0:
                             return maybe_msg
                         else:
                             self.log.warning(f"Bad checksum {checksum} for packet '{maybe_msg}, tossing first byte'")

--- a/software/control/microcontroller.py
+++ b/software/control/microcontroller.py
@@ -1021,33 +1021,56 @@ class Microcontroller:
             self.abort_current_command("Resend last requested with no last command")
 
     def read_received_packet(self):
+        crc_calculator = CrcCalculator(Crc8.CCITT, table_based=True)
+
         while not self.terminate_reading_received_packet_thread:
             try:
-                # wait to receive data
-                if self._serial.bytes_available() == 0 or self._serial.bytes_available() % self.rx_buffer_length != 0:
+                # If anything hangs, we may fall way behind reading the serial buffer.  In that case, toss everything
+                # in the read buffer and start over.  This should always be safe to do because the micro sends updates
+                # periodically without prompting, and so we'll always get more updates on the current micro state.
+                if self._serial.bytes_available() >= BUFFER_SIZE_LIMIT:
+                    self._serial.reset_input_buffer()
+                    continue
+
+                # If we don't at least have enough bytes for a full packet (rx_buffer_length), there's no reason to
+                # waste our time looking for a valid message.  So wait here until we have at least that many bytes.
+                if self._serial.bytes_available() < self.rx_buffer_length:
                     # Sleep a negligible amount of time just to give other threads time to run.  Otherwise,
                     # we run the rise of spinning forever here and not letting progress happen elsewhere.
                     time.sleep(0.0001)
-                    if self._serial.bytes_available() == BUFFER_SIZE_LIMIT:
-                        self._serial.reset_input_buffer()
                     if not self._serial.is_open():
                         if not self._serial.reconnect(attempts=Microcontroller.MAX_RECONNECT_COUNT):
                             self.log.error(
                                 "In read loop, serial device failed to reconnect.  Microcontroller is defunct!"
                             )
-
                     continue
 
-                # get rid of old data
-                num_bytes_in_rx_buffer = self._serial.bytes_available()
-                if num_bytes_in_rx_buffer > self.rx_buffer_length:
-                    for i in range(num_bytes_in_rx_buffer - self.rx_buffer_length):
-                        self._serial.read()
+                # This helper reads bytes in the order received by serial, and checks that packet-sized chunks
+                # have valid checksums.  IF the first packet size chunk does not have a valid checksum, it tosses
+                # the first byte and keeps going until it either finds a valid checksum packet or runs out of bytes.
+                def get_msg_with_good_checksum():
+                    maybe_msg = []
+                    while self._serial.bytes_available() > 0:
+                        maybe_msg.append(ord(self._serial.read()))
+                        if len(maybe_msg) < self.rx_buffer_length:
+                            continue
 
-                # read the buffer
-                msg = []
-                for i in range(self.rx_buffer_length):
-                    msg.append(ord(self._serial.read()))
+                        checksum = crc_calculator.calculate_checksum(maybe_msg[:-1])
+                        # NOTE(imo): Before April 2025, we didn't send the crc from the micro.  This is
+                        # here to support firmware that still sends 0 as the checksum.  This means for
+                        # the firmware that does support checksums, we can get fooled by zeros!
+                        if checksum == maybe_msg[-1] or checksum == 0:
+                            return maybe_msg
+                        else:
+                            self.log.warning(f"Bad checksum {checksum} for packet '{maybe_msg}, tossing first byte'")
+                            maybe_msg.pop(0)
+                    return None
+
+                msg = get_msg_with_good_checksum()
+
+                if msg is None:
+                    self.log.warning("Back checksums found, skipping.")
+                    continue
 
                 # parse the message
                 """

--- a/software/tools/microcontroller_stress_test.py
+++ b/software/tools/microcontroller_stress_test.py
@@ -24,9 +24,14 @@ def main(args):
     stage = None
     if args.stage:
         stage = squid.stage.cephla.CephlaStage(micro, stage_config=squid.config.get_stage_config())
+        # stage.home(x=False, y=False, z=True, theta=False)
+        log.info("Moving z to 0.1")
         stage.move_z(0.1)
+        log.info("Moving x to 20")
         stage.move_x(20)
+        log.info("Homing y")
         stage.home(x=False, y=True, z=False, theta=False)
+        log.info("Homing x")
         stage.home(x=True, y=False, z=False, theta=False)
     end_time = time.time() + args.runtime
     start_time = time.time()

--- a/software/tools/microcontroller_stress_test.py
+++ b/software/tools/microcontroller_stress_test.py
@@ -32,20 +32,21 @@ def main(args):
         loop_count = 0
         last_loop_end = time.time()
         while time.time() < end_time and keep_running.is_set():
+            next_pos = next(stage_positions)
+            # The stage moves are split so they bracket other micro commands.
             if stage:
-                next_pos = next(stage_positions)
-                log.info(f"Moving to {next_pos} [mm]")
+                log.debug(f"Moving to {next_pos} [mm]")
                 stage.move_x_to(next_pos[0])
-                stage.move_y_to(next_pos[1])
             if args.laser_af:
-                log.info("Turning af laser on then off.")
+                log.debug("Turning af laser on then off.")
                 micro.turn_on_AF_laser()
                 micro.wait_till_operation_is_completed()
                 micro.turn_off_AF_laser()
                 micro.wait_till_operation_is_completed()
+            if stage:
+                stage.move_y_to(next_pos[1])
             if not args.no_loop_sleep:
-                log.info("Sleeping to yield main test thread")
-                time.sleep(0)
+                time.sleep(0.0001)
 
             loop_count += 1
             if loop_count % args.report_interval == 0:


### PR DESCRIPTION
This makes sure the incoming crc are correct, and if not scans along the read buffer trying to find a valid message border.  It also changes our logic to get rid of the exact packet length match in favor of just requiring enough bytes for a valid packet.

Tested By: Running `tools/microcontroller_stress_test.py` for a while with #195 on the firmware side.  I also tested without #195 on the firmware side to make sure that case still works.