### PR TITLE
add a button to show/hide well selector

### DIFF
--- a/software/control/core/core.py
+++ b/software/control/core/core.py
@@ -2959,7 +2959,6 @@ class ImageDisplayWindow(QMainWindow):
         status_layout.addWidget(QLabel(" | "))  # Add separator
         status_layout.addWidget(self.piezo_position_label)
         status_layout.addStretch()  # Push labels to the left
-        status_layout.addWidget(QLabel(" | "))  # Add separator
         status_layout.addWidget(self.btn_well_selector)  # Add well selector button
         status_layout.addWidget(QLabel(" | "))  # Add separator
         status_layout.addWidget(self.btn_line_profiler)  # Add line profiler button

--- a/software/control/core/core.py
+++ b/software/control/core/core.py
@@ -2946,6 +2946,10 @@ class ImageDisplayWindow(QMainWindow):
         self.btn_line_profiler.setEnabled(False)
         self.btn_line_profiler.clicked.connect(self.toggle_line_profiler)
 
+        # Add well selector toggle button
+        self.btn_well_selector = QPushButton("Show Well Selector")
+        self.btn_well_selector.setCheckable(False)
+
         # Add labels to status layout with spacing
         status_layout.addWidget(self.cursor_position_label)
         status_layout.addWidget(QLabel(" | "))  # Add separator
@@ -2956,7 +2960,9 @@ class ImageDisplayWindow(QMainWindow):
         status_layout.addWidget(self.piezo_position_label)
         status_layout.addStretch()  # Push labels to the left
         status_layout.addWidget(QLabel(" | "))  # Add separator
-        status_layout.addWidget(self.btn_line_profiler)  # Add button after stretch
+        status_layout.addWidget(self.btn_well_selector)  # Add well selector button
+        status_layout.addWidget(QLabel(" | "))  # Add separator
+        status_layout.addWidget(self.btn_line_profiler)  # Add line profiler button
 
         status_widget.setLayout(status_layout)
 


### PR DESCRIPTION
This pull request introduces a new "Well Selector" feature to the application's user interface. The changes include adding a toggle button for the Well Selector, updating its visibility logic based on the active tab and acquisition state, and ensuring its state is preserved across tab switches. The most important changes are grouped into UI enhancements and logic updates.

### UI Enhancements:
* Added a new toggle button `btn_well_selector` in `software/control/core/core.py` to allow users to show or hide the Well Selector. The button is integrated into the status layout alongside existing controls. [[1]](diffhunk://#diff-2fc90167f3cd3e8a6b36bdd78086c6ae5811054d9f87239fa2fe2b3a8858d691R2949-R2952) [[2]](diffhunk://#diff-2fc90167f3cd3e8a6b36bdd78086c6ae5811054d9f87239fa2fe2b3a8858d691L2959-R2965)

### Logic Updates:
* Introduced a `well_selector_visible` attribute in `software/control/gui_hcs.py` to track the Well Selector's visibility state.
* Updated the `toggleWellSelector` method to include a `remember_state` parameter, ensuring the visibility state is preserved only in the "Live View" tab and updated the button text dynamically based on visibility.
* Modified tab-switching logic in `onDisplayTabChanged` to restore the Well Selector's visibility state when returning to the "Live View" tab.
* Adjusted acquisition start logic in `toggleAcquisitionStart` to toggle the Well Selector without updating its stored visibility state.