### PR TITLE
Microcontroller: Add a read-staleness watchdog (sortof) so we can see if new data is coming in

### DIFF
--- a/software/control/microcontroller.py
+++ b/software/control/microcontroller.py
@@ -516,9 +516,13 @@ class Microcontroller:
 
     def _warn_if_reads_stale(self):
         now = time.time()
-        last_read = float(self._last_successful_read_time)  # Just in case it gets update, capture it for printing below.
+        last_read = float(
+            self._last_successful_read_time
+        )  # Just in case it gets update, capture it for printing below.
         if now - last_read > Microcontroller.STALE_READ_TIMEOUT:
-            self.log.warning(f"Read thread is stale, it has been {now - last_read} [s] since a valid packet. Last cmd id from the mcu was {self._cmd_id_mcu}, our last sent cmd id was {self._cmd_id}")
+            self.log.warning(
+                f"Read thread is stale, it has been {now - last_read} [s] since a valid packet. Last cmd id from the mcu was {self._cmd_id_mcu}, our last sent cmd id was {self._cmd_id}"
+            )
 
     def close(self):
         self.terminate_reading_received_packet_thread = True


### PR DESCRIPTION
This will tell us if new data is still coming in from the microcontroller.  If we don't see printouts, valid packets are coming in.

Tested by: I set the stale timeout to <10ms to make sure this prints out.  Also, I ran the stress test with `--no_wait` which locks up responses on the microcontroller.  Both of these made prints occur.