### PR TITLE
close cameras explicitly on exit

### DIFF
--- a/software/control/camera.py
+++ b/software/control/camera.py
@@ -133,7 +133,7 @@ class DefaultCamera(AbstractCamera):
         self._frame_lock = threading.Lock()
         self._current_frame: Optional[CameraFrame] = None
 
-    def __del__(self):
+    def close(self):
         try:
             if self._camera:
                 self._camera.close_device()

--- a/software/control/camera_hamamatsu.py
+++ b/software/control/camera_hamamatsu.py
@@ -105,7 +105,7 @@ class HamamatsuCamera(AbstractCamera):
         self._exposure_time_ms: int = 20
         self.set_exposure_time(self._exposure_time_ms)
 
-    def __del__(self):
+    def close(self):
         self._cleanup_read_thread()
 
     def _set_prop(self, dcam_prop, prop_value):

--- a/software/control/camera_photometrics.py
+++ b/software/control/camera_photometrics.py
@@ -91,10 +91,6 @@ class PhotometricsCamera(AbstractCamera):
         self.temperature_reading_thread.start()
         """
 
-    def __del__(self):
-        self.stop_streaming()
-        self._close()
-
     def _configure_camera(self):
         """Configure camera with default settings."""
         self._camera.exp_res = 0  # Exposure resolution in milliseconds
@@ -140,7 +136,7 @@ class PhotometricsCamera(AbstractCamera):
     def get_is_streaming(self):
         return self._is_streaming.is_set()
 
-    def _close(self):
+    def close(self):
         try:
             self._camera.close()
         except Exception as e:

--- a/software/control/camera_toupcam.py
+++ b/software/control/camera_toupcam.py
@@ -235,11 +235,6 @@ class ToupcamCamera(AbstractCamera):
         self._start_raw_camera_stream()
         self._update_internal_settings()
 
-    def __del__(self):
-        if self.get_is_streaming():
-            self.stop_streaming()
-        self._close()
-
     def _start_raw_camera_stream(self):
         """
         Make sure the camera is setup to tell us when frames are available.
@@ -379,7 +374,7 @@ class ToupcamCamera(AbstractCamera):
     def _get_raw_exposure_time(self) -> float:
         return self._camera.get_ExpoTime() / 1000.0  # microseconds -> milliseconds
 
-    def _close(self):
+    def close(self):
         self.terminate_read_temperature_thread = True
         self.thread_read_temperature.join()
         self._set_fan_speed(0)

--- a/software/control/camera_tucsen.py
+++ b/software/control/camera_tucsen.py
@@ -168,10 +168,6 @@ class TucsenCamera(AbstractCamera):
         self.temperature_reading_thread = threading.Thread(target=self._check_temperature, daemon=True)
         self.temperature_reading_thread.start()
 
-    def __del__(self):
-        self.stop_streaming()
-        self._close()
-
     def _configure_camera(self):
         # TODO: Add support for FL26BW model
         # TODO: For 400BSI V3, we use the default HDR mode for now.
@@ -223,7 +219,7 @@ class TucsenCamera(AbstractCamera):
     def get_is_streaming(self):
         return self._is_streaming.is_set()
 
-    def _close(self):
+    def close(self):
         if self.temperature_reading_thread is not None:
             self._terminate_temperature_event.set()
             self.temperature_reading_thread.join()

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -1664,6 +1664,8 @@ class HighContentScreeningGui(QMainWindow):
             squid.stage.utils.cache_position(pos=self.stage.get_pos(), stage_config=self.stage.get_config())
         except ValueError as e:
             self.log.error(f"Couldn't cache position while closing.  Ignoring and continuing. Error is: {e}")
+        self.movement_update_timer.stop()
+
         if USE_ZABER_EMISSION_FILTER_WHEEL:
             self.emission_filter_wheel.set_emission_filter(1)
         if USE_OPTOSPIN_EMISSION_FILTER_WHEEL:
@@ -1677,6 +1679,7 @@ class HighContentScreeningGui(QMainWindow):
 
         self.liveController.stop_live()
         self.camera.stop_streaming()
+        self.camera.close()
 
         self.microcontroller.turn_off_all_pid()
 

--- a/software/control/serial_peripherals.py
+++ b/software/control/serial_peripherals.py
@@ -498,7 +498,7 @@ class LDI(LightSource):
             for pair in pairs:
                 channel, value = pair.split("=")
                 intensities[int(channel)] = int(value)
-            return intensity[channel]
+            return intensities[channel]
         except:
             return None
 

--- a/software/squid/abc.py
+++ b/software/squid/abc.py
@@ -733,3 +733,10 @@ class AbstractCamera(metaclass=abc.ABCMeta):
         Set the callback to be called when the temperature reading changes.
         """
         pass
+
+    @abc.abstractmethod
+    def close(self):
+        """
+        Close the camera.
+        """
+        pass

--- a/software/squid/camera/utils.py
+++ b/software/squid/camera/utils.py
@@ -415,3 +415,7 @@ class SimulatedCamera(AbstractCamera):
 
     def get_frame_id(self) -> int:
         return self._frame_id
+
+    @debug_log
+    def close(self):
+        pass


### PR DESCRIPTION
The code block in `__del__` in the camera classes can not be reached due to some segmentation fault. For now we will explicitly close cameras on exiting software.