### PR TITLE
camera fix: Kinetix camera set exposure time and Hamamatsu camera get exposure time range

### DIFF
--- a/software/control/camera_hamamatsu.py
+++ b/software/control/camera_hamamatsu.py
@@ -198,7 +198,7 @@ class HamamatsuCamera(AbstractCamera):
 
     def get_exposure_limits(self) -> Tuple[float, float]:
         exposure_attr = self._camera.prop_getattr(DCAM_IDPROP.EXPOSURETIME)
-        return exposure_attr.valuemin, exposure_attr.valuemax  # in ms
+        return exposure_attr.valuemin * 1000.0, exposure_attr.valuemax * 1000.0  # in ms
 
     def get_strobe_time(self) -> float:
         resolution = self.get_resolution()

--- a/software/control/camera_photometrics.py
+++ b/software/control/camera_photometrics.py
@@ -249,6 +249,10 @@ class PhotometricsCamera(AbstractCamera):
             return self._current_frame.frame_id if self._current_frame else -1
 
     def set_exposure_time(self, exposure_time_ms: float):
+        # Kinetix camera set_exposure_time is slow, so we don't want to call it unnecessarily.
+        if exposure_time_ms == self._exposure_time_ms:
+            return
+
         if self.get_acquisition_mode() == CameraAcquisitionMode.HARDWARE_TRIGGER:
             strobe_time_ms = self.get_strobe_time()
             adjusted_exposure_time = exposure_time_ms + strobe_time_ms
@@ -370,6 +374,7 @@ class PhotometricsCamera(AbstractCamera):
                     raise ValueError(f"Unsupported acquisition mode: {acquisition_mode}")
 
                 self._acquisition_mode = acquisition_mode
+                self.set_exposure_time(self._exposure_time_ms)
 
             except Exception as e:
                 raise CameraError(f"Failed to set acquisition mode: {e}")


### PR DESCRIPTION
This pull request includes updates to the camera control software to improve exposure time handling and optimize performance. The changes focus on ensuring consistent exposure time units across different camera models and avoiding unnecessary operations to enhance efficiency.

### Exposure time handling updates:

* [`software/control/camera_hamamatsu.py`](diffhunk://#diff-d6cb813e4a91ece8b40a46cc9255b3fbd30991a7a4a3e3eca8c796ff14416775L201-R201): Adjusted the `get_exposure_limits` method to convert exposure time limits from seconds to milliseconds for consistency with other methods.

### Performance optimizations:

* [`software/control/camera_photometrics.py`](diffhunk://#diff-23a4bc5c57c95dc0d00bcabf405aded068e842d342e105b4206a18781ddd6b90R252-R255): Updated the `set_exposure_time` method to check if the new exposure time matches the current value, avoiding redundant calls to the slow `set_exposure_time` function on Kinetix cameras.
* [`software/control/camera_photometrics.py`](diffhunk://#diff-23a4bc5c57c95dc0d00bcabf405aded068e842d342e105b4206a18781ddd6b90R377): Modified the `_set_acquisition_mode_imp` method to ensure the exposure time is set whenever the acquisition mode is changed, maintaining consistency in camera settings.