### PR TITLE
logging: add thread id to our log lines

### DIFF
--- a/software/squid/logging.py
+++ b/software/squid/logging.py
@@ -8,7 +8,7 @@ import sys
 import platformdirs
 
 _squid_root_logger_name = "squid"
-_baseline_log_format = "%(asctime)s.%(msecs)03d - %(name)s - %(levelname)s - %(message)s (%(filename)s:%(lineno)d)"
+_baseline_log_format = "%(asctime)s.%(msecs)03d - %(thread_id)d - %(name)s - %(levelname)s - %(message)s (%(filename)s:%(lineno)d)"
 _baseline_log_dateformat = "%Y-%m-%d %H:%M:%S"
 
 
@@ -38,8 +38,13 @@ class _CustomFormatter(py_logging.Formatter):
     def format(self, record):
         return self.FORMATTERS[record.levelno].format(record)
 
+def thread_id_filter(record):
+   """Inject thread_id to log records"""
+   record.thread_id = threading.get_native_id()
+   return record
 
 _COLOR_STREAM_HANDLER = py_logging.StreamHandler()
+_COLOR_STREAM_HANDLER.addFilter(thread_id_filter)
 _COLOR_STREAM_HANDLER.setFormatter(_CustomFormatter())
 
 # Make sure the squid root logger has all the handlers we want setup.  We could move this into a helper so it

--- a/software/squid/logging.py
+++ b/software/squid/logging.py
@@ -8,7 +8,9 @@ import sys
 import platformdirs
 
 _squid_root_logger_name = "squid"
-_baseline_log_format = "%(asctime)s.%(msecs)03d - %(thread_id)d - %(name)s - %(levelname)s - %(message)s (%(filename)s:%(lineno)d)"
+_baseline_log_format = (
+    "%(asctime)s.%(msecs)03d - %(thread_id)d - %(name)s - %(levelname)s - %(message)s (%(filename)s:%(lineno)d)"
+)
 _baseline_log_dateformat = "%Y-%m-%d %H:%M:%S"
 
 
@@ -38,10 +40,12 @@ class _CustomFormatter(py_logging.Formatter):
     def format(self, record):
         return self.FORMATTERS[record.levelno].format(record)
 
+
 def _thread_id_filter(record: logging.LogRecord):
-   """Inject thread_id to log records"""
-   record.thread_id = threading.get_native_id()
-   return True
+    """Inject thread_id to log records"""
+    record.thread_id = threading.get_native_id()
+    return True
+
 
 _COLOR_STREAM_HANDLER = py_logging.StreamHandler()
 _COLOR_STREAM_HANDLER.addFilter(_thread_id_filter)

--- a/software/squid/logging.py
+++ b/software/squid/logging.py
@@ -38,13 +38,13 @@ class _CustomFormatter(py_logging.Formatter):
     def format(self, record):
         return self.FORMATTERS[record.levelno].format(record)
 
-def thread_id_filter(record):
+def _thread_id_filter(record: logging.LogRecord):
    """Inject thread_id to log records"""
    record.thread_id = threading.get_native_id()
-   return record
+   return True
 
 _COLOR_STREAM_HANDLER = py_logging.StreamHandler()
-_COLOR_STREAM_HANDLER.addFilter(thread_id_filter)
+_COLOR_STREAM_HANDLER.addFilter(_thread_id_filter)
 _COLOR_STREAM_HANDLER.setFormatter(_CustomFormatter())
 
 # Make sure the squid root logger has all the handlers we want setup.  We could move this into a helper so it
@@ -191,6 +191,7 @@ def add_file_logging(log_filename, replace_existing=False):
 
     formatter = py_logging.Formatter(fmt=_baseline_log_format, datefmt=_baseline_log_dateformat)
     new_handler.setFormatter(formatter)
+    new_handler.addFilter(_thread_id_filter)
 
     log.info(f"Adding new file logger writing to file '{new_handler.baseFilename}'")
     root_logger.addHandler(new_handler)


### PR DESCRIPTION
This is helpful for debugging since we have multiple threads in play in multiple areas.

Tested by: The logging unit tests still pass.