### PR TITLE
tools: stage timing: allow any axis, start and step, no home

### DIFF
--- a/software/tools/stage_timing.py
+++ b/software/tools/stage_timing.py
@@ -6,33 +6,53 @@ import time
 
 log = squid.logging.get_logger("stage timing")
 
+def get_move_fn(scope: Microscope, axis: str):
+    match axis.lower():
+        case "z":
+            return scope.move_z_to
+        case "y":
+            return scope.move_y_to
+        case "x":
+            return scope.move_x_to
+        case _:
+            raise ValueError(f"Unknown axis {axis}")
+
+def home(scope: Microscope):
+    scope.stage.home(x=False, y=False, z=True, theta=False)
+    scope.stage.move_x(20)
+    scope.stage.home(x=False, y=True, z=False, theta=False)
+    scope.stage.home(x=True, y=False, z=False, theta=False)
 
 def main(args):
     if args.verbose:
         squid.logging.set_stdout_log_level(logging.DEBUG)
 
     scope = Microscope(is_simulation=False)
-    scope.stage.home(x=False, y=False, z=True, theta=False)
 
-    z_pos_um = 1000
-    scope.move_z_to(z_pos_um / 1000)
+    if args.home:
+        home(scope)
+
+    axis_move_fn = get_move_fn(scope, args.axis)
+    axis_move_fn(args.start)
 
     t0 = time.time()
-    N = args.count
+    total_moves = args.count
+    log.info(f"Argument summary:\n {args}")
 
     def report(moves_so_far):
         elapsed = time.time() - t0
         log.info(
-            f"After {moves_so_far}/{N} moves:\n  total time={elapsed:.3f} [s]\n  time per move={elapsed / moves_so_far:.3f} [s]"
+            f"\nAfter {moves_so_far}/{total_moves} moves of {args.axis} axis starting at {args.start} [mm] and step of {args.step} [mm]:\n  total time={elapsed:.3f} [s]\n  time per move={elapsed / moves_so_far:.3f} [s]\n  current position= {scope.stage.get_pos()} [mm, mm, mm]"
         )
 
-    step_direction = 1 if not args.down else -1
-    for i in range(N):
+    step = args.step
+    start_pos = args.start
+    for i in range(total_moves):
         this_move_num = i + 1
-        scope.move_z_to((z_pos_um + step_direction * i) / 1000)
+        axis_move_fn(start_pos + step * this_move_num)
         if this_move_num % args.report_interval == 0:
             report(this_move_num)
-    report(N)
+    report(total_moves)
 
 
 if __name__ == "__main__":
@@ -44,6 +64,9 @@ if __name__ == "__main__":
     ap.add_argument("--verbose", action="store_true")
     ap.add_argument("--report_interval", type=int, default=10, help="Report every this many moves.")
     ap.add_argument("--count", type=int, default=25, help="The number of moves to execute.")
-    ap.add_argument("--down", action="store_true", help="Instead of making +z steps, make -z steps.")
+    ap.add_argument("--axis", type=str, choices=["x", "y", "z"], default="z", help="The axis to do a timing test with.")
+    ap.add_argument("--start", type=float, default=0.1, help="The starting position to use in mm.")
+    ap.add_argument("--step", type=float, default=0.001, help="The step size to use in mm.  This should be small!  EG 0.001")
+    ap.add_argument("--no_home", dest="home", action="store_false", help="Do not home zxy before running.")
 
     sys.exit(main(ap.parse_args()))

--- a/software/tools/stage_timing.py
+++ b/software/tools/stage_timing.py
@@ -6,6 +6,7 @@ import time
 
 log = squid.logging.get_logger("stage timing")
 
+
 def get_move_fn(scope: Microscope, axis: str):
     match axis.lower():
         case "z":
@@ -17,11 +18,13 @@ def get_move_fn(scope: Microscope, axis: str):
         case _:
             raise ValueError(f"Unknown axis {axis}")
 
+
 def home(scope: Microscope):
     scope.stage.home(x=False, y=False, z=True, theta=False)
     scope.stage.move_x(20)
     scope.stage.home(x=False, y=True, z=False, theta=False)
     scope.stage.home(x=True, y=False, z=False, theta=False)
+
 
 def main(args):
     if args.verbose:
@@ -66,7 +69,9 @@ if __name__ == "__main__":
     ap.add_argument("--count", type=int, default=25, help="The number of moves to execute.")
     ap.add_argument("--axis", type=str, choices=["x", "y", "z"], default="z", help="The axis to do a timing test with.")
     ap.add_argument("--start", type=float, default=0.1, help="The starting position to use in mm.")
-    ap.add_argument("--step", type=float, default=0.001, help="The step size to use in mm.  This should be small!  EG 0.001")
+    ap.add_argument(
+        "--step", type=float, default=0.001, help="The step size to use in mm.  This should be small!  EG 0.001"
+    )
     ap.add_argument("--no_home", dest="home", action="store_false", help="Do not home zxy before running.")
 
     sys.exit(main(ap.parse_args()))


### PR DESCRIPTION
This is just a modification to our stage testing script so we get nicer results, and can test in a bunch of different scenarios.

Example usage:
```
$ python tools/stage_timing.py --start 1.000 --step 0.001 --axis=z --count 100
$ python tools/stage_timing.py --start 1.100 --step -0.001 --axis=z --count 100
```

Tested by: Tested on CephlaStage a bunch.