### PR TITLE
pixel value display int instead of float, no display when cursor off image

### DIFF
--- a/software/control/core/core.py
+++ b/software/control/core/core.py
@@ -3319,27 +3319,19 @@ class ImageDisplayWindow(QMainWindow):
                 self.cursor_position_label.setText(f"Position: ({x}, {y})")
 
                 # Get pixel value
-                if hasattr(self.graphics_widget.img, "image"):
-                    image = self.graphics_widget.img.image
-                    if image is not None and 0 <= y < image.shape[0] and 0 <= x < image.shape[1]:
-                        pixel_value = image[y, x]
-                        self.last_valid_value = pixel_value
-                        self.pixel_value_label.setText(f"Value: {pixel_value:.2f}")
-                    else:
-                        self.pixel_value_label.setText("Value: N/A")
+                image = self.graphics_widget.img.image
+                if image is not None and 0 <= y < image.shape[0] and 0 <= x < image.shape[1]:
+                    pixel_value = image[y, x]
+                    self.last_valid_value = pixel_value
+                    self.pixel_value_label.setText(f"Value: {pixel_value}")
                 else:
-                    self.pixel_value_label.setText("Value: N/A")
+                    self.pixel_value_label.setText("Value:")
             else:
-                self.cursor_position_label.setText("Position: Out of bounds")
-                self.pixel_value_label.setText("Value: N/A")
+                self.cursor_position_label.setText("Position:")
+                self.pixel_value_label.setText("Value:")
+                self.has_valid_position = False
         except:
-            # Keep last valid position if available
-            if self.has_valid_position:
-                self.cursor_position_label.setText(f"Position: ({self.last_valid_x}, {self.last_valid_y})")
-                self.pixel_value_label.setText(f"Value: {self.last_valid_value:.2f}")
-            else:
-                self.cursor_position_label.setText("Position: (0, 0)")
-                self.pixel_value_label.setText("Value: N/A")
+            pass
 
     def handle_mouse_click(self, evt):
         """Handle mouse clicks for both line drawing and other interactions."""
@@ -3494,11 +3486,11 @@ class ImageDisplayWindow(QMainWindow):
                     pixel_value = image[self.last_valid_y, self.last_valid_x]
                     self.last_valid_value = pixel_value
                     self.cursor_position_label.setText(f"Position: ({self.last_valid_x}, {self.last_valid_y})")
-                    self.pixel_value_label.setText(f"Value: {pixel_value:.2f}")
+                    self.pixel_value_label.setText(f"Value: {pixel_value}")
             except:
                 # If there's an error, keep the last valid values
                 self.cursor_position_label.setText(f"Position: ({self.last_valid_x}, {self.last_valid_y})")
-                self.pixel_value_label.setText(f"Value: {self.last_valid_value:.2f}")
+                self.pixel_value_label.setText(f"Value: {self.last_valid_value}")
 
         if self.line_roi is not None and self.btn_line_profiler.isChecked():
             self.update_line_profile()


### PR DESCRIPTION

## Copilot summary
This pull request simplifies the handling of pixel value display and error cases in the `core.py` file by removing unnecessary checks and formatting changes. The key changes focus on improving code readability and consistency.

### Simplifications in pixel value handling:

* Removed the `hasattr` check for the `image` attribute in `handle_mouse_move` and directly accessed the `image` property, assuming its presence.
* Simplified the pixel value display by removing the `.2f` formatting for floating-point values in both `handle_mouse_move` and `display_image`. This ensures consistent display without unnecessary precision. [[1]](diffhunk://#diff-2fc90167f3cd3e8a6b36bdd78086c6ae5811054d9f87239fa2fe2b3a8858d691L3322-R3334) [[2]](diffhunk://#diff-2fc90167f3cd3e8a6b36bdd78086c6ae5811054d9f87239fa2fe2b3a8858d691L3497-R3493)

### Error handling adjustments:

* Replaced complex error handling in `handle_mouse_move` with a simple `pass` statement, removing redundant fallback logic for invalid positions.
* Simplified the fallback logic in `display_image` to maintain the last valid pixel value without formatting adjustments.… when cursor not on image)