### PR TITLE
gui: Make sure laser af attribs are set to none

### DIFF
--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -313,6 +313,12 @@ class HighContentScreeningGui(QMainWindow):
                 self.objectiveStore,
                 self.laserAFSettingManager,
             )
+        else:
+            self.liveController_focus_camera = None
+            self.streamHandler_focus_camera = None
+            self.imageDisplayWindow_focus = None
+            self.displacementMeasurementController = None
+            self.laserAutofocusController = None
 
         if USE_SQUID_FILTERWHEEL:
             self.squid_filter_wheel = filterwheel.SquidFilterWheelWrapper(self.microcontroller)


### PR DESCRIPTION
#273 introduced a check for the presence of the laser af controller, but we didn't always set that attribute to `None` on the gui.  This fixes that (and also `None`s the other relevant).

Tested by: On system testing, and unit tests.