### PR TITLE
firmware: check and send position updates every 5ms, not 10ms

### DIFF
--- a/firmware/octopi_firmware_v2/main_controller_teensy41/main_controller_teensy41.ino
+++ b/firmware/octopi_firmware_v2/main_controller_teensy41/main_controller_teensy41.ino
@@ -303,10 +303,10 @@ static const int TIMER_PERIOD = 500; // in us
 volatile int counter_send_pos_update = 0;
 volatile bool flag_send_pos_update = false;
 
-static const int interval_send_pos_update = 10000; // in us
+static const int interval_send_pos_update = 5000; // in us
 elapsedMicros us_since_last_pos_update;
 
-static const int interval_check_position = 10000; // in us
+static const int interval_check_position = 5000; // in us
 elapsedMicros us_since_last_check_position;
 
 static const int interval_send_joystick_update = 30000; // in us

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -385,24 +385,6 @@ class Microscope(QObject):
         return self.stage.get_pos().z_mm
 
     def move_z_to(self, z_mm, blocking=True):
-        # From Hongquan, we want the z axis to rest on the "up" (wrt gravity) direction of gravity. So if we
-        # are moving in the negative (down) z direction, we need to move past our mark a bit then
-        # back up.  If we are already moving in the "up" position, we can move straight there.
-        need_clear_backlash = z_mm < self.stage.get_pos().z_mm
-
-        # NOTE(imo): It seems really tricky to only clear backlash if via the blocking call?
-        if blocking and need_clear_backlash:
-            backlash_offset = -abs(
-                self.stage.get_config().Z_AXIS.convert_to_real_units(
-                    max(160, 20 * self.stage.get_config().Z_AXIS.MICROSTEPS_PER_STEP)
-                )
-            )
-            # Move past our final position, so we can move up to the final position and
-            # rest on the downside of the drive mechanism.  But make sure we don't drive past the min position
-            # to do this.
-            clamped_z_backlash_pos = max(z_mm + backlash_offset, self.stage.get_config().Z_AXIS.MIN_POSITION)
-            self.stage.move_z_to(clamped_z_backlash_pos, blocking=blocking)
-
         self.stage.move_z_to(z_mm)
 
     def start_live(self):

--- a/software/squid/stage/cephla.py
+++ b/software/squid/stage/cephla.py
@@ -8,6 +8,8 @@ from squid.config import StageConfig, AxisConfig
 
 
 class CephlaStage(AbstractStage):
+    _BACKLASH_COMPENSATION_DISTANCE_MM = 0.005
+
     @staticmethod
     def _calc_move_timeout(distance, max_speed):
         # We arbitrarily guess that if a move takes 3x the naive "infinite acceleration" time, then it
@@ -70,11 +72,7 @@ class CephlaStage(AbstractStage):
         # NOTE(imo): It seems really tricky to only clear backlash if via the blocking call?
         final_rel_move_mm = rel_mm
         if blocking and need_clear_backlash:
-            backlash_offset = -abs(
-                self.get_config().Z_AXIS.convert_to_real_units(
-                    max(160, 20 * self.get_config().Z_AXIS.MICROSTEPS_PER_STEP)
-                )
-            )
+            backlash_offset = -CephlaStage._BACKLASH_COMPENSATION_DISTANCE_MM
             final_rel_move_mm = -backlash_offset
             # Move past our final position, so we can move up to the final position and
             # rest on the downside of the drive mechanism.  But make sure we don't drive past the min position
@@ -117,11 +115,7 @@ class CephlaStage(AbstractStage):
 
         # NOTE(imo): It seems really tricky to only clear backlash if via the blocking call?
         if blocking and need_clear_backlash:
-            backlash_offset = -abs(
-                self.get_config().Z_AXIS.convert_to_real_units(
-                    max(160, 20 * self.get_config().Z_AXIS.MICROSTEPS_PER_STEP)
-                )
-            )
+            backlash_offset = -CephlaStage._BACKLASH_COMPENSATION_DISTANCE_MM
             # Move past our final position, so we can move up to the final position and
             # rest on the downside of the drive mechanism.  But make sure we don't drive past the min position
             # to do this.

--- a/software/squid/stage/cephla.py
+++ b/software/squid/stage/cephla.py
@@ -80,12 +80,13 @@ class CephlaStage(AbstractStage):
             # rest on the downside of the drive mechanism.  But make sure we don't drive past the min position
             # to do this.
             rel_move_with_backlash_offset_mm = rel_mm + backlash_offset
-            rel_move_with_backlash_offset_usteps = self._config.Z_AXIS.convert_real_units_to_ustep(rel_move_with_backlash_offset_mm)
+            rel_move_with_backlash_offset_usteps = self._config.Z_AXIS.convert_real_units_to_ustep(
+                rel_move_with_backlash_offset_mm
+            )
             self._microcontroller.move_z_usteps(rel_move_with_backlash_offset_usteps)
             if blocking:
                 self._microcontroller.wait_till_operation_is_completed(
-                    self._calc_move_timeout(rel_move_with_backlash_offset_mm,
-                                            self.get_config().Z_AXIS.MAX_SPEED)
+                    self._calc_move_timeout(rel_move_with_backlash_offset_mm, self.get_config().Z_AXIS.MAX_SPEED)
                 )
 
         self._microcontroller.move_z_usteps(self._config.Z_AXIS.convert_real_units_to_ustep(final_rel_move_mm))
@@ -129,7 +130,9 @@ class CephlaStage(AbstractStage):
             self._microcontroller.move_z_to_usteps(clamped_z_backlash_pos_usteps)
             if blocking:
                 self._microcontroller.wait_till_operation_is_completed(
-                    self._calc_move_timeout(clamped_z_backlash_pos - self.get_pos().z_mm, self.get_config().Z_AXIS.MAX_SPEED)
+                    self._calc_move_timeout(
+                        clamped_z_backlash_pos - self.get_pos().z_mm, self.get_config().Z_AXIS.MAX_SPEED
+                    )
                 )
 
         self._microcontroller.move_z_to_usteps(self._config.Z_AXIS.convert_real_units_to_ustep(abs_mm))

--- a/software/squid/stage/cephla.py
+++ b/software/squid/stage/cephla.py
@@ -62,10 +62,36 @@ class CephlaStage(AbstractStage):
             )
 
     def move_z(self, rel_mm: float, blocking: bool = True):
-        self._microcontroller.move_z_usteps(self._config.Z_AXIS.convert_real_units_to_ustep(rel_mm))
+        # From Hongquan, we want the z axis to rest on the "up" (wrt gravity) direction of gravity. So if we
+        # are moving in the negative (down) z direction, we need to move past our mark a bit then
+        # back up.  If we are already moving in the "up" position, we can move straight there.
+        need_clear_backlash = rel_mm < 0
+
+        # NOTE(imo): It seems really tricky to only clear backlash if via the blocking call?
+        final_rel_move_mm = rel_mm
+        if blocking and need_clear_backlash:
+            backlash_offset = -abs(
+                self.get_config().Z_AXIS.convert_to_real_units(
+                    max(160, 20 * self.get_config().Z_AXIS.MICROSTEPS_PER_STEP)
+                )
+            )
+            final_rel_move_mm = -backlash_offset
+            # Move past our final position, so we can move up to the final position and
+            # rest on the downside of the drive mechanism.  But make sure we don't drive past the min position
+            # to do this.
+            rel_move_with_backlash_offset_mm = rel_mm + backlash_offset
+            rel_move_with_backlash_offset_usteps = self._config.Z_AXIS.convert_real_units_to_ustep(rel_move_with_backlash_offset_mm)
+            self._microcontroller.move_z_usteps(rel_move_with_backlash_offset_usteps)
+            if blocking:
+                self._microcontroller.wait_till_operation_is_completed(
+                    self._calc_move_timeout(rel_move_with_backlash_offset_mm,
+                                            self.get_config().Z_AXIS.MAX_SPEED)
+                )
+
+        self._microcontroller.move_z_usteps(self._config.Z_AXIS.convert_real_units_to_ustep(final_rel_move_mm))
         if blocking:
             self._microcontroller.wait_till_operation_is_completed(
-                self._calc_move_timeout(rel_mm, self.get_config().Z_AXIS.MAX_SPEED)
+                self._calc_move_timeout(final_rel_move_mm, self.get_config().Z_AXIS.MAX_SPEED)
             )
 
     def move_x_to(self, abs_mm: float, blocking: bool = True):
@@ -83,6 +109,29 @@ class CephlaStage(AbstractStage):
             )
 
     def move_z_to(self, abs_mm: float, blocking: bool = True):
+        # From Hongquan, we want the z axis to rest on the "up" (wrt gravity) direction of gravity. So if we
+        # are moving in the negative (down) z direction, we need to move past our mark a bit then
+        # back up.  If we are already moving in the "up" position, we can move straight there.
+        need_clear_backlash = abs_mm < self.get_pos().z_mm
+
+        # NOTE(imo): It seems really tricky to only clear backlash if via the blocking call?
+        if blocking and need_clear_backlash:
+            backlash_offset = -abs(
+                self.get_config().Z_AXIS.convert_to_real_units(
+                    max(160, 20 * self.get_config().Z_AXIS.MICROSTEPS_PER_STEP)
+                )
+            )
+            # Move past our final position, so we can move up to the final position and
+            # rest on the downside of the drive mechanism.  But make sure we don't drive past the min position
+            # to do this.
+            clamped_z_backlash_pos = max(abs_mm + backlash_offset, self.get_config().Z_AXIS.MIN_POSITION)
+            clamped_z_backlash_pos_usteps = self._config.Z_AXIS.convert_real_units_to_ustep(clamped_z_backlash_pos)
+            self._microcontroller.move_z_to_usteps(clamped_z_backlash_pos_usteps)
+            if blocking:
+                self._microcontroller.wait_till_operation_is_completed(
+                    self._calc_move_timeout(clamped_z_backlash_pos - self.get_pos().z_mm, self.get_config().Z_AXIS.MAX_SPEED)
+                )
+
         self._microcontroller.move_z_to_usteps(self._config.Z_AXIS.convert_real_units_to_ustep(abs_mm))
         if blocking:
             self._microcontroller.wait_till_operation_is_completed(


### PR DESCRIPTION
Before:
  Z step = 0.001 --> 41 ms per move
  Z step = -0.001 --> 127 ms per move

After:
  Z step = 0.001 --> 37 ms per move
  Z step = -0.001 --> 112 ms per move

This one is a freebie, but I haven't looked into whether or not doubling the frequency of position checks and updates can cause actual issues.  Our packets are so small that I sorta doubt it, but I haven't actually investigated.  So there's some risk to just going for it with this one.

Tested by: using the `tools/stage_timing.py` script.