### PR TITLE
bug fix: Prior stage config update; Daheng camera model support

### DIFF
--- a/software/configurations/configuration_Squid+_H117_ORCA.ini
+++ b/software/configurations/configuration_Squid+_H117_ORCA.ini
@@ -110,7 +110,7 @@ homing_enabled_x = False
 _homing_enabled_x_options = [True, False]
 homing_enabled_y = False
 _homing_enabled_y_options = [True, False]
-homing_enabled_z = True
+homing_enabled_z = False
 _homing_enabled_z_options = [True, False]
 sleep_time_s = 0.005
 led_matrix_r_factor = 1.0
@@ -219,12 +219,12 @@ dy = 0.9
 dz = 1.5
 
 [SOFTWARE_POS_LIMIT]
-x_positive = 112.5
-x_negative = 10
-y_positive = 76
-y_negative = 6
+x_positive = 117
+x_negative = 3
+y_positive = 77
+y_negative = 3
 z_positive = 6
-z_negative = 0.05
+z_negative = -0.05
 
 [SLIDE_POSITION]
 loading_x_mm = 0.5

--- a/software/control/camera.py
+++ b/software/control/camera.py
@@ -327,6 +327,7 @@ class DefaultCamera(AbstractCamera):
 
     _MODEL_TO_SENSOR = {
         GxipyCameraModel.MER2_1220_32U3M: CameraSensor.IMX226,
+        GxipyCameraModel.MER2_1220_32U3C: CameraSensor.IMX226,
         GxipyCameraModel.MER2_630_60U3M: CameraSensor.IMX178,
     }
 

--- a/software/squid/config.py
+++ b/software/squid/config.py
@@ -171,6 +171,7 @@ class CameraVariant(enum.Enum):
 
 class GxipyCameraModel(enum.Enum):
     MER2_1220_32U3M = "MER2-1220-32U3M"
+    MER2_1220_32U3C = "MER2-1220-32U3C"
     MER2_630_60U3M = "MER2-630-60U3M"
 
     @staticmethod


### PR DESCRIPTION
This pull request includes updates to configuration files and camera-related code to enhance functionality and ensure compatibility with additional hardware. The most important changes involve adjustments to homing and position limits in the configuration file, as well as support for a new camera model.

### Configuration Updates:

* [`software/configurations/configuration_Squid+_H117_ORCA.ini`](diffhunk://#diff-60d10781037ed93624c6ffe737893efe804d2cc1ed2a50885c749610a4f143e2L113-R113): Changed `homing_enabled_z` from `True` to `False`, and updated software position limits for X, Y, and Z axes to refine movement boundaries. [[1]](diffhunk://#diff-60d10781037ed93624c6ffe737893efe804d2cc1ed2a50885c749610a4f143e2L113-R113) [[2]](diffhunk://#diff-60d10781037ed93624c6ffe737893efe804d2cc1ed2a50885c749610a4f143e2L222-R227)

### Camera Compatibility:

* [`software/control/camera.py`](diffhunk://#diff-1f0ea86f2716d10c7fac39432a662c1ba9cb884c850a7f46602fbbc8805473f4R330): Added support for the `MER2-1220-32U3C` camera model by mapping it to the `IMX226` sensor.
* [`software/squid/config.py`](diffhunk://#diff-d721a332424b0a4636d89fa4bf1d5eb87817e778a9073dc2731cde5dcbfd8473R174): Extended the `GxipyCameraModel` enum to include the `MER2-1220-32U3C` camera model for compatibility with new hardware.