### PR TITLE
MultiPointWorker: Use callbacks for image processing so we can trigger faster

### DIFF
--- a/software/control/core/core.py
+++ b/software/control/core/core.py
@@ -2280,12 +2280,10 @@ class MultiPointController(QObject):
         else:
             self.liveController_was_live_before_multipoint = False
 
-        # disable callback
-        if self.camera.get_callbacks_enabled():
-            self.camera_callback_was_enabled_before_multipoint = True
-            self.camera.enable_callbacks(False)
-        else:
-            self.camera_callback_was_enabled_before_multipoint = False
+        self.camera_callback_was_enabled_before_multipoint = self.camera.get_callbacks_enabled()
+        # We need callbacks, because we trigger and then use callbacks for image processing.  This
+        # lets us do overlapping triggering (soon).
+        self.camera.enable_callbacks(True)
 
         if self.usb_spectrometer != None:
             if self.usb_spectrometer.streaming_started == True and self.usb_spectrometer.streaming_paused == False:
@@ -2423,10 +2421,8 @@ class MultiPointController(QObject):
         self.signal_current_configuration.emit(self.configuration_before_running_multipoint)
         self.liveController.set_microscope_mode(self.configuration_before_running_multipoint)
 
-        # re-enable callback
-        if self.camera_callback_was_enabled_before_multipoint:
-            self.camera.enable_callbacks(True)
-            self.camera_callback_was_enabled_before_multipoint = False
+        # Restore callbacks to pre-acquisition state
+        self.camera.enable_callbacks(self.camera_callback_was_enabled_before_multipoint)
 
         # re-enable live if it's previously on
         if self.liveController_was_live_before_multipoint and RESUME_LIVE_AFTER_ACQUISITION:

--- a/software/control/core/multi_point_worker.py
+++ b/software/control/core/multi_point_worker.py
@@ -7,6 +7,7 @@ from datetime import datetime
 
 import cv2
 import imageio as iio
+import tifffile
 import numpy as np
 from numpy.typing import NDArray
 import pandas as pd
@@ -660,8 +661,8 @@ class MultiPointWorker(QObject):
                 "z_mm": info.position.z_mm,
             }
             output_path = os.path.join(info.save_directory, f"{info.region_id}_{info.fov:0{FILE_ID_PADDING}}_stack.tiff")
-            tiff_writer = iio.get_writer(output_path, format="TIFF")
-            tiff_writer.append_data(image, meta=metadata)
+            with tifffile.TiffWriter(output_path, append=True) as tiff_writer:
+                tiff_writer.write(image, metadata=metadata)
         else:
             saved_image = utils_acquisition.save_image(
                 image=image, file_id=info.file_id, save_directory=info.save_directory, config=info.configuration, is_color=is_color

--- a/software/control/core/multi_point_worker.py
+++ b/software/control/core/multi_point_worker.py
@@ -66,6 +66,7 @@ class MultiPointWorker(QObject):
         self.multiPointController = multiPointController
         self._log = squid.logging.get_logger(__class__.__name__)
         self._timing = control.utils.TimingManager("MultiPointWorker Timer Manager")
+        self._file_writer = None
         self.start_time = 0
         self.camera: AbstractCamera = self.multiPointController.camera
         self.microcontroller = self.multiPointController.microcontroller

--- a/software/control/core/multi_point_worker.py
+++ b/software/control/core/multi_point_worker.py
@@ -219,6 +219,10 @@ class MultiPointWorker(QObject):
         if not self._image_callback_idle.wait(self._frame_wait_timeout_s()):
             self._log.warning("Timed out waiting for the last image to process!")
 
+        # No matter what, set the flags so things can continue
+        self._ready_for_next_trigger.set()
+        self._image_callback_idle.set()
+
     def wait_till_operation_is_completed(self):
         self.microcontroller.wait_till_operation_is_completed()
 

--- a/software/control/core/multi_point_worker.py
+++ b/software/control/core/multi_point_worker.py
@@ -1,11 +1,17 @@
 import os
+import threading
 import time
+from typing import List, Optional
+from dataclasses import dataclass
 from datetime import datetime
 
 import cv2
 import imageio as iio
 import numpy as np
+from numpy.typing import NDArray
 import pandas as pd
+
+import control.utils
 
 os.environ["QT_API"] = "pyqt5"
 from qtpy.QtCore import Signal, QObject
@@ -15,7 +21,7 @@ from control._def import *
 from control import utils, utils_acquisition
 from control.piezo import PiezoStage
 from control.utils_config import ChannelMode
-from squid.abc import AbstractCamera
+from squid.abc import AbstractCamera, CameraFrame
 import squid.logging
 
 try:
@@ -24,6 +30,16 @@ try:
     print("custom multipoint script found")
 except:
     pass
+
+
+@dataclass
+class CaptureInfo:
+    position: squid.abc.Pos
+    z_index: int
+    capture_time: float
+    configuration: ChannelMode
+    save_directory: str
+    file_id: str
 
 
 class MultiPointWorker(QObject):
@@ -46,6 +62,7 @@ class MultiPointWorker(QObject):
         QObject.__init__(self)
         self.multiPointController = multiPointController
         self._log = squid.logging.get_logger(__class__.__name__)
+        self._timing = control.utils.TimingManager("MultiPointWorker Timer Manager")
         self.start_time = 0
         self.camera: AbstractCamera = self.multiPointController.camera
         self.microcontroller = self.multiPointController.microcontroller
@@ -100,14 +117,27 @@ class MultiPointWorker(QObject):
         self.merged_image = None
         self.image_count = 0
 
+        # This is for keeping track of whether or not we have the last image we tried to capture.
+        # NOTE(imo): Once we do overlapping triggering, we'll want to keep a queue of images we are expecting.
+        # For now, this is an improvement over blocking immediately while waiting for the next image!
+        self._ready_for_next_trigger = threading.Event()
+        # Set this to true so that the first frame capture can proceed.
+        self._ready_for_next_trigger.set()
+        # This is protected by the threading event above (aka set after clear, take copy before set)
+        self._current_capture_info: Optional[CaptureInfo] = None
+        # This is only touched via the image callback path.  Don't touch it outside of there!
+        self._current_round_images = {}
+
     def update_use_piezo(self, value):
         self.use_piezo = value
         self._log.info(f"MultiPointWorker: updated use_piezo to {value}")
 
     def run(self):
+        this_image_callback_id = None
         try:
             self.start_time = time.perf_counter_ns()
             self.camera.start_streaming()
+            this_image_callback_id = self.camera.add_frame_callback(self._image_callback)
 
             while self.time_point < self.Nt:
                 # check if abort acquisition has been requested
@@ -121,7 +151,8 @@ class MultiPointWorker(QObject):
                     self.fluidics.run_before_imaging()
                     self.fluidics.wait_for_completion()
 
-                self.run_single_time_point()
+                with self._timing.get_timer("run_single_time_point"):
+                    self.run_single_time_point()
 
                 if self.fluidics and self.multiPointController.use_fluidics:
                     # For MERFISH, after imaging, run the following 2 sequences (Cleavage buffer, SSC rinse)
@@ -159,6 +190,10 @@ class MultiPointWorker(QObject):
             self._log.error(f"Operation timed out during acquisition, aborting acquisition!")
             self._log.error(te)
             self.multiPointController.request_abort_aquisition()
+        finally:
+            self._log.debug(self._timing.get_report())
+            if this_image_callback_id:
+                self.camera.remove_frame_callback(this_image_callback_id)
         if not self.headless:
             self.finished.emit()
 
@@ -183,7 +218,8 @@ class MultiPointWorker(QObject):
         # init z parameters, z range
         self.initialize_z_stack()
 
-        self.run_coordinate_acquisition(current_path)
+        with self._timing.get_timer("run_coordinate_acquisition"):
+            self.run_coordinate_acquisition(current_path)
 
         # finished region scan
         self.coordinates_pd.to_csv(os.path.join(current_path, "coordinates.csv"), index=False, header=True)
@@ -297,9 +333,10 @@ class MultiPointWorker(QObject):
             self.total_scans = self.num_fovs * self.NZ * len(self.selected_configurations)
 
             for fov_count, coordinate_mm in enumerate(coordinates):
-
-                self.move_to_coordinate(coordinate_mm)
-                self.acquire_at_position(region_id, current_path, fov_count)
+                with self._timing.get_timer("move_to_coordinate"):
+                    self.move_to_coordinate(coordinate_mm)
+                with self._timing.get_timer("acquire_at_position"):
+                    self.acquire_at_position(region_id, current_path, fov_count)
 
                 if self.multiPointController.abort_acqusition_requested:
                     self.handle_acquisition_abort(current_path, region_id)
@@ -319,7 +356,6 @@ class MultiPointWorker(QObject):
         if self.NZ > 1:
             self.prepare_z_stack()
 
-        pos = self.stage.get_pos()
         if self.use_piezo:
             self.z_piezo_um = self.piezo.position
 
@@ -349,37 +385,13 @@ class MultiPointWorker(QObject):
                     self.handle_z_offset(config, True)
 
                 # acquire image
-                if "USB Spectrometer" not in config.name and "RGB" not in config.name:
-                    image = self.acquire_camera_image(
-                        config,
-                        file_ID,
-                        current_path,
-                        current_round_images,
-                        z_level,
-                        save_individual_images=(FILE_SAVING_OPTION == FileSavingOption.INDIVIDUAL_IMAGES),
-                    )
-
-                    # Write image to multipage TIFF if FILE_FORMAT is "Multi-Page TIFF"
-                    if FILE_SAVING_OPTION == FileSavingOption.MULTI_PAGE_TIFF and tiff_writer is not None:
-                        # Add metadata for the image
-                        metadata = {
-                            "z_level": z_level,
-                            "channel": config.name,
-                            "channel_index": config_idx,
-                            "region_id": region_id,
-                            "fov": fov,
-                            "x_mm": acquire_pos.x_mm,
-                            "y_mm": acquire_pos.y_mm,
-                            "z_mm": acquire_pos.z_mm,
-                        }
-
-                        # Write the image to TIFF
-                        tiff_writer.append_data(image, meta=metadata)
-
-                elif "RGB" in config.name:
-                    self.acquire_rgb_image(config, file_ID, current_path, current_round_images, z_level)
-                else:
-                    self.acquire_spectrometer_data(config, file_ID, current_path, z_level)
+                with self._timing.get_timer("acquire_camera_image"):
+                    if "USB Spectrometer" not in config.name and "RGB" not in config.name:
+                        self.acquire_camera_image(config, file_ID, current_path, current_round_images, z_level)
+                    elif "RGB" in config.name:
+                        self.acquire_rgb_image(config, file_ID, current_path, current_round_images, z_level)
+                    else:
+                        self.acquire_spectrometer_data(config, file_ID, current_path, z_level)
 
                 if self.NZ == 1:  # TODO: handle z offset for z stack
                     self.handle_z_offset(config, False)
@@ -471,6 +483,49 @@ class MultiPointWorker(QObject):
                 self.wait_till_operation_is_completed()
                 self._sleep(SCAN_STABILIZATION_TIME_MS_Z / 1000)
 
+    def _image_callback(self, camera_frame: CameraFrame):
+        with self._timing.get_timer("_image_callback"):
+            self._log.debug(f"In Image callback for frame_id={camera_frame.frame_id}")
+            info = self._current_capture_info
+            self._current_capture_info = None
+            self._ready_for_next_trigger.set()
+            if not info:
+                self._log.error("In image callback, no current capture info! Something is wrong. Aborting.")
+                self.multiPointController.request_abort_aquisition()
+                return
+
+            image = camera_frame.frame
+            if not camera_frame or image is None:
+                self._log.warning("image in frame callback is None. Something is really wrong, aborting!")
+                self.multiPointController.request_abort_aquisition()
+                return
+
+            height, width = image.shape[:2]
+            with self._timing.get_timer("crop_image"):
+                image_to_display = utils.crop_image(
+                    image,
+                    round(width * self.display_resolution_scaling),
+                    round(height * self.display_resolution_scaling),
+                )
+            with self._timing.get_timer("image_to_display*.emit"):
+                self.image_to_display.emit(image_to_display)
+                self.image_to_display_multi.emit(image_to_display, info.configuration.illumination_source)
+
+            with self._timing.get_timer("save_image"):
+                self.save_image(image, info.file_id, info.configuration, info.save_directory, camera_frame.is_color())
+            with self._timing.get_timer("update_napari"):
+                self.update_napari(image, info.configuration.name, info.z_index)
+            with self._timing.get_timer("_current_round_images"):
+                self._current_round_images[info.configuration.name] = np.copy(image)
+
+            with self._timing.get_timer("handle_rgb_generation"):
+                MultiPointWorker.handle_rgb_generation(
+                    self._current_round_images, info.file_id, info.save_directory, info.z_index
+                )
+
+    def _frame_wait_timeout_s(self):
+        return (self.camera.get_total_frame_time() / 1e3) + 10
+
     def acquire_camera_image(self, config, file_ID, current_path, current_round_images, k):
         self._select_config(config)
 
@@ -486,47 +541,40 @@ class MultiPointWorker(QObject):
                 #  "reset_image_ready_flag" arg, so this is broken for all other cameras.  Also this used to do some other funky stuff like setting internal camera flags.
                 #   I am pretty sure this is broken!
                 self.microscope.nl5.start_acquisition()
+        # This is some large timeout that we use just so as to not block forever
+        if not self._ready_for_next_trigger.wait(self._frame_wait_timeout_s()):
+            self._log.error("Frame callback never set _have_last_triggered_image callback! Aborting acquisition.")
+            self.multiPointController.request_abort_aquisition()
+            return
+
+        # This should be a noop - we have the frame already.  Still, check!
         while not self.camera.get_ready_for_trigger():
             self._sleep(0.001)
+
+        self._ready_for_next_trigger.clear()
+        # Even though the capture time will be slightly after this, we need to capture and set the capture info
+        # before the trigger to be 100% sure the callback doesn't stomp on it.
+        current_capture_info = CaptureInfo(
+            position=self.stage.get_pos(),
+            z_index=k,
+            capture_time=time.time(),
+            configuration=config,
+            save_directory=current_path,
+            file_id=file_ID,
+        )
+        self._current_capture_info = current_capture_info
         self.camera.send_trigger(illumination_time=camera_illumination_time)
-        camera_frame = self.camera.read_camera_frame()
-        image = camera_frame.frame
-        if not camera_frame or image is None:
-            self._log.warning("self.camera.read_frame() returned None")
-            return
+        exposure_done_time = time.time() + self.camera.get_total_frame_time() / 1e3
+        # Even though we can do overlapping triggers, we want to make sure that we don't move before our exposure
+        # is done.  So we still need to at least sleep for the total frame time corresponding to this exposure.
+        self._sleep(max(0.0, exposure_done_time - time.time()))
 
         # turn off the illumination if using software trigger
         if self.liveController.trigger_mode == TriggerMode.SOFTWARE:
             self.liveController.turn_off_illumination()
 
-        height, width = image.shape[:2]
-        self._log.info("Cropping image...")
-        image_to_display = utils.crop_image(
-            image,
-            round(width * self.display_resolution_scaling),
-            round(height * self.display_resolution_scaling),
-        )
-        self._log.info("Emitting display image...")
-        self.image_to_display.emit(image_to_display)
-        self.image_to_display_multi.emit(image_to_display, config.illumination_source)
-
-        self._log.info("Saving image...")
-        self.save_image(image, file_ID, config, current_path, camera_frame.is_color())
-        self._log.info("Updating napari...")
-        self.update_napari(image, config.name, k)
-        self._log.info("storing current round...")
-        current_round_images[config.name] = np.copy(image)
-
-        # current_round_images[config.name] = np.copy(image) # to remove
-        # MultiPointWorker.handle_rgb_generation(current_round_images, file_ID, current_path, k) # to remove
-
         if not self.headless:
             QApplication.processEvents()
-
-        if save_individual_images:
-            self.save_image(image, file_ID, config, current_path, camera_frame.is_color())
-
-        return image
 
     def _sleep(self, sec):
         self._log.info(f"Sleeping for {sec} [s]")
@@ -705,6 +753,12 @@ class MultiPointWorker(QObject):
         # Save coordinates.csv
         self.coordinates_pd.to_csv(os.path.join(current_path, "coordinates.csv"), index=False, header=True)
         self.microcontroller.enable_joystick(True)
+
+        # If there are outstanding frames, wait for them to come in.
+        self._log.info("Waiting for any outstanding frames at end of acquisition.")
+        if not self._ready_for_next_trigger.wait(self._frame_wait_timeout_s()):
+            self._log.warning("Timed out waiting for the last outstanding frames at end of acquisition!")
+
 
     def move_z_for_stack(self):
         if self.use_piezo:


### PR DESCRIPTION
This is step 1 of 2 to get to full overlapped triggering acquisitions.  This adds in the callback mechanism in `MultiPointWorker` for handling frames asynchronously, but only triggers one frame at a time (and uses the `threading.Event()` flag to note when the frame comes in).  This is still faster than what we had before, because we can move and do other processing after the full frame time passes, but is still slower than doing overlapped triggering.

The next step after this works will be to add overlapped triggering.  That is a bit tricky because we need to be 100% sure we don't drop any frames, or else we can do an entire acquisition with all the remaining frames (after the dropped one(s)) shifted!

Tested by: I ran a local simulation and unit tests pass, but this needs actual testing on hardware!