### PR TITLE
firmware: check and send position updates every 5ms, not 10ms

### DIFF
--- a/firmware/octopi_firmware_v2/main_controller_teensy41/main_controller_teensy41.ino
+++ b/firmware/octopi_firmware_v2/main_controller_teensy41/main_controller_teensy41.ino
@@ -303,10 +303,10 @@ static const int TIMER_PERIOD = 500; // in us
 volatile int counter_send_pos_update = 0;
 volatile bool flag_send_pos_update = false;
 
-static const int interval_send_pos_update = 10000; // in us
+static const int interval_send_pos_update = 5000; // in us
 elapsedMicros us_since_last_pos_update;
 
-static const int interval_check_position = 10000; // in us
+static const int interval_check_position = 5000; // in us
 elapsedMicros us_since_last_check_position;
 
 static const int interval_send_joystick_update = 30000; // in us


### PR DESCRIPTION
Before:
  Z step = 0.001 --> 41 ms per move
  Z step = -0.001 --> 127 ms per move

After:
  Z step = 0.001 --> 37 ms per move
  Z step = -0.001 --> 112 ms per move

This one is a freebie, but I haven't looked into whether or not doubling the frequency of position checks and updates can cause actual issues.  Our packets are so small that I sorta doubt it, but I haven't actually investigated.  So there's some risk to just going for it with this one.

Tested by: using the `tools/stage_timing.py` script.