### PR TITLE
line profiler - keep manual range if manual range is specified

### DIFF
--- a/software/control/core/core.py
+++ b/software/control/core/core.py
@@ -3035,6 +3035,7 @@ class ImageDisplayWindow(QMainWindow):
         self.line_profiler_plot.setLabel("left", "Intensity")
         self.line_profiler_plot.setLabel("bottom", "Position")
         self.line_profiler_widget.hide()  # Initially hidden
+        self.line_profiler_manual_range = False  # Flag to track if y-range is manually set
 
         # Create splitter
         self.splitter = QSplitter(Qt.Vertical)
@@ -3139,6 +3140,13 @@ class ImageDisplayWindow(QMainWindow):
             else:
                 self.graphics_widget.view.setCursor(self.normal_cursor)
 
+        # Connect to the view range changed signal to detect manual range changes
+        self.line_profiler_plot.sigRangeChanged.connect(self._on_range_changed)
+
+    def _on_range_changed(self, view_range):
+        """Handle manual range changes in the line profiler plot."""
+        self.line_profiler_manual_range = True
+
     def create_line_roi(self):
         """Create a line ROI for intensity profiling."""
         if self.line_roi is None and self.line_start_pos is not None and self.line_end_pos is not None:
@@ -3221,8 +3229,9 @@ class ImageDisplayWindow(QMainWindow):
                     # Add legend
                     self.line_profiler_plot.addLegend()
 
-                    # Auto-scale the plot
-                    self.line_profiler_plot.autoRange()
+                    # Only auto-range if not manually set
+                    if not self.line_profiler_manual_range:
+                        self.line_profiler_plot.autoRange()
         except Exception as e:
             self._log.error(f"Error updating line profile: {str(e)}")
 


### PR DESCRIPTION
This pull request introduces enhancements to the line profiler functionality in `software/control/core/core.py`, including the addition of a flag to track manual y-range adjustments and logic to prevent auto-scaling when the range is manually set.

### Line profiler functionality enhancements:

* [`software/control/core/core.py`](diffhunk://#diff-2fc90167f3cd3e8a6b36bdd78086c6ae5811054d9f87239fa2fe2b3a8858d691R3038): Added the `line_profiler_manual_range` flag in the `__init__` method to track whether the y-range of the line profiler plot is manually adjusted.
* [`software/control/core/core.py`](diffhunk://#diff-2fc90167f3cd3e8a6b36bdd78086c6ae5811054d9f87239fa2fe2b3a8858d691R3143-R3149): Connected the `sigRangeChanged` signal of the `line_profiler_plot` to a new `_on_range_changed` method in `toggle_line_profiler`. This method sets the `line_profiler_manual_range` flag to `True` when the range is manually changed.
* [`software/control/core/core.py`](diffhunk://#diff-2fc90167f3cd3e8a6b36bdd78086c6ae5811054d9f87239fa2fe2b3a8858d691L3224-R3233): Updated the `update_line_profile` method to conditionally auto-range the plot only if the `line_profiler_manual_range` flag is not set.