### PR TITLE
tests: sim cam: force no flip or rotate

### DIFF
--- a/software/tests/squid/test_camera.py
+++ b/software/tests/squid/test_camera.py
@@ -4,6 +4,7 @@ import squid.camera.utils
 import squid.config
 from squid.abc import AbstractCamera, CameraFrame
 from squid.camera.utils import SimulatedCamera
+from squid.config import CameraConfig
 
 
 def test_create_simulated_camera():
@@ -11,7 +12,10 @@ def test_create_simulated_camera():
 
 
 def test_simulated_camera():
-    sim_cam = squid.camera.utils.get_camera(squid.config.get_camera_config(), simulated=True)
+    sim_cam_config: CameraConfig = squid.config.get_camera_config().model_copy(
+        update={"rotate_image_angle": None, "flip": None}
+    )
+    sim_cam = squid.camera.utils.get_camera(sim_cam_config, simulated=True)
 
     # Really basic tests to make sure the simulated camera does what is expected.
     sim_cam.send_trigger()


### PR DESCRIPTION
If the config this test grabbed had rotation or flipping, we can end up with an issue where the resolution doesn't match the resulting frame, so the test fails.

This actually highlights a potential api issue - it's surprising when resolution does not match the frame dimensions.  But since we allow cropping, rotating, flipping, etc it'd get really complicated to carry that through to resolution (and it's not clear that's what you'd want anyway).

For now, resolution is what comes off the camera.  And there's no guarantee the frame will match that.

Tested by: Tests pass with rotation angle = 90 now.