### PR TITLE
bug fix: default trigger mode

### DIFF
--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -76,12 +76,10 @@ class TriggerMode:
         if isinstance(option, TriggerMode):
             return option
 
-        try:
-            for name, value in vars(TriggerMode).items():
-                if value == option or name == option.upper():
-                    return getattr(TriggerMode, name)
-        except KeyError:
-            raise ValueError(f"Invalid trigger mode: {option}")
+        for name, value in vars(TriggerMode).items():
+            if value == option or name == option.upper():
+                return getattr(TriggerMode, name)
+        raise ValueError(f"Invalid trigger mode: {option}")
 
 
 class Acquisition:


### PR DESCRIPTION
This pull request introduces a new method to the `TriggerMode` class and updates the `load_formats` function to utilize it. The changes aim to improve the handling of trigger mode conversions and ensure better compatibility with string inputs.

Enhancements to `TriggerMode` class:

* Added a static method `convert_to_var` in `TriggerMode` to convert a string or `TriggerMode` instance into a `TriggerMode` object. This method includes validation and error handling for invalid inputs.

Updates to `load_formats` function:

* Modified `load_formats` to use the new `convert_to_var` method for converting the `DEFAULT_TRIGGER_MODE` variable into a `TriggerMode` object.