### PR TITLE
bug fix: illumination and exposure time for software triggered acquisition

### DIFF
--- a/software/control/camera_toupcam.py
+++ b/software/control/camera_toupcam.py
@@ -790,8 +790,8 @@ class ToupcamCamera(AbstractCamera):
                 error_type = hresult_checker(ex)
                 self._log.exception("Unable to set GPIO1 for trigger ready: " + error_type)
                 raise
-            # Re-set exposure time to force strobe to get set to the remote.
-            self.set_exposure_time(self.get_exposure_time())
+        # Re-set exposure time on trigger mode change.
+        self.set_exposure_time(self.get_exposure_time())
 
     def get_acquisition_mode(self) -> CameraAcquisitionMode:
         trigger_option_value = self._camera.get_Option(toupcam.TOUPCAM_OPTION_TRIGGER)

--- a/software/control/core/multi_point_worker.py
+++ b/software/control/core/multi_point_worker.py
@@ -583,7 +583,13 @@ class MultiPointWorker(QObject):
         )
         self._current_capture_info = current_capture_info
         self.camera.send_trigger(illumination_time=camera_illumination_time)
-        exposure_done_time = time.time() + self.camera.get_total_frame_time() / 1e3
+        if self.liveController.trigger_mode == TriggerMode.HARDWARE:
+            exposure_done_time = time.time() + self.camera.get_total_frame_time() / 1e3
+        else:
+            # For software trigger, add another strobe time to illuminate until the readout stage.
+            exposure_done_time = (
+                time.time() + (self.camera.get_total_frame_time() + self.camera.get_strobe_time()) / 1e3
+            )
         # Even though we can do overlapping triggers, we want to make sure that we don't move before our exposure
         # is done.  So we still need to at least sleep for the total frame time corresponding to this exposure.
         self._sleep(max(0.0, exposure_done_time - time.time()))


### PR DESCRIPTION
Tested with microscope (Toupcam)
- For software trigger, add another strobe time to illuminate until the readout stage.
- Update exposure time whenever trigger mode is switched (Toupcam)