### PR TITLE
startup xy and objective switcher sequence update

### DIFF
--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -1705,6 +1705,13 @@ class HighContentScreeningGui(QMainWindow):
         self.camera.stop_streaming()
         self.camera.close()
 
+        # retract z
+        self.stage.move_z_to(0.1)
+
+        # reset objective changer
+        if USE_XERYON:
+            self.objective_changer.moveToZero()
+
         self.microcontroller.turn_off_all_pid()
 
         if ENABLE_CELLX:

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -522,14 +522,13 @@ class HighContentScreeningGui(QMainWindow):
                 # in that case, we drive off of the loading position and the clamp closes quickly.
                 # This doesn't seem to cause problems, and there isn't a clean way to avoid the corner
                 # case.
-                self.log.info("Moving y+20, then x->home->+20 to make sure system is clear for homing.")
+                self.log.info("Moving y+20, then x->home->+50 to make sure system is clear for homing.")
                 self.stage.move_y(20)
                 self.stage.home(x=True, y=False, z=False, theta=False)
-                self.stage.move_x(20)
+                self.stage.move_x(50)
 
-                self.log.info("Homing the X and Y axes...")
+                self.log.info("Homing the Y axis...")
                 self.stage.home(x=False, y=True, z=False, theta=False)
-                self.stage.home(x=True, y=False, z=False, theta=False)
                 self.slidePositionController.homing_done = True
             if USE_ZABER_EMISSION_FILTER_WHEEL:
                 self.emission_filter_wheel.wait_for_homing_complete()

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -570,9 +570,9 @@ class HighContentScreeningGui(QMainWindow):
             self.objective_changer.home()
             self.objective_changer.setSpeed(XERYON_SPEED)
             if DEFAULT_OBJECTIVE in XERYON_OBJECTIVE_SWITCHER_POS_1:
-                self.objective_changer.moveToPosition1()
+                self.objective_changer.moveToPosition1(move_z=False)
             elif DEFAULT_OBJECTIVE in XERYON_OBJECTIVE_SWITCHER_POS_2:
-                self.objective_changer.moveToPosition2()
+                self.objective_changer.moveToPosition2(move_z=False)
 
     def waitForMicrocontroller(self, timeout=5.0, error_message=None):
         try:

--- a/software/control/objective_changer_2_pos_controller.py
+++ b/software/control/objective_changer_2_pos_controller.py
@@ -31,6 +31,10 @@ class ObjectiveChanger2PosController:
     def home(self):
         self.axisX.findIndex()
 
+    def moveToZero(self):
+        self.axisX.setDPOS(0)
+        self.current_position = 0
+
     def moveToPosition1(self, move_z=True):
         self.axisX.setDPOS(self.position1)
         if self.stage is not None and self.current_position == 2 and self.retracted:

--- a/software/control/objective_changer_2_pos_controller.py
+++ b/software/control/objective_changer_2_pos_controller.py
@@ -31,19 +31,21 @@ class ObjectiveChanger2PosController:
     def home(self):
         self.axisX.findIndex()
 
-    def moveToPosition1(self):
+    def moveToPosition1(self, move_z=True):
         self.axisX.setDPOS(self.position1)
         if self.stage is not None and self.current_position == 2 and self.retracted:
             # revert retracting z by self.position2_offset
-            self.stage.move_z(self.position2_offset)
+            if move_z:
+                self.stage.move_z(self.position2_offset)
             self.retracted = False
         self.current_position = 1
 
-    def moveToPosition2(self):
+    def moveToPosition2(self, move_z=True):
         self.axisX.setDPOS(self.position2)
         if self.stage is not None and self.current_position == 1:
             # retract z by self.position2_offset
-            self.stage.move_z(-self.position2_offset)
+            if move_z:
+                self.stage.move_z(-self.position2_offset)
             self.retracted = True
         self.current_position = 2
 
@@ -71,14 +73,14 @@ class ObjectiveChanger2PosController_Simulation:
     def home(self):
         pass
 
-    def moveToPosition1(self):
+    def moveToPosition1(self, move_z=True):
         if self.stage is not None and self.current_position == 2 and self.retracted:
             # revert retracting z by self.position2_offset
             self.stage.move_z(self.position2_offset)
             self.retracted = False
         self.current_position = 1
 
-    def moveToPosition2(self):
+    def moveToPosition2(self, move_z=True):
         if self.stage is not None and self.current_position == 1:
             # retract z by self.position2_offset
             self.stage.move_z(-self.position2_offset)


### PR DESCRIPTION
This pull request includes updates to the hardware setup and objective changer logic in the `software/control` module to improve system behavior and add new functionality. Key changes include adjustments to movement parameters, the introduction of optional `move_z` functionality, and new methods for resetting the objective changer.

### Updates to hardware setup:

* [`software/control/gui_hcs.py`](diffhunk://#diff-b32c2c591f7e7074dc4393294e5993027fa1de4429b34dbf8e760d697b2c7219L525-L532): Adjusted movement parameters during hardware setup to ensure adequate clearance for homing operations. Specifically, the x-axis movement was increased from 20 to 50 units. Additionally, the homing process now excludes the x-axis for improved efficiency.

### Updates to objective changer logic:

* [`software/control/gui_hcs.py`](diffhunk://#diff-b32c2c591f7e7074dc4393294e5993027fa1de4429b34dbf8e760d697b2c7219L573-R574): Updated calls to `moveToPosition1` and `moveToPosition2` to include the new `move_z` parameter, allowing for conditional movement of the z-axis during objective switching.
* [`software/control/objective_changer_2_pos_controller.py`](diffhunk://#diff-2dcdba9fa63adde62a55121385811c29e8ce606da2c1e3d8c6eb4d73d51333a0L34-R51): Added a new method `moveToZero` to reset the objective changer to its zero position. Updated `moveToPosition1` and `moveToPosition2` methods to include the optional `move_z` parameter, enabling finer control over z-axis movement during position changes.

### New functionality for system shutdown:

* [`software/control/gui_hcs.py`](diffhunk://#diff-b32c2c591f7e7074dc4393294e5993027fa1de4429b34dbf8e760d697b2c7219R1707-R1713): Added logic to retract the z-axis and reset the objective changer to its zero position during system shutdown. This ensures the hardware is in a safe state when closing the application.