### PR TITLE
bug fix: gui connections for selecting microscope mode

### DIFF
--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -1067,12 +1067,12 @@ class HighContentScreeningGui(QMainWindow):
             self.objectivesWidget.signal_objective_changed.connect(self.wellplateMultiPointWidget.update_coordinates)
 
         self.profileWidget.signal_profile_changed.connect(
-            lambda: self.liveControlWidget.update_microscope_mode_by_name(
+            lambda: self.liveControlWidget.select_new_microscope_mode_by_name(
                 self.liveControlWidget.currentConfiguration.name
             )
         )
         self.objectivesWidget.signal_objective_changed.connect(
-            lambda: self.liveControlWidget.update_microscope_mode_by_name(
+            lambda: self.liveControlWidget.select_new_microscope_mode_by_name(
                 self.liveControlWidget.currentConfiguration.name
             )
         )
@@ -1131,7 +1131,7 @@ class HighContentScreeningGui(QMainWindow):
                 self.channelConfigurationManager.toggle_confocal_widefield
             )
             self.spinningDiskConfocalWidget.signal_toggle_confocal_widefield.connect(
-                lambda: self.liveControlWidget.update_microscope_mode_by_name(
+                lambda: self.liveControlWidget.select_new_microscope_mode_by_name(
                     self.liveControlWidget.currentConfiguration.name
                 )
             )

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -1499,7 +1499,7 @@ class LiveControlWidget(QFrame):
         self.entry_displayFPS.valueChanged.connect(self.streamHandler.set_display_fps)
         self.slider_resolutionScaling.valueChanged.connect(self.streamHandler.set_display_resolution_scaling)
         self.slider_resolutionScaling.valueChanged.connect(self.liveController.set_display_resolution_scaling)
-        self.dropdown_modeSelection.activated.connect(self.select_new_microscope_mode_by_index)
+        self.dropdown_modeSelection.activated[str].connect(self.select_new_microscope_mode_by_name)
         self.dropdown_triggerManu.currentIndexChanged.connect(self.update_trigger_mode)
         self.btn_live.clicked.connect(self.toggle_live)
         self.entry_exposureTime.valueChanged.connect(self.update_config_exposure_time)
@@ -1598,8 +1598,7 @@ class LiveControlWidget(QFrame):
             self.update_ui_for_mode(first_config)
             self.liveController.set_microscope_mode(first_config)
 
-    def select_new_microscope_mode_by_index(self, config_index):
-        config_name = self.dropdown_modeSelection.itemText(config_index)
+    def select_new_microscope_mode_by_name(self, config_name):
         maybe_new_config = self.channelConfigurationManager.get_channel_configuration_by_name(
             self.objectiveStore.current_objective, config_name
         )


### PR DESCRIPTION
Tested in simulation mode

This pull request refactors the handling of microscope mode selection in the `software/control` module, replacing index-based selection with name-based selection for improved clarity and maintainability. The changes primarily affect signal connections and method definitions in the `gui_hcs.py` and `widgets.py` files.

### Refactoring microscope mode selection:

* **Signal connections updated to use name-based selection**:
  - In `gui_hcs.py`: Updated signal connections in `makeConnections` and `slot_settings_changed_laser_af` to use `select_new_microscope_mode_by_name` instead of `update_microscope_mode_by_name`. [[1]](diffhunk://#diff-b32c2c591f7e7074dc4393294e5993027fa1de4429b34dbf8e760d697b2c7219L1070-R1075) [[2]](diffhunk://#diff-b32c2c591f7e7074dc4393294e5993027fa1de4429b34dbf8e760d697b2c7219L1134-R1134)
  - In `widgets.py`: Modified the signal connection for `dropdown_modeSelection.activated` to use `select_new_microscope_mode_by_name` with the mode name as the parameter.

* **Method refactored to use name-based selection**:
  - In `widgets.py`: Replaced `select_new_microscope_mode_by_index` with `select_new_microscope_mode_by_name`, allowing mode selection by name instead of index.