### PR TITLE
cameras: default: fix strobe and exposure

### DIFF
--- a/software/control/camera.py
+++ b/software/control/camera.py
@@ -79,7 +79,7 @@ class DefaultCamera(AbstractCamera):
                 and camera.BalanceRatioSelector.is_writable()
             ),
             auto_white_balance=(camera.BalanceWhiteAuto.is_implemented() and camera.BalanceWhiteAuto.is_writable()),
-            is_global_shutter=False
+            is_global_shutter=False,
         )
 
         # NOTE(imo): In our previous driver, we did all these as defaults/prep to make things down the line work.
@@ -223,7 +223,7 @@ class DefaultCamera(AbstractCamera):
 
         self._log.debug(
             f"Setting exposure time {exposure_time_calculated_us} [us] for exposure_time={exposure_time_ms * 1000} [us] and strobe={self._strobe_delay_us} [us]"
-        ) 
+        )
         self._camera.ExposureTime.set(exposure_time_calculated_us)
         self._exposure_time_ms = exposure_time_ms
 

--- a/software/control/camera.py
+++ b/software/control/camera.py
@@ -204,7 +204,7 @@ class DefaultCamera(AbstractCamera):
         row_count = self.get_resolution()[1]  # TODO: this should be the row count after setting ROI
         row_period_us = 10
 
-        self._strobe_delay_us = (
+        self._strobe_delay_us = 10000 + (
             exposure_delay_us + exposure_time_us + row_period_us * pixel_size_bytes * (row_count - 1) + 500
         )
 
@@ -215,10 +215,13 @@ class DefaultCamera(AbstractCamera):
         exposure_time_calculated_us = 1000.0 * exposure_time_ms
         if not self._capabilities.is_global_shutter:
             self._update_strobe_time()
-            exposure_time_calculated_us += self._strobe_delay_us
+
         self._log.debug(
             f"Setting exposure time {exposure_time_calculated_us} [us] for exposure_time={exposure_time_ms * 1000} [us] and strobe={self._strobe_delay_us} [us]"
         )
+        # The camera exposure time is the actual per-row exposure time we want, not including the strobe delay.  If this
+        # is not a global shutter camera, the frame time will actually be longer than this (and so illumination should use
+        # fram time, not exposure time).  
         self._camera.ExposureTime.set(exposure_time_calculated_us)
         self._exposure_time_ms = exposure_time_ms
 


### PR DESCRIPTION
Before, we weren't updating the strobe delay properly and we were setting the camera exposure time incorrectly in the software trigger case.  

This fixes both of those.

We still observed issues with early-row darkness when using hardware triggering, and some potential timing issues related to hardware triggering in live mode.  Although those seem like separate issues (aka: the fixes here are definitely needed!).

Tested by: acquisitions on an octopi with both software and hardware triggering.