### PR TITLE
MultiPointWorker: protect against in flight triggering

### DIFF
--- a/software/control/core/multi_point_worker.py
+++ b/software/control/core/multi_point_worker.py
@@ -501,6 +501,10 @@ class MultiPointWorker(QObject):
 
     def _image_callback(self, camera_frame: CameraFrame):
         try:
+            if self._ready_for_next_trigger.is_set():
+                self._log.warning("Got an image in the image callback, but we didn't send a trigger.  Ignoring the image.")
+                return
+
             self._image_callback_idle.clear()
             with self._timing.get_timer("_image_callback"):
                 self._log.debug(f"In Image callback for frame_id={camera_frame.frame_id}")

--- a/software/control/core/multi_point_worker.py
+++ b/software/control/core/multi_point_worker.py
@@ -502,7 +502,9 @@ class MultiPointWorker(QObject):
     def _image_callback(self, camera_frame: CameraFrame):
         try:
             if self._ready_for_next_trigger.is_set():
-                self._log.warning("Got an image in the image callback, but we didn't send a trigger.  Ignoring the image.")
+                self._log.warning(
+                    "Got an image in the image callback, but we didn't send a trigger.  Ignoring the image."
+                )
                 return
 
             self._image_callback_idle.clear()


### PR DESCRIPTION
See title.  This is maybe not the exact right fix, but it does work.  The issue is that the QTimer might be running its callback when we stop, so one image may sneak through.  This can then get into the callback at acquisition start (and so you get an error about capture info not existing at the start of an acquisition).

Tested by: Running a bunch of acquisitions with live mode enabled to start, and observing the WARNING prints.