### PR TITLE
cameras: toupcam: fix timing to respect camera "trigger delay" and fix hardware triggering

### DIFF
--- a/software/control/camera_toupcam.py
+++ b/software/control/camera_toupcam.py
@@ -438,7 +438,7 @@ class ToupcamCamera(AbstractCamera):
             # Only add the strobe_time_us, and not strobe_time_us + trigger_delay_us.  We'll tell the lighting
             # to come on at strobe_time_us + trigger_delay_us since that's when the common (all row) exposure time
             # starts, but if we tell that to the camera we'll get an extra trigger_delay_us of exposure.
-            exposure_for_camera_us += self._strobe_info.strobe_time_us
+            exposure_for_camera_us += int(self._strobe_info.strobe_time_us)
 
         self._log.debug(
             f"Sending exposure {exposure_for_camera_us} [us] to camera for exposure_time={1000 * exposure_time} [us]"

--- a/software/control/camera_toupcam.py
+++ b/software/control/camera_toupcam.py
@@ -445,10 +445,10 @@ class ToupcamCamera(AbstractCamera):
 
         return exposure_for_camera_ms
 
-    def _calculate_and_set_camera_exposure_time(self, image_exposure_time_us):
-        exposure_for_camera_us = self._calculate_camera_exposure_time(image_exposure_time_us) * 1000.0
+    def _calculate_and_set_camera_exposure_time(self, image_exposure_time_ms):
+        exposure_for_camera_us = int(self._calculate_camera_exposure_time(image_exposure_time_ms) * 1000.0)
         self._log.debug(
-            f"Sending exposure {exposure_for_camera_us} [us] to camera for exposure_time={1000 * image_exposure_time_us} [us]"
+            f"Sending exposure {exposure_for_camera_us} [us] to camera for image_exposure_time={1000 * image_exposure_time_ms} [us]"
         )
         self._camera.put_ExpoTime(exposure_for_camera_us)
 

--- a/software/control/camera_toupcam.py
+++ b/software/control/camera_toupcam.py
@@ -356,7 +356,7 @@ class ToupcamCamera(AbstractCamera):
             capabilities=self._capabilities,
         )
         if self._hw_set_strobe_delay_ms_fn:
-            self._hw_set_strobe_delay_ms_fn(self._strobe_info.delay_us / 1000.0)
+            self._hw_set_strobe_delay_ms_fn(self.get_strobe_time() / 1000.0)
 
         if send_exposure:
             self.set_exposure_time(exposure_time_ms)


### PR DESCRIPTION
This is a two fold change.  First, the toupcam has a "trigger delay" that depends on the exposure time, capture dimensions, etc.  We weren't calculating and using this before.  The attached diagram outlines the issue.

So, with this, we now:
For Software Triggering:
1. Send the camera the raw exposure time in ms for its exposure_time.
2. Turn on illumination right before we send the software trigger.
3. Turn off illumination after trigger_delay + strobe_time + exposure_time.

This results in all rows getting exposure_time of illumination while capturing data.

For Hardware Triggering:
1. Send the camera exposure_time + strobe_delay for exposure time
2. Use exposure_time + strobe_delay to calculate trigger_delay
3. Send the microcontroller exposure_time for illumination time
4. Send the microcontroller strobe_delay + trigger_delay for strobe delay so illumination comes on strobe_delay + trigger_delay after the hw trigger, and stays on for exposure_time

One of the keys in there is calculating trigger_delay using the correct exposure time (exposure_time for SW trigger, exposure_time + strobe_delay for HW trigger).

![image_123650291 (3)](https://github.com/user-attachments/assets/5f8f072e-3fa5-4a04-b6e1-8e87237b084d)

There was also a bug in ms -> us conversion that needed fixing.

Tested by: Tested on a system with a toupcam and both hw and software trigger setup.