### PR TITLE
use characterization mode when laser af is not enabled

### DIFF
--- a/software/control/core/multi_point_worker.py
+++ b/software/control/core/multi_point_worker.py
@@ -392,7 +392,10 @@ class MultiPointWorker(QObject):
             self._log.info(f"Acquiring image: ID={file_ID}, Metadata={metadata}")
 
             # laser af characterization mode
-            if self.do_reflection_af and self.microscope.laserAutofocusController.characterization_mode:
+            if (
+                self.microscope.laserAutofocusController
+                and self.microscope.laserAutofocusController.characterization_mode
+            ):
                 image = self.microscope.laserAutofocusController.get_image()
                 saving_path = os.path.join(current_path, file_ID + "_laser af camera" + ".bmp")
                 iio.imwrite(saving_path, image)


### PR DESCRIPTION
This pull request includes a fix to the `acquire_at_position` method in `multi_point_worker.py`. The change removes the requirement of `self.do_reflection_af` flag so we can save characterization images when laser AF is not enabled.
Tested in simulation mode.