### PR TITLE
cameras: toupcam: allow ignoring default black level

### DIFF
--- a/software/control/camera_toupcam.py
+++ b/software/control/camera_toupcam.py
@@ -343,7 +343,10 @@ class ToupcamCamera(AbstractCamera):
 
         self._raw_set_frame_format(CameraFrameFormat.RAW)
         self._raw_set_pixel_format(self._pixel_format)  # 'MONO8'
-        self.set_black_level(DEFAULT_BLACKLEVEL_VALUE)
+        try:
+            self.set_black_level(DEFAULT_BLACKLEVEL_VALUE)
+        except NotImplementedError:
+            self._log.warning("Black level is not supported by this toupcam model, ignoring default black level value")
 
         # We can't trigger update_internal_settings yet, because the strobe calc will fail.  So set the res
         # using the raw helper.


### PR DESCRIPTION
Toupcam color cameras do not support black level.  We still want them to boot up, though.  So, in the default config case, allow skipping black level (set_black_level will still fail for other callers, though).

Tested by: On hardware testing with a color Toupcam.