### PR TITLE
microscope mode selection: do it directly, and only use signals for ui updates

### DIFF
--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -1017,7 +1017,7 @@ class HighContentScreeningGui(QMainWindow):
             self.movement_updater.position_after_move.connect(self.wellplateMultiPointWidget.update_live_coordinates)
             self.is_live_scan_grid_on = True
         self.multipointController.signal_register_current_fov.connect(self.navigationViewer.register_fov)
-        self.multipointController.signal_current_configuration.connect(self.liveControlWidget.set_microscope_mode)
+        self.multipointController.signal_current_configuration.connect(self.liveControlWidget.update_ui_for_mode)
         if self.piezoWidget:
             self.multipointController.signal_z_piezo_um.connect(self.piezoWidget.update_displacement_um_display)
         self.multipointController.signal_set_display_tabs.connect(self.setAcquisitionDisplayTabs)
@@ -1027,7 +1027,7 @@ class HighContentScreeningGui(QMainWindow):
             self.imageDisplayTabs.currentChanged.connect(self.onDisplayTabChanged)
 
         if USE_NAPARI_FOR_LIVE_VIEW and not self.live_only_mode:
-            self.multipointController.signal_current_configuration.connect(self.napariLiveWidget.set_microscope_mode)
+            self.multipointController.signal_current_configuration.connect(self.napariLiveWidget.update_ui_for_mode)
             self.autofocusController.image_to_display.connect(
                 lambda image: self.napariLiveWidget.updateLiveLayer(image, from_autofocus=True)
             )
@@ -1160,7 +1160,7 @@ class HighContentScreeningGui(QMainWindow):
         # Setup live view connections
         if USE_NAPARI_FOR_LIVE_VIEW and not self.live_only_mode:
             self.napari_connections["napariLiveWidget"] = [
-                (self.multipointController.signal_current_configuration, self.napariLiveWidget.set_microscope_mode),
+                (self.multipointController.signal_current_configuration, self.napariLiveWidget.update_ui_for_mode),
                 (
                     self.autofocusController.image_to_display,
                     lambda image: self.napariLiveWidget.updateLiveLayer(image, from_autofocus=True),

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -1379,7 +1379,8 @@ class LiveControlWidget(QFrame):
 
         self.add_components(show_trigger_options, show_display_options, show_autolevel, autolevel, stretch)
         self.setFrameStyle(QFrame.Panel | QFrame.Raised)
-        self.update_microscope_mode_by_name(self.currentConfiguration.name)
+        self.liveController.set_microscope_mode(self.currentConfiguration)
+        self.update_ui_for_mode(self.currentConfiguration)
 
         self.is_switching_mode = False  # flag used to prevent from settings being set by twice - from both mode change slot and value change slot; another way is to use blockSignals(True)
 
@@ -1498,7 +1499,7 @@ class LiveControlWidget(QFrame):
         self.entry_displayFPS.valueChanged.connect(self.streamHandler.set_display_fps)
         self.slider_resolutionScaling.valueChanged.connect(self.streamHandler.set_display_resolution_scaling)
         self.slider_resolutionScaling.valueChanged.connect(self.liveController.set_display_resolution_scaling)
-        self.dropdown_modeSelection.currentTextChanged.connect(self.update_microscope_mode_by_name)
+        self.dropdown_modeSelection.activated.connect(self.select_new_microscope_mode_by_index)
         self.dropdown_triggerManu.currentIndexChanged.connect(self.update_trigger_mode)
         self.btn_live.clicked.connect(self.toggle_live)
         self.entry_exposureTime.valueChanged.connect(self.update_config_exposure_time)
@@ -1583,30 +1584,47 @@ class LiveControlWidget(QFrame):
         # Update the mode selection dropdown
         self.dropdown_modeSelection.blockSignals(True)
         self.dropdown_modeSelection.clear()
+        first_config = None
         for microscope_configuration in self.channelConfigurationManager.get_channel_configurations_for_objective(
             self.objectiveStore.current_objective
         ):
+            if not first_config:
+                first_config = microscope_configuration
             self.dropdown_modeSelection.addItem(microscope_configuration.name)
         self.dropdown_modeSelection.blockSignals(False)
 
         # Update to first configuration
         if self.dropdown_modeSelection.count() > 0:
-            self.update_microscope_mode_by_name(self.dropdown_modeSelection.currentText())
+            self.update_ui_for_mode(first_config)
+            self.liveController.set_microscope_mode(first_config)
 
-    def update_microscope_mode_by_name(self, current_microscope_mode_name):
-        self.is_switching_mode = True
-        # identify the mode selected (note that this references the object in self.channelConfigurationManager.get_channel_configurations_for_objective(self.objectiveStore.current_objective))
-        self.currentConfiguration = self.channelConfigurationManager.get_channel_configuration_by_name(
-            self.objectiveStore.current_objective, current_microscope_mode_name
+    def select_new_microscope_mode_by_index(self, config_index):
+        config_name = self.dropdown_modeSelection.itemText(config_index)
+        maybe_new_config = self.channelConfigurationManager.get_channel_configuration_by_name(
+            self.objectiveStore.current_objective, config_name
         )
-        self.signal_live_configuration.emit(self.currentConfiguration)
-        # update the microscope to the current configuration
-        self.liveController.set_microscope_mode(self.currentConfiguration)
-        # update the exposure time and analog gain settings according to the selected configuration
-        self.entry_exposureTime.setValue(self.currentConfiguration.exposure_time)
-        self.entry_analogGain.setValue(self.currentConfiguration.analog_gain)
-        self.entry_illuminationIntensity.setValue(self.currentConfiguration.illumination_intensity)
-        self.is_switching_mode = False
+
+        if not maybe_new_config:
+            self._log.error(f"User attempted to select config named '{config_name}' but it does not exist!")
+            return
+
+        self.liveController.set_microscope_mode(maybe_new_config)
+        self.update_ui_for_mode(maybe_new_config)
+
+    def update_ui_for_mode(self, config):
+        try:
+            self.is_switching_mode = True
+            self.currentConfiguration = config
+            self.dropdown_modeSelection.setCurrentText(config.name if config else "Unknown")
+            if self.currentConfiguration:
+                self.signal_live_configuration.emit(self.currentConfiguration)
+
+                # update the exposure time and analog gain settings according to the selected configuration
+                self.entry_exposureTime.setValue(self.currentConfiguration.exposure_time)
+                self.entry_analogGain.setValue(self.currentConfiguration.analog_gain)
+                self.entry_illuminationIntensity.setValue(self.currentConfiguration.illumination_intensity)
+        finally:
+            self.is_switching_mode = False
 
     def update_trigger_mode(self):
         self.liveController.set_trigger_mode(self.dropdown_triggerManu.currentText())
@@ -1634,10 +1652,6 @@ class LiveControlWidget(QFrame):
                 self.objectiveStore.current_objective, self.currentConfiguration.id, "IlluminationIntensity", new_value
             )
             self.liveController.update_illumination()
-
-    def set_microscope_mode(self, config):
-        # self.liveController.set_microscope_mode(config)
-        self.dropdown_modeSelection.setCurrentText(config.name)
 
     def set_trigger_mode(self, trigger_mode):
         self.dropdown_triggerManu.setCurrentText(trigger_mode)
@@ -6244,6 +6258,7 @@ class NapariLiveWidget(QWidget):
         parent=None,
     ):
         super().__init__(parent)
+        self._log = squid.logging.get_logger(self.__class__.__name__)
         self.streamHandler = streamHandler
         self.liveController = liveController
         self.stage = stage
@@ -6268,7 +6283,7 @@ class NapariLiveWidget(QWidget):
         self.initNapariViewer()
         self.addNapariGrayclipColormap()
         self.initControlWidgets(show_trigger_options, show_display_options, show_autolevel, autolevel)
-        self.update_microscope_mode_by_name(self.live_configuration.name)
+        self.update_ui_for_mode(self.live_configuration)
 
     def initNapariViewer(self):
         self.viewer = napari.Viewer(show=False)
@@ -6325,7 +6340,7 @@ class NapariLiveWidget(QWidget):
         ):
             self.dropdown_modeSelection.addItem(config.name)
         self.dropdown_modeSelection.setCurrentText(self.live_configuration.name)
-        self.dropdown_modeSelection.currentTextChanged.connect(self.update_microscope_mode_by_name)
+        self.dropdown_modeSelection.activated(self.select_new_microscope_mode_by_name)
 
         # Live button
         self.btn_live = QPushButton("Start Live")
@@ -6572,15 +6587,23 @@ class NapariLiveWidget(QWidget):
             well_selector_dock_widget, area="bottom", name="well selector", tabify=True
         )
 
-    def set_microscope_mode(self, config):
-        self.dropdown_modeSelection.setCurrentText(config.name)
-
-    def update_microscope_mode_by_name(self, current_microscope_mode_name):
-        self.live_configuration = self.channelConfigurationManager.get_channel_configuration_by_name(
-            self.objectiveStore.current_objective, current_microscope_mode_name
+    def select_new_microscope_mode_by_name(self, config_index):
+        config_name = self.dropdown_modeSelection.itemText(config_index)
+        maybe_new_config = self.channelConfigurationManager.get_channel_configuration_by_name(
+            self.objectiveStore.current_objective, config_name
         )
+
+        if not maybe_new_config:
+            self._log.error(f"User attempted to select config named '{config_name}' but it does not exist!")
+            return
+
+        self.liveController.set_microscope_mode(maybe_new_config)
+        self.update_ui_for_mode(maybe_new_config)
+
+    def update_ui_for_mode(self, config):
+        self.live_configuration = config
+        self.dropdown_modeSelection.setCurrentText(config.name if config else "Unknown")
         if self.live_configuration:
-            self.liveController.set_microscope_mode(self.live_configuration)
             self.entry_exposureTime.setValue(self.live_configuration.exposure_time)
             self.entry_analogGain.setValue(self.live_configuration.analog_gain)
             self.slider_illuminationIntensity.setValue(int(self.live_configuration.illumination_intensity))


### PR DESCRIPTION
This is not a totally complete "decouple the ui" PR, but is a stepping stone to get there.  Before, we used `MultiPointWorker.signal_current_configuration -> MultiPointController.signal_current_configuration -> LiveControlWidget.set_microscope_mode -> dropdown text change signal -> update mode from name -> LiveController.set_microscope_mode` to update the hardware settings for each acquisition frame.  This was a lot of qt machinery to work through!

Instead, this directly calls `LiveController.set_microscope_mode` and separately signals updating the ui.  And the `LiveControlWidget` is changed so that it calls `LiveController.set_microscope_mode` only when a new user selected value is triggered (and otherwise, only updates the ui).

This would be better without the `BlockingQueuedConnection`, but if we do that then the main event loop is not processing events (even with me using `QtThread.yieldCurrentThread` and `QtThread.usleep` - I am missing something here!).  Note that `QtApplication.processEvents` only processes the current thread's events, so that doesn't help us.

Tested by: Running some local acquisitions, unit tests, and still needs HW testing.