### PR TITLE
show a dialog for confirmation on close

### DIFF
--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -1660,6 +1660,19 @@ class HighContentScreeningGui(QMainWindow):
         self.stage.move_y_to(y_mm)
 
     def closeEvent(self, event):
+        # Show confirmation dialog
+        reply = QMessageBox.question(
+            self,
+            "Confirm Exit",
+            "Are you sure you want to exit the software?",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+
+        if reply == QMessageBox.No:
+            event.ignore()
+            return
+
         try:
             squid.stage.utils.cache_position(pos=self.stage.get_pos(), stage_config=self.stage.get_config())
         except ValueError as e:


### PR DESCRIPTION
Tested in simulation mode

This pull request introduces a user-friendly enhancement to the `software/control/gui_hcs.py` file. Specifically, it adds a confirmation dialog to the `closeEvent` method to ensure users confirm their intent to exit the software.

User experience improvement:

* [`software/control/gui_hcs.py`](diffhunk://#diff-b32c2c591f7e7074dc4393294e5993027fa1de4429b34dbf8e760d697b2c7219R1663-R1675): Added a confirmation dialog in the `closeEvent` method to prompt users with a "Confirm Exit" message before closing the software. If the user selects "No," the event is ignored, preventing accidental exits.