### PR TITLE
camera bug fix: temperature reading; Hamamatsu model config; Squid configuration file 

### DIFF
--- a/software/configurations/configuration_HCS_v2.ini
+++ b/software/configurations/configuration_HCS_v2.ini
@@ -161,7 +161,7 @@ illumination_intensity_factor = 0.6
 
 [CAMERA_CONFIG]
 rotate_image_angle = None
-flip_image = None
+flip_image = Vertical
 _flip_image_options = [Vertical, Horizontal, Both, None]
 crop_width_unbinned = 3000
 crop_height_unbinned = 3000

--- a/software/control/camera.py
+++ b/software/control/camera.py
@@ -527,3 +527,6 @@ class DefaultCamera(AbstractCamera):
 
     def get_temperature(self) -> float:
         raise NotImplementedError("DefaultCameras do not support getting current temperature")
+
+    def set_temperature_reading_callback(self, callback: Callable):
+        raise NotImplementedError("DefaultCameras do not support getting current temperature")

--- a/software/control/camera_toupcam.py
+++ b/software/control/camera_toupcam.py
@@ -368,7 +368,7 @@ class ToupcamCamera(AbstractCamera):
 
         # TODO: Do hardware cropping here (set ROI)
 
-    def _set_temperature_reading_callback(self, func):
+    def set_temperature_reading_callback(self, func):
         self.temperature_reading_callback = func
 
     def _get_raw_exposure_time(self) -> float:

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -1115,8 +1115,7 @@ class CameraSettingsWidget(QFrame):
             temp_line.addWidget(self.label_temperature_measured)
             try:
                 self.entry_temperature.valueChanged.connect(self.set_temperature)
-                # TODO(imo): temp reading callback restoration, or polling
-                # self.camera.set_temperature_reading_callback(self.update_measured_temperature)
+                self.camera.set_temperature_reading_callback(self.update_measured_temperature)
             except AttributeError:
                 pass
             self.camera_layout.addLayout(temp_line)

--- a/software/squid/abc.py
+++ b/software/squid/abc.py
@@ -719,3 +719,10 @@ class AbstractCamera(metaclass=abc.ABCMeta):
         Get the current temperature of the camera in deg C.
         """
         pass
+
+    @abc.abstractmethod
+    def set_temperature_reading_callback(self, callback: Callable):
+        """
+        Set the callback to be called when the temperature reading changes.
+        """
+        pass

--- a/software/squid/camera/utils.py
+++ b/software/squid/camera/utils.py
@@ -397,5 +397,9 @@ class SimulatedCamera(AbstractCamera):
     def get_temperature(self) -> float:
         return self._temperature_setpoint
 
+    @debug_log
+    def set_temperature_reading_callback(self, callback: Callable):
+        self._temperature_reading_callback = callback
+
     def get_frame_id(self) -> int:
         return self._frame_id

--- a/software/squid/config.py
+++ b/software/squid/config.py
@@ -214,6 +214,20 @@ class TucsenCameraModel(enum.Enum):
             return None
 
 
+class HamamatsuCameraModel(enum.Enum):
+    C15440_20UP = "C15440-20UP"
+
+    @staticmethod
+    def from_string(cam_string: str) -> Optional["HamamatsuCameraModel"]:
+        """
+        Attempts to convert the given string to a Hamamatsu camera model.  This ignores all letter cases.
+        """
+        try:
+            return HamamatsuCameraModel[cam_string.upper()]
+        except KeyError:
+            return None
+
+
 class CameraSensor(enum.Enum):
     """
     Some camera sensors may not be included here.
@@ -284,7 +298,7 @@ class CameraConfig(pydantic.BaseModel):
 
     # Specific camera model. This will be used to determine the model-specific parameters, because one camera class may
     # support multiple models from the same brand.
-    camera_model: Optional[Union[GxipyCameraModel, TucsenCameraModel]] = None
+    camera_model: Optional[Union[GxipyCameraModel, TucsenCameraModel, ToupcamCameraModel, HamamatsuCameraModel]] = None
 
     # The serial number of the camera. You may use this to select a specific camera to open if there are multiple
     # cameras using the same SDK/driver.


### PR DESCRIPTION
This pull request introduces several updates to enhance camera configuration, add support for new camera models, and implement temperature reading callbacks. The most significant changes include enabling temperature reading callbacks across camera modules, adding support for the Hamamatsu camera model, and updating camera configuration options.

### Temperature Reading Callback Enhancements:
* Added a new abstract method `set_temperature_reading_callback` to the base camera interface (`software/squid/abc.py`) to support temperature reading callbacks.
* Implemented the `set_temperature_reading_callback` method in `camera_toupcam.py`, replacing the previously private `_set_temperature_reading_callback` method.
* Restored the temperature reading callback functionality in the widget interface by connecting the callback to `update_measured_temperature` in `widgets.py`.

### New Camera Model Support:
* Added a new `HamamatsuCameraModel` enum to represent Hamamatsu camera models, including a `from_string` method for string conversion.
* Extended the `CameraConfig` class to include support for `HamamatsuCameraModel` and `ToupcamCameraModel` in the `camera_model` field.

### Configuration Updates:
* Updated the `flip_image` option in `configuration_HCS_v2.ini` to default to `Vertical` instead of `None`.