### PR TITLE
stage: cephla: change backlash comp from 30um to 5um for speed

### DIFF
--- a/software/squid/stage/cephla.py
+++ b/software/squid/stage/cephla.py
@@ -8,6 +8,8 @@ from squid.config import StageConfig, AxisConfig
 
 
 class CephlaStage(AbstractStage):
+    _BACKLASH_COMPENSATION_DISTANCE_MM = 0.005
+
     @staticmethod
     def _calc_move_timeout(distance, max_speed):
         # We arbitrarily guess that if a move takes 3x the naive "infinite acceleration" time, then it
@@ -70,11 +72,7 @@ class CephlaStage(AbstractStage):
         # NOTE(imo): It seems really tricky to only clear backlash if via the blocking call?
         final_rel_move_mm = rel_mm
         if blocking and need_clear_backlash:
-            backlash_offset = -abs(
-                self.get_config().Z_AXIS.convert_to_real_units(
-                    max(160, 20 * self.get_config().Z_AXIS.MICROSTEPS_PER_STEP)
-                )
-            )
+            backlash_offset = -CephlaStage._BACKLASH_COMPENSATION_DISTANCE_MM
             final_rel_move_mm = -backlash_offset
             # Move past our final position, so we can move up to the final position and
             # rest on the downside of the drive mechanism.  But make sure we don't drive past the min position
@@ -117,11 +115,7 @@ class CephlaStage(AbstractStage):
 
         # NOTE(imo): It seems really tricky to only clear backlash if via the blocking call?
         if blocking and need_clear_backlash:
-            backlash_offset = -abs(
-                self.get_config().Z_AXIS.convert_to_real_units(
-                    max(160, 20 * self.get_config().Z_AXIS.MICROSTEPS_PER_STEP)
-                )
-            )
+            backlash_offset = -CephlaStage._BACKLASH_COMPENSATION_DISTANCE_MM
             # Move past our final position, so we can move up to the final position and
             # rest on the downside of the drive mechanism.  But make sure we don't drive past the min position
             # to do this.


### PR DESCRIPTION
Our default was to use ~30um backlash compensation.  This means that for a 1um move in the -z direction, we actually do a -31um move, then a 30um move.  A 30um move takes about 100 ms on the CephlaStage, which means that 1 um move with backlash compensation took about 200ms!

For reference, a 1um move without backlash compensation takes about 40 ms.

Changing our backlash compensation to 5um gets a 1um move with backlash compensation down to about 125 ms.

Tested by:  Running the `tools/stage_timing.py` script before and after both with and without `--relative`. 