### PR TITLE
add Tenengrad focus measure option

### DIFF
--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -548,7 +548,7 @@ N_SPECTRUM_PER_POINT = 5
 
 # focus measure operator
 FOCUS_MEASURE_OPERATOR = (
-    "LAPE"  # 'GLVA' # LAPE has worked well for bright field images; GLVA works well for darkfield/fluorescence
+    "TENENGRAD"  # LAPE has worked well for bright field images; GLVA works well for darkfield/fluorescence
 )
 
 # controller version

--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -548,7 +548,7 @@ N_SPECTRUM_PER_POINT = 5
 
 # focus measure operator
 FOCUS_MEASURE_OPERATOR = (
-    "TENENGRAD"  # LAPE has worked well for bright field images; GLVA works well for darkfield/fluorescence
+    "LAPE"  # LAPE has worked well for bright field images; GLVA works well for darkfield/fluorescence
 )
 
 # controller version

--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -267,6 +267,25 @@ class FileSavingOption(Enum):
             raise ValueError(f"Invalid file saving option: {option}")
 
 
+class FocusMeasureOperator(Enum):
+    LAPE = "LAPE"  # LAPE has worked well for bright field images
+    GLVA = "GLVA"  # GLVA works well for darkfield/fluorescence
+    TENENGRAD = "TENENGRAD"
+
+    @staticmethod
+    def convert_to_enum(option: Union[str, "FocusMeasureOperator"]) -> "FocusMeasureOperator":
+        """
+        Attempts to convert the given string to a FocusMeasureOperator.  This ignores all letter cases.
+        """
+        if isinstance(option, FocusMeasureOperator):
+            return option
+
+        try:
+            return FocusMeasureOperator[option.upper()]
+        except KeyError:
+            raise ValueError(f"Invalid focus measure operator: {option}")
+
+
 PRINT_CAMERA_FPS = True
 
 ###########################################################
@@ -547,9 +566,7 @@ WELLPLATE_OFFSET_Y_mm = 0  # y offset adjustment for using different plates
 N_SPECTRUM_PER_POINT = 5
 
 # focus measure operator
-FOCUS_MEASURE_OPERATOR = (
-    "LAPE"  # LAPE has worked well for bright field images; GLVA works well for darkfield/fluorescence
-)
+FOCUS_MEASURE_OPERATOR = FocusMeasureOperator.LAPE
 
 # controller version
 CONTROLLER_VERSION = "Arduino Due"  # 'Teensy'
@@ -910,8 +927,9 @@ A1_Y_PIXEL = WELLPLATE_FORMAT_SETTINGS[WELLPLATE_FORMAT]["a1_y_pixel"]  # coordi
 HAS_OBJECTIVE_PIEZO = "PIEZO" in Z_MOTOR_CONFIG
 MULTIPOINT_USE_PIEZO_FOR_ZSTACKS = HAS_OBJECTIVE_PIEZO
 
-# file saving
+# convert str to enum
 FILE_SAVING_OPTION = FileSavingOption.convert_to_enum(FILE_SAVING_OPTION)
+FOCUS_MEASURE_OPERATOR = FocusMeasureOperator.convert_to_enum(FOCUS_MEASURE_OPERATOR)
 
 # saving path
 if not (DEFAULT_SAVING_PATH.startswith(str(Path.home()))):

--- a/software/control/utils.py
+++ b/software/control/utils.py
@@ -24,6 +24,7 @@ from control._def import (
     LASER_AF_MIN_PEAK_PROMINENCE,
     LASER_AF_SPOT_SPACING,
     SpotDetectionMode,
+    FocusMeasureOperator,
 )
 import squid.logging
 
@@ -45,23 +46,23 @@ def crop_image(image, crop_width, crop_height):
     return image_cropped
 
 
-def calculate_focus_measure(image, method="LAPE"):
+def calculate_focus_measure(image, method=FocusMeasureOperator.LAPE):
     if len(image.shape) == 3:
         image = cv2.cvtColor(image, cv2.COLOR_RGB2GRAY)  # optional
-    if method == "LAPE":
+    if method == FocusMeasureOperator.LAPE:
         if image.dtype == np.uint16:
             lap = cv2.Laplacian(image, cv2.CV_32F)
         else:
             lap = cv2.Laplacian(image, cv2.CV_16S)
         focus_measure = mean(square(lap))
-    elif method == "GLVA":
+    elif method == FocusMeasureOperator.GLVA:
         focus_measure = np.std(image, axis=None)  # GLVA
-    elif method == "TENENGRAD":
+    elif method == FocusMeasureOperator.TENENGRAD:
         sobelx = cv2.Sobel(image, cv2.CV_64F, 1, 0, ksize=3)
         sobely = cv2.Sobel(image, cv2.CV_64F, 0, 1, ksize=3)
         focus_measure = np.sum(cv2.magnitude(sobelx, sobely))
     else:
-        focus_measure = np.std(image, axis=None)  # GLVA
+        raise ValueError(f"Invalid focus measure operator: {method}")
     return focus_measure
 
 

--- a/software/control/utils.py
+++ b/software/control/utils.py
@@ -59,7 +59,7 @@ def calculate_focus_measure(image, method="LAPE"):
     elif method == "TENENGRAD":
         sobelx = cv2.Sobel(image, cv2.CV_64F, 1, 0, ksize=3)
         sobely = cv2.Sobel(image, cv2.CV_64F, 0, 1, ksize=3)
-        focus_measure = np.sum(np.sqrt(sobelx**2 + sobely**2))
+        focus_measure = np.sum(cv2.magnitude(sobelx, sobely))
     else:
         focus_measure = np.std(image, axis=None)  # GLVA
     return focus_measure

--- a/software/control/utils.py
+++ b/software/control/utils.py
@@ -56,6 +56,10 @@ def calculate_focus_measure(image, method="LAPE"):
         focus_measure = mean(square(lap))
     elif method == "GLVA":
         focus_measure = np.std(image, axis=None)  # GLVA
+    elif method == "TENENGRAD":
+        sobelx = cv2.Sobel(image, cv2.CV_64F, 1, 0, ksize=3)
+        sobely = cv2.Sobel(image, cv2.CV_64F, 0, 1, ksize=3)
+        focus_measure = np.sum(np.sqrt(sobelx**2 + sobely**2))
     else:
         focus_measure = np.std(image, axis=None)  # GLVA
     return focus_measure


### PR DESCRIPTION
This pull request introduces a new focus measure method, `TENENGRAD`, to enhance the calculation of focus measures for images. Additionally, it includes a minor cleanup of a comment in the `FOCUS_MEASURE_OPERATOR` definition.

### Enhancements to focus measure calculation:

* [`software/control/utils.py`](diffhunk://#diff-5cc827e63be4a68ecf96663b01f88bca923d92292e6b1c54c6a4174beb53a82eR59-R62): Added support for the `TENENGRAD` method in the `calculate_focus_measure` function, which uses Sobel operators to compute focus measure based on image gradients.

### Code cleanup:

* [`software/control/_def.py`](diffhunk://#diff-def41afca339c9319b94636b379bd2c544c5fb81b6e8a37e4d732bdc05fffb97L551-R551): Removed outdated comment regarding the `FOCUS_MEASURE_OPERATOR` default value while retaining the existing "LAPE" method.