### PR TITLE
multi process jobs: Add in a job and job runner mechanism for processing images on separate processes

### DIFF
--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -78,7 +78,7 @@ class Acquisition:
     DZ = 1.5
     NX = 1
     NY = 1
-    USE_MULTIPROCESSING = False
+    USE_MULTIPROCESSING = True
 
 
 class PosUpdate:

--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -78,6 +78,7 @@ class Acquisition:
     DZ = 1.5
     NX = 1
     NY = 1
+    USE_MULTIPROCESSING = False
 
 
 class PosUpdate:

--- a/software/control/camera_toupcam.py
+++ b/software/control/camera_toupcam.py
@@ -438,7 +438,7 @@ class ToupcamCamera(AbstractCamera):
             # Only add the strobe_time_us, and not strobe_time_us + trigger_delay_us.  We'll tell the lighting
             # to come on at strobe_time_us + trigger_delay_us since that's when the common (all row) exposure time
             # starts, but if we tell that to the camera we'll get an extra trigger_delay_us of exposure.
-            exposure_for_camera_us += self._strobe_info.strobe_time_us
+            exposure_for_camera_us += int(self._strobe_info.strobe_time_us)
 
         self._log.debug(
             f"Sending exposure {exposure_for_camera_us} [us] to camera for exposure_time={1000 * exposure_time} [us]"

--- a/software/control/camera_toupcam.py
+++ b/software/control/camera_toupcam.py
@@ -445,10 +445,10 @@ class ToupcamCamera(AbstractCamera):
 
         return exposure_for_camera_ms
 
-    def _calculate_and_set_camera_exposure_time(self, image_exposure_time_us):
-        exposure_for_camera_us = self._calculate_camera_exposure_time(image_exposure_time_us) * 1000.0
+    def _calculate_and_set_camera_exposure_time(self, image_exposure_time_ms):
+        exposure_for_camera_us = int(self._calculate_camera_exposure_time(image_exposure_time_ms) * 1000.0)
         self._log.debug(
-            f"Sending exposure {exposure_for_camera_us} [us] to camera for exposure_time={1000 * image_exposure_time_us} [us]"
+            f"Sending exposure {exposure_for_camera_us} [us] to camera for image_exposure_time={1000 * image_exposure_time_ms} [us]"
         )
         self._camera.put_ExpoTime(exposure_for_camera_us)
 

--- a/software/control/camera_toupcam.py
+++ b/software/control/camera_toupcam.py
@@ -356,7 +356,7 @@ class ToupcamCamera(AbstractCamera):
             capabilities=self._capabilities,
         )
         if self._hw_set_strobe_delay_ms_fn:
-            self._hw_set_strobe_delay_ms_fn(self._strobe_info.delay_us / 1000.0)
+            self._hw_set_strobe_delay_ms_fn(self.get_strobe_time() / 1000.0)
 
         if send_exposure:
             self.set_exposure_time(exposure_time_ms)

--- a/software/control/core/job_processing.py
+++ b/software/control/core/job_processing.py
@@ -31,11 +31,15 @@ class CaptureInfo:
     fov: int
     configuration_idx: int
 
+
 @dataclass()
 class JobImage:
     image_array: Optional[np.array]
 
+
 T = TypeVar("T")
+
+
 @dataclass
 class Job(abc.ABC, Generic[T]):
     capture_info: CaptureInfo
@@ -57,11 +61,13 @@ class Job(abc.ABC, Generic[T]):
     def run(self) -> T:
         raise NotImplementedError("You must implement run for your job type.")
 
+
 @dataclass
 class JobResult(Generic[T]):
     job_id: str
     result: Optional[T]
     exception: Optional[Exception]
+
 
 class SaveImageJob(Job):
     def run(self) -> bool:
@@ -100,6 +106,7 @@ class SaveImageJob(Job):
                 raise NotImplementedError("Image merging not supported yet")
 
         return True
+
 
 class JobRunner(multiprocessing.Process):
     def __init__(self):

--- a/software/control/core/job_processing.py
+++ b/software/control/core/job_processing.py
@@ -1,0 +1,145 @@
+import abc
+import multiprocessing
+import queue
+import os
+from typing import Optional, Generic, TypeVar
+from uuid import uuid4
+
+from dataclasses import dataclass
+
+import imageio as iio
+import numpy as np
+from tifffile import tifffile
+
+from control import _def, utils_acquisition
+import squid.abc
+import squid.logging
+from control.utils_config import ChannelMode
+
+
+# NOTE(imo): We want this to be fast.  But pydantic does not support numpy serialization natively, which means
+# that we need a custom serializer (which will be slow!).  So, use dataclass here instead.
+@dataclass
+class CaptureInfo:
+    position: squid.abc.Pos
+    z_index: int
+    capture_time: float
+    configuration: ChannelMode
+    save_directory: str
+    file_id: str
+    region_id: int
+    fov: int
+    configuration_idx: int
+
+@dataclass()
+class JobImage:
+    image_array: Optional[np.array]
+
+T = TypeVar("T")
+@dataclass
+class Job(abc.ABC, Generic[T]):
+    capture_info: CaptureInfo
+    capture_image: JobImage
+
+    _id: str = str(uuid4())
+
+    @property
+    def job_id(self) -> str:
+        return self._id
+
+    def image_array(self) -> np.array:
+        if self.capture_image.image_array is not None:
+            return self.capture_image.image_array
+
+        raise NotImplementedError("Only np array JobImages are supported right now.")
+
+    @abc.abstractmethod
+    def run(self) -> T:
+        raise NotImplementedError("You must implement run for your job type.")
+
+@dataclass
+class JobResult(Generic[T]):
+    job_id: str
+    result: Optional[T]
+    exception: Optional[Exception]
+
+class SaveImageJob(Job):
+    def run(self) -> bool:
+        is_color = len(self.image_array().shape) > 2
+        return self.save_image(self.image_array(), self.capture_info, is_color)
+
+    def save_image(self, image: np.array, info: CaptureInfo, is_color: bool):
+        # NOTE(imo): We silently fall back to individual image saving here.  We should warn or do something.
+        if _def.FILE_SAVING_OPTION == _def.FileSavingOption.MULTI_PAGE_TIFF:
+            metadata = {
+                "z_level": info.z_index,
+                "channel": info.configuration.name,
+                "channel_index": info.configuration_idx,
+                "region_id": info.region_id,
+                "fov": info.fov,
+                "x_mm": info.position.x_mm,
+                "y_mm": info.position.y_mm,
+                "z_mm": info.position.z_mm,
+            }
+            output_path = os.path.join(
+                info.save_directory, f"{info.region_id}_{info.fov:0{_def.FILE_ID_PADDING}}_stack.tiff"
+            )
+            with tifffile.TiffWriter(output_path, append=True) as tiff_writer:
+                tiff_writer.write(image, metadata=metadata)
+        else:
+            saved_image = utils_acquisition.save_image(
+                image=image,
+                file_id=info.file_id,
+                save_directory=info.save_directory,
+                config=info.configuration,
+                is_color=is_color,
+            )
+
+            if _def.MERGE_CHANNELS:
+                # TODO(imo): Add this back in
+                raise NotImplementedError("Image merging not supported yet")
+
+        return True
+
+class JobRunner(multiprocessing.Process):
+    def __init__(self):
+        super().__init__()
+        self._log = squid.logging.get_logger(__class__.__name__)
+
+        self._input_queue: multiprocessing.Queue = multiprocessing.Queue()
+        self._input_timeout = 1.0
+        self._output_queue: multiprocessing.Queue = multiprocessing.Queue()
+        self._shutdown_event: multiprocessing.Event = multiprocessing.Event()
+
+    def dispatch(self, job: Job):
+        self._input_queue.put_nowait(job)
+
+        return True
+
+    def output_queue(self) -> multiprocessing.Queue:
+        return self._output_queue
+
+    def has_pending(self):
+        return not self._input_queue.empty()
+
+    def shutdown(self, timeout_s=1.0):
+        self._shutdown_event.set()
+        self.join(timeout=timeout_s)
+
+    def run(self):
+        while not self._shutdown_event.is_set():
+            job = None
+            try:
+                job = self._input_queue.get(timeout=self._input_timeout)
+                self._log.info(f"Running job {job.job_id}...")
+                result = job.run()
+                self._log.info(f"Job {job.job_id} returned. Sending result to output queue.")
+                self._output_queue.put_nowait(JobResult(job_id=job.job_id, result=result, exception=None))
+                self._log.debug(f"Result for {job.job_id} is on output queue.")
+            except queue.Empty:
+                pass
+            except Exception as e:
+                if job:
+                    self._log.exception(f"Job {job.job_id} failed! Returning exception result.")
+                    self._output_queue.put_nowait(JobResult(job_id=job.job_id, result=None, exception=e))
+        self._log.info("Shutdown request received, exiting run.")

--- a/software/control/core/multi_point_worker.py
+++ b/software/control/core/multi_point_worker.py
@@ -501,6 +501,10 @@ class MultiPointWorker(QObject):
 
     def _image_callback(self, camera_frame: CameraFrame):
         try:
+            if self._ready_for_next_trigger.is_set():
+                self._log.warning("Got an image in the image callback, but we didn't send a trigger.  Ignoring the image.")
+                return
+
             self._image_callback_idle.clear()
             with self._timing.get_timer("_image_callback"):
                 self._log.debug(f"In Image callback for frame_id={camera_frame.frame_id}")

--- a/software/control/core/multi_point_worker.py
+++ b/software/control/core/multi_point_worker.py
@@ -144,7 +144,6 @@ class MultiPointWorker(QObject):
                 job_runner.start()
             self._job_runners.append((job_class, job_runner))
 
-
     def update_use_piezo(self, value):
         self.use_piezo = value
         self._log.info(f"MultiPointWorker: updated use_piezo to {value}")
@@ -235,7 +234,9 @@ class MultiPointWorker(QObject):
         self._image_callback_idle.set()
 
     def _finish_jobs(self, timeout_s=10):
-        self._log.info(f"Waiting for jobs to finish on {len(self._job_runners)} job runners before shutting them down...")
+        self._log.info(
+            f"Waiting for jobs to finish on {len(self._job_runners)} job runners before shutting them down..."
+        )
         timeout_time = time.time() + timeout_s
 
         def timed_out():
@@ -244,13 +245,15 @@ class MultiPointWorker(QObject):
         def time_left():
             return max(timeout_time - time.time(), 0)
 
-        for (job_class, job_runner) in self._job_runners:
+        for job_class, job_runner in self._job_runners:
             if job_runner is not None:
                 while job_runner.has_pending():
                     if not timed_out():
                         time.sleep(0.1)
                     else:
-                        self._log.error(f"Timed out after {timeout_s} [s] waiting for jobs to finish.  Pending jobs for {job_class.__name__} abandoned!!!")
+                        self._log.error(
+                            f"Timed out after {timeout_s} [s] waiting for jobs to finish.  Pending jobs for {job_class.__name__} abandoned!!!"
+                        )
                         job_runner.kill()
 
                 self._log.info("Trying to shut down job runner...")
@@ -381,7 +384,7 @@ class MultiPointWorker(QObject):
         self._sleep(SCAN_STABILIZATION_TIME_MS_Z / 1000)
 
     def _summarize_runner_outputs(self):
-        for (job_class, job_runner) in self._job_runners:
+        for job_class, job_runner in self._job_runners:
             if job_runner is None:
                 continue
             out_queue = job_runner.output_queue()
@@ -585,7 +588,7 @@ class MultiPointWorker(QObject):
                     return
 
                 with self._timing.get_timer("job creation and dispatch"):
-                    for (job_class, job_runner) in self._job_runners:
+                    for job_class, job_runner in self._job_runners:
                         job = job_class(capture_info=info, capture_image=JobImage(image_array=image))
                         if job_runner is not None:
                             if not job_runner.dispatch(job):

--- a/software/control/core/multi_point_worker.py
+++ b/software/control/core/multi_point_worker.py
@@ -593,8 +593,12 @@ class MultiPointWorker(QObject):
                                 self.multiPointController.request_abort_aquisition()
                                 return
                         else:
-                            result = job.run()
-                            if not self._summarize_job_result(result):
+                            try:
+                                # NOTE(imo): We don't have any way of people using results, so for now just
+                                # grab and ignore it.
+                                result = job.run()
+                            except Exception:
+                                self._log.exception("Failed to execute job, abandoning acquisition!")
                                 self.multiPointController.request_abort_aquisition()
                                 return
 

--- a/software/control/core/multi_point_worker.py
+++ b/software/control/core/multi_point_worker.py
@@ -502,7 +502,9 @@ class MultiPointWorker(QObject):
     def _image_callback(self, camera_frame: CameraFrame):
         try:
             if self._ready_for_next_trigger.is_set():
-                self._log.warning("Got an image in the image callback, but we didn't send a trigger.  Ignoring the image.")
+                self._log.warning(
+                    "Got an image in the image callback, but we didn't send a trigger.  Ignoring the image."
+                )
                 return
 
             self._image_callback_idle.clear()

--- a/software/control/core/multi_point_worker.py
+++ b/software/control/core/multi_point_worker.py
@@ -1,12 +1,14 @@
 import os
+import queue
 import threading
 import time
-from typing import List, Optional
+from typing import List, Optional, Tuple, Type
 from dataclasses import dataclass
 from datetime import datetime
 
 import cv2
 import imageio as iio
+import pydantic
 import tifffile
 import numpy as np
 from numpy.typing import NDArray
@@ -24,6 +26,8 @@ from control.piezo import PiezoStage
 from control.utils_config import ChannelMode
 from squid.abc import AbstractCamera, CameraFrame
 import squid.logging
+import control.core.job_processing
+from control.core.job_processing import CaptureInfo, SaveImageJob, Job, JobImage, JobRunner, JobResult
 
 try:
     from control.multipoint_custom_script_entry_v2 import *
@@ -31,19 +35,6 @@ try:
     print("custom multipoint script found")
 except:
     pass
-
-
-@dataclass
-class CaptureInfo:
-    position: squid.abc.Pos
-    z_index: int
-    capture_time: float
-    configuration: ChannelMode
-    save_directory: str
-    file_id: str
-    region_id: int
-    fov: int
-    configuration_idx: int
 
 
 class MultiPointWorker(QObject):
@@ -62,7 +53,7 @@ class MultiPointWorker(QObject):
     signal_acquisition_progress = Signal(int, int, int)
     signal_region_progress = Signal(int, int)
 
-    def __init__(self, multiPointController):
+    def __init__(self, multiPointController, extra_job_classes: list[type[Job]] | None = None):
         QObject.__init__(self)
         self.multiPointController = multiPointController
         self._log = squid.logging.get_logger(__class__.__name__)
@@ -136,6 +127,22 @@ class MultiPointWorker(QObject):
         # This is only touched via the image callback path.  Don't touch it outside of there!
         self._current_round_images = {}
 
+        job_classes = [SaveImageJob]
+        if extra_job_classes:
+            job_classes.extend(extra_job_classes)
+
+        # For now, use 1 runner per job class.  There's no real reason/rationale behind this, though.  The runners
+        # can all run any job type.  But 1 per is a reasonable arbitrary arrangement while we don't have a lot
+        # of job types.  If we have a lot of custom jobs, this could cause problems via resource hogging.
+        self._job_runners: List[Tuple[Type[Job], JobRunner]] = []
+        for job_class in job_classes:
+            self._log.info(f"Creating job runner for {job_class.__name__} jobs")
+            job_runner = control.core.job_processing.JobRunner()
+            job_runner.daemon = True
+            job_runner.start()
+            self._job_runners.append((job_class, job_runner))
+
+
     def update_use_piezo(self, value):
         self.use_piezo = value
         self._log.info(f"MultiPointWorker: updated use_piezo to {value}")
@@ -207,6 +214,8 @@ class MultiPointWorker(QObject):
             self._log.debug(self._timing.get_report())
             if this_image_callback_id:
                 self.camera.remove_frame_callback(this_image_callback_id)
+
+            self._finish_jobs()
         if not self.headless:
             self.finished.emit()
 
@@ -222,6 +231,27 @@ class MultiPointWorker(QObject):
         # No matter what, set the flags so things can continue
         self._ready_for_next_trigger.set()
         self._image_callback_idle.set()
+
+    def _finish_jobs(self, timeout_s=10):
+        self._log.info(f"Waiting for jobs to finish on {len(self._job_runners)} job runners before shutting them down...")
+        timeout_time = time.time() + timeout_s
+
+        def timed_out():
+            return time.time() > timeout_time
+
+        def time_left():
+            return max(timeout_time - time.time(), 0)
+
+        for (job_class, job_runner) in self._job_runners:
+            while job_runner.has_pending():
+                if not timed_out():
+                    time.sleep(0.1)
+                else:
+                    self._log.error(f"Timed out after {timeout_s} [s] waiting for jobs to finish.  Pending jobs for {job_class.__name__} abandoned!!!")
+                    job_runner.kill()
+
+            self._log.info("Trying to shut down job runner...")
+            job_runner.shutdown(time_left())
 
     def wait_till_operation_is_completed(self):
         self.microcontroller.wait_till_operation_is_completed()
@@ -358,6 +388,19 @@ class MultiPointWorker(QObject):
             self.total_scans = self.num_fovs * self.NZ * len(self.selected_configurations)
 
             for fov_count, coordinate_mm in enumerate(coordinates):
+                # Just so the job result queues don't get too big, check and print a summary of intermediate results here
+                with self._timing.get_timer("job result summaries"):
+                    for (job_class, job_runner) in self._job_runners:
+                        out_queue = job_runner.output_queue()
+                        try:
+                            job_result: JobResult = out_queue.get_nowait()
+                            if job_result.exception is not None:
+                                self._log.error(f"Error while running job {job_result.job_id}: {job_result.exception}")
+                                # TODO(imo): Should we abort?
+                            else:
+                                self._log.info(f"Got result for job {job_result.job_id}, it completed!")
+                        except queue.Empty:
+                            continue
                 with self._timing.get_timer("move_to_coordinate"):
                     self.move_to_coordinate(coordinate_mm)
                 with self._timing.get_timer("acquire_at_position"):
@@ -525,6 +568,14 @@ class MultiPointWorker(QObject):
                     self.multiPointController.request_abort_aquisition()
                     return
 
+                with self._timing.get_timer("job creation and dispatch"):
+                    for (job_class, job_runner) in self._job_runners:
+                        job = job_class(capture_info=info, capture_image=JobImage(image_array=image))
+                        if not job_runner.dispatch(job):
+                            self._log.error("Failed to dispatch job!")
+                            self.multiPointController.request_abort_aquisition()
+                            return
+
                 height, width = image.shape[:2]
                 with self._timing.get_timer("crop_image"):
                     image_to_display = utils.crop_image(
@@ -536,8 +587,6 @@ class MultiPointWorker(QObject):
                     self.image_to_display.emit(image_to_display)
                     self.image_to_display_multi.emit(image_to_display, info.configuration.illumination_source)
 
-                with self._timing.get_timer("save_image"):
-                    self.save_image(image, info, camera_frame.is_color())
                 with self._timing.get_timer("update_napari"):
                     self.update_napari(image, info)
         finally:
@@ -661,55 +710,6 @@ class MultiPointWorker(QObject):
                     current_path, file_ID + "_" + str(config.name).replace(" ", "_") + "_" + str(l) + ".csv"
                 )
                 np.savetxt(saving_path, data, delimiter=",")
-
-    def save_image(self, image: np.array, info: CaptureInfo, is_color: bool):
-        # NOTE(imo): We silently fall back to individual image saving here.  We should warn or do something.
-        if FILE_SAVING_OPTION == FileSavingOption.MULTI_PAGE_TIFF:
-            metadata = {
-                "z_level": info.z_index,
-                "channel": info.configuration.name,
-                "channel_index": info.configuration_idx,
-                "region_id": info.region_id,
-                "fov": info.fov,
-                "x_mm": info.position.x_mm,
-                "y_mm": info.position.y_mm,
-                "z_mm": info.position.z_mm,
-            }
-            output_path = os.path.join(
-                info.save_directory, f"{info.region_id}_{info.fov:0{FILE_ID_PADDING}}_stack.tiff"
-            )
-            with tifffile.TiffWriter(output_path, append=True) as tiff_writer:
-                tiff_writer.write(image, metadata=metadata)
-        else:
-            saved_image = utils_acquisition.save_image(
-                image=image,
-                file_id=info.file_id,
-                save_directory=info.save_directory,
-                config=info.configuration,
-                is_color=is_color,
-            )
-
-            if MERGE_CHANNELS:
-                self._save_merged_image(saved_image, info.file_id, info.save_directory)
-
-    def _save_merged_image(self, image: np.array, file_ID: str, current_path: str):
-        self.image_count += 1
-
-        if self.image_count == 1:
-            self.merged_image = image
-        else:
-            self.merged_image = np.maximum(self.merged_image, image)
-
-            if self.image_count == len(self.selected_configurations):
-                if image.dtype == np.uint16:
-                    saving_path = os.path.join(current_path, file_ID + "_merged" + ".tiff")
-                else:
-                    saving_path = os.path.join(current_path, file_ID + "_merged" + "." + Acquisition.IMAGE_FORMAT)
-
-                iio.imwrite(saving_path, self.merged_image)
-                self.image_count = 0
-
-        return
 
     def update_napari(self, image, capture_info: CaptureInfo):
         if not self.performance_mode and (USE_NAPARI_FOR_MOSAIC_DISPLAY or USE_NAPARI_FOR_MULTIPOINT):


### PR DESCRIPTION
This adds in a proto multi-process / job running mechanism.  Long term, it'd be much better to use something like dramatiq, huey, rq, celery, or any of the other well known job queues.  But these require some setup overhead, a broker, and won't get us up and running quickly.  Hopefully the Job and JobRunner mechanism in this PR helps make the swap to that easier later on.

This is "proto" because it does not allow specifying job pipelines, does not allow doing anything with the result, and doesn't plumb through custom jobs yet.  All this does is add image saving to the jobs on separate processes.  

Performance improvement numbers to come.

Tested by: Running tests in sim and the hw I have at home, although it needs a lot more testing.  Specifically, I want to test how error cases pan out.