### PR TITLE
headless: reverse relationship between gui <-> microscope so we can have a truly headless api

### DIFF
--- a/software/control/core/channel_configuration_mananger.py
+++ b/software/control/core/channel_configuration_mananger.py
@@ -1,0 +1,134 @@
+from enum import Enum
+from typing import Any, List, Dict
+
+from control.utils_config import ChannelConfig, ChannelMode
+import control.utils_config as utils_config
+from control._def import *
+import squid.logging
+
+
+class ConfigType(Enum):
+    CHANNEL = "channel"
+    CONFOCAL = "confocal"
+    WIDEFIELD = "widefield"
+
+
+class ChannelConfigurationManager:
+    def __init__(self):
+        self._log = squid.logging.get_logger(self.__class__.__name__)
+        self.config_root = None
+        self.all_configs: Dict[ConfigType, Dict[str, ChannelConfig]] = {
+            ConfigType.CHANNEL: {},
+            ConfigType.CONFOCAL: {},
+            ConfigType.WIDEFIELD: {},
+        }
+        self.active_config_type = ConfigType.CHANNEL if not ENABLE_SPINNING_DISK_CONFOCAL else ConfigType.CONFOCAL
+
+    def set_profile_path(self, profile_path: Path) -> None:
+        """Set the root path for configurations"""
+        self.config_root = profile_path
+
+    def _load_xml_config(self, objective: str, config_type: ConfigType) -> None:
+        """Load XML configuration for a specific config type, generating default if needed"""
+        config_file = self.config_root / objective / f"{config_type.value}_configurations.xml"
+
+        if not config_file.exists():
+            utils_config.generate_default_configuration(str(config_file))
+
+        xml_content = config_file.read_bytes()
+        self.all_configs[config_type][objective] = ChannelConfig.from_xml(xml_content)
+
+    def load_configurations(self, objective: str) -> None:
+        """Load available configurations for an objective"""
+        if ENABLE_SPINNING_DISK_CONFOCAL:
+            # Load both confocal and widefield configurations
+            self._load_xml_config(objective, ConfigType.CONFOCAL)
+            self._load_xml_config(objective, ConfigType.WIDEFIELD)
+        else:
+            # Load only channel configurations
+            self._load_xml_config(objective, ConfigType.CHANNEL)
+
+    def _save_xml_config(self, objective: str, config_type: ConfigType) -> None:
+        """Save XML configuration for a specific config type"""
+        if objective not in self.all_configs[config_type]:
+            return
+
+        config = self.all_configs[config_type][objective]
+        save_path = self.config_root / objective / f"{config_type.value}_configurations.xml"
+
+        if not save_path.parent.exists():
+            save_path.parent.mkdir(parents=True)
+
+        xml_str = config.to_xml(pretty_print=True, encoding="utf-8")
+        save_path.write_bytes(xml_str)
+
+    def save_configurations(self, objective: str) -> None:
+        """Save configurations based on spinning disk configuration"""
+        if ENABLE_SPINNING_DISK_CONFOCAL:
+            # Save both confocal and widefield configurations
+            self._save_xml_config(objective, ConfigType.CONFOCAL)
+            self._save_xml_config(objective, ConfigType.WIDEFIELD)
+        else:
+            # Save only channel configurations
+            self._save_xml_config(objective, ConfigType.CHANNEL)
+
+    def save_current_configuration_to_path(self, objective: str, path: Path) -> None:
+        """Only used in TrackingController. Might be temporary."""
+        config = self.all_configs[self.active_config_type][objective]
+        xml_str = config.to_xml(pretty_print=True, encoding="utf-8")
+        path.write_bytes(xml_str)
+
+    def get_configurations(self, objective: str) -> List[ChannelMode]:
+        """Get channel modes for current active type"""
+        config = self.all_configs[self.active_config_type].get(objective)
+        if not config:
+            return []
+        return config.modes
+
+    def update_configuration(self, objective: str, config_id: str, attr_name: str, value: Any) -> None:
+        """Update a specific configuration in current active type"""
+        config = self.all_configs[self.active_config_type].get(objective)
+        if not config:
+            self._log.error(f"Objective {objective} not found")
+            return
+
+        for mode in config.modes:
+            if mode.id == config_id:
+                setattr(mode, utils_config.get_attr_name(attr_name), value)
+                break
+
+        self.save_configurations(objective)
+
+    def write_configuration_selected(
+        self, objective: str, selected_configurations: List[ChannelMode], filename: str
+    ) -> None:
+        """Write selected configurations to a file"""
+        config = self.all_configs[self.active_config_type].get(objective)
+        if not config:
+            raise ValueError(f"Objective {objective} not found")
+
+        # Update selected status
+        for mode in config.modes:
+            mode.selected = any(conf.id == mode.id for conf in selected_configurations)
+
+        # Save to specified file
+        xml_str = config.to_xml(pretty_print=True, encoding="utf-8")
+        filename = Path(filename)
+        filename.write_bytes(xml_str)
+
+        # Reset selected status
+        for mode in config.modes:
+            mode.selected = False
+        self.save_configurations(objective)
+
+    def get_channel_configurations_for_objective(self, objective: str) -> List[ChannelMode]:
+        """Get Configuration objects for current active type (alias for get_configurations)"""
+        return self.get_configurations(objective)
+
+    def get_channel_configuration_by_name(self, objective: str, name: str) -> ChannelMode:
+        """Get Configuration object by name"""
+        return next((mode for mode in self.get_configurations(objective) if mode.name == name), None)
+
+    def toggle_confocal_widefield(self, confocal: bool) -> None:
+        """Toggle between confocal and widefield configurations"""
+        self.active_config_type = ConfigType.CONFOCAL if confocal else ConfigType.WIDEFIELD

--- a/software/control/core/configuration_mananger.py
+++ b/software/control/core/configuration_mananger.py
@@ -1,0 +1,84 @@
+import os
+from pathlib import Path
+from typing import List, Optional
+
+from control.core.channel_configuration_mananger import ChannelConfigurationManager
+from control.core.laser_af_settings_manager import LaserAFSettingManager
+from control._def import OBJECTIVES
+
+
+class ConfigurationManager:
+    """Main configuration manager that coordinates channel and autofocus configurations."""
+
+    def __init__(
+        self,
+        channel_manager: ChannelConfigurationManager,
+        laser_af_manager: Optional[LaserAFSettingManager] = None,
+        base_config_path: Path = Path("acquisition_configurations"),
+        profile: str = "default_profile",
+    ):
+        super().__init__()
+        self.base_config_path = Path(base_config_path)
+        self.current_profile = profile
+        self.available_profiles = self._get_available_profiles()
+
+        self.channel_manager = channel_manager
+        self.laser_af_manager = laser_af_manager
+
+        self.load_profile(profile)
+
+    def _get_available_profiles(self) -> List[str]:
+        """Get all available user profile names in the base config path. Use default profile if no other profiles exist."""
+        if not self.base_config_path.exists():
+            os.makedirs(self.base_config_path)
+            os.makedirs(self.base_config_path / "default_profile")
+            for objective in OBJECTIVES:
+                os.makedirs(self.base_config_path / "default_profile" / objective)
+        return [d.name for d in self.base_config_path.iterdir() if d.is_dir()]
+
+    def _get_available_objectives(self, profile_path: Path) -> List[str]:
+        """Get all available objective names in a profile."""
+        return [d.name for d in profile_path.iterdir() if d.is_dir()]
+
+    def load_profile(self, profile_name: str) -> None:
+        """Load all configurations from a specific profile."""
+        profile_path = self.base_config_path / profile_name
+        if not profile_path.exists():
+            raise ValueError(f"Profile {profile_name} does not exist")
+
+        self.current_profile = profile_name
+        if self.channel_manager:
+            self.channel_manager.set_profile_path(profile_path)
+        if self.laser_af_manager:
+            self.laser_af_manager.set_profile_path(profile_path)
+
+        # Load configurations for each objective
+        for objective in self._get_available_objectives(profile_path):
+            if self.channel_manager:
+                self.channel_manager.load_configurations(objective)
+            if self.laser_af_manager:
+                self.laser_af_manager.load_configurations(objective)
+
+    def create_new_profile(self, profile_name: str) -> None:
+        """Create a new profile using current configurations."""
+        new_profile_path = self.base_config_path / profile_name
+        if new_profile_path.exists():
+            raise ValueError(f"Profile {profile_name} already exists")
+        os.makedirs(new_profile_path)
+
+        objectives = OBJECTIVES
+
+        self.current_profile = profile_name
+        if self.channel_manager:
+            self.channel_manager.set_profile_path(new_profile_path)
+        if self.laser_af_manager:
+            self.laser_af_manager.set_profile_path(new_profile_path)
+
+        for objective in objectives:
+            os.makedirs(new_profile_path / objective)
+            if self.channel_manager:
+                self.channel_manager.save_configurations(objective)
+            if self.laser_af_manager:
+                self.laser_af_manager.save_configurations(objective)
+
+        self.available_profiles = self._get_available_profiles()

--- a/software/control/core/contrast_manager.py
+++ b/software/control/core/contrast_manager.py
@@ -1,0 +1,53 @@
+import numpy as np
+
+
+class ContrastManager:
+    def __init__(self):
+        self.contrast_limits = {}
+        self.acquisition_dtype = None
+
+    def update_limits(self, channel, min_val, max_val):
+        self.contrast_limits[channel] = (min_val, max_val)
+
+    def get_limits(self, channel, dtype=None):
+        if dtype is not None:
+            if self.acquisition_dtype is None:
+                self.acquisition_dtype = dtype
+            elif self.acquisition_dtype != dtype:
+                self.scale_contrast_limits(dtype)
+        return self.contrast_limits.get(channel, self.get_default_limits())
+
+    def get_default_limits(self):
+        if self.acquisition_dtype is None:
+            return (0, 1)
+        elif np.issubdtype(self.acquisition_dtype, np.integer):
+            info = np.iinfo(self.acquisition_dtype)
+            return (info.min, info.max)
+        elif np.issubdtype(self.acquisition_dtype, np.floating):
+            return (0.0, 1.0)
+        else:
+            return (0, 1)
+
+    def get_scaled_limits(self, channel, target_dtype):
+        min_val, max_val = self.get_limits(channel)
+        if self.acquisition_dtype == target_dtype:
+            return min_val, max_val
+
+        source_info = np.iinfo(self.acquisition_dtype)
+        target_info = np.iinfo(target_dtype)
+
+        scaled_min = (min_val - source_info.min) / (source_info.max - source_info.min) * (
+            target_info.max - target_info.min
+        ) + target_info.min
+        scaled_max = (max_val - source_info.min) / (source_info.max - source_info.min) * (
+            target_info.max - target_info.min
+        ) + target_info.min
+
+        return scaled_min, scaled_max
+
+    def scale_contrast_limits(self, target_dtype):
+        print(f"{self.acquisition_dtype} -> {target_dtype}")
+        for channel in self.contrast_limits.keys():
+            self.contrast_limits[channel] = self.get_scaled_limits(channel, target_dtype)
+
+        self.acquisition_dtype = target_dtype

--- a/software/control/core/core.py
+++ b/software/control/core/core.py
@@ -63,6 +63,7 @@ if ENABLE_NL5:
 else:
     NL5 = TypeVar("NL5")
 
+
 class QtStreamHandler(QObject):
 
     image_to_display = Signal(np.ndarray)
@@ -610,12 +611,13 @@ class AutoFocusController(QObject):
     image_to_display = Signal(np.ndarray)
 
     def __init__(
-            self,
-            camera: AbstractCamera,
-            stage: AbstractStage,
-            liveController: LiveController,
-            microcontroller: Microcontroller,
-            nl5: Optional[NL5]):
+        self,
+        camera: AbstractCamera,
+        stage: AbstractStage,
+        liveController: LiveController,
+        microcontroller: Microcontroller,
+        nl5: Optional[NL5],
+    ):
         QObject.__init__(self)
         self.camera: AbstractCamera = camera
         self.stage: AbstractStage = stage

--- a/software/control/core/core.py
+++ b/software/control/core/core.py
@@ -3,12 +3,6 @@ import os
 import sys
 import tempfile
 
-import control._def
-from control.microcontroller import Microcontroller
-from control.piezo import PiezoStage
-from squid.abc import AbstractStage, AbstractCamera, CameraAcquisitionMode
-import squid.logging
-
 # qt libraries
 os.environ["QT_API"] = "pyqt5"
 import qtpy
@@ -17,17 +11,27 @@ from qtpy.QtCore import *
 from qtpy.QtWidgets import *
 from qtpy.QtGui import *
 
-# control
 from control._def import *
-from control.core.multi_point_worker import MultiPointWorker
 from control.core import job_processing
-
+from control.core.live_controller import LiveController
+from control.core.multi_point_worker import MultiPointWorker
+from control.core.objective_store import ObjectiveStore
+from control.core.stream_handler import StreamHandlerFunctions, StreamHandler
+from control.core.laser_af_settings_manager import LaserAFSettingManager
+from control.core.channel_configuration_mananger import ChannelConfigurationManager
+from control.core.configuration_mananger import ConfigurationManager
+from control.core.contrast_manager import ContrastManager
+from control.microcontroller import Microcontroller
+from control.piezo import PiezoStage
+from squid.abc import AbstractStage, AbstractCamera, CameraAcquisitionMode, CameraFrame
+import control._def
+import control.serial_peripherals as serial_peripherals
+import control.tracking as tracking
 import control.utils as utils
 import control.utils_acquisition as utils_acquisition
 import control.utils_channel as utils_channel
 import control.utils_config as utils_config
-import control.tracking as tracking
-import control.serial_peripherals as serial_peripherals
+import squid.logging
 
 try:
     from control.multipoint_custom_script_entry_v2 import *
@@ -55,131 +59,45 @@ import squid.abc
 import scipy.ndimage
 
 
-class ObjectiveStore:
-    def __init__(self, objectives_dict=OBJECTIVES, default_objective=DEFAULT_OBJECTIVE):
-        self.objectives_dict = objectives_dict
-        self.default_objective = default_objective
-        self.current_objective = default_objective
-        objective = self.objectives_dict[self.current_objective]
-        self.pixel_size_factor = ObjectiveStore.calculate_pixel_size_factor(objective, TUBE_LENS_MM)
-
-    def get_pixel_size_factor(self):
-        return self.pixel_size_factor
-
-    @staticmethod
-    def calculate_pixel_size_factor(objective, tube_lens_mm):
-        """pixel_size_um = sensor_pixel_size * binning_factor * lens_factor"""
-        magnification = objective["magnification"]
-        objective_tube_lens_mm = objective["tube_lens_f_mm"]
-        lens_factor = objective_tube_lens_mm / magnification / tube_lens_mm
-        return lens_factor
-
-    def set_current_objective(self, objective_name):
-        if objective_name in self.objectives_dict:
-            self.current_objective = objective_name
-            objective = self.objectives_dict[objective_name]
-            self.pixel_size_factor = ObjectiveStore.calculate_pixel_size_factor(objective, TUBE_LENS_MM)
-        else:
-            raise ValueError(f"Objective {objective_name} not found in the store.")
-
-    def get_current_objective_info(self):
-        return self.objectives_dict[self.current_objective]
-
-
-class StreamHandler(QObject):
+class QtStreamHandler(QObject):
 
     image_to_display = Signal(np.ndarray)
     packet_image_to_write = Signal(np.ndarray, int, float)
-    packet_image_for_tracking = Signal(np.ndarray, int, float)
     signal_new_frame_received = Signal()
 
-    def __init__(
-        self,
-        display_resolution_scaling=1,
-        accept_new_frame_fn: Callable[[], bool] = lambda: True,
-    ):
-        QObject.__init__(self)
-        self.fps_display = 1
-        self.fps_save = 1
-        self.fps_track = 1
-        self.timestamp_last_display = 0
-        self.timestamp_last_save = 0
-        self.timestamp_last_track = 0
+    def __init__(self, display_resolution_scaling=1, accept_new_frame_fn: Callable[[], bool] = lambda: True):
+        super().__init__()
 
-        self.display_resolution_scaling = display_resolution_scaling
+        functions = StreamHandlerFunctions(
+            image_to_display=self.image_to_display.emit,
+            packet_image_to_write=self.packet_image_to_write.emit,
+            signal_new_frame_received=self.signal_new_frame_received.emit,
+            accept_new_frame=accept_new_frame_fn,
+        )
+        self._handler = StreamHandler(
+            handler_functions=functions, display_resolution_scaling=display_resolution_scaling
+        )
 
-        self.save_image_flag = False
-        self.handler_busy = False
-
-        # for fps measurement
-        self.timestamp_last = 0
-        self.counter = 0
-        self.fps_real = 0
-
-        # Only accept new frames if this user defined function returns true
-        self._accept_new_frames_fn = accept_new_frame_fn
+    def get_frame_callback(self) -> Callable[[CameraFrame], None]:
+        return self._handler.on_new_frame
 
     def start_recording(self):
-        self.save_image_flag = True
+        self._handler.start_recording()
 
     def stop_recording(self):
-        self.save_image_flag = False
+        self._handler.stop_recording()
 
     def set_display_fps(self, fps):
-        self.fps_display = fps
+        self._handler.set_display_fps(fps)
 
     def set_save_fps(self, fps):
-        self.fps_save = fps
+        self._handler.set_save_fps(fps)
 
     def set_display_resolution_scaling(self, display_resolution_scaling):
-        self.display_resolution_scaling = display_resolution_scaling / 100
-        print(self.display_resolution_scaling)
-
-    def on_new_frame(self, frame: squid.abc.CameraFrame):
-        if not self._accept_new_frames_fn():
-            return
-
-        self.handler_busy = True
-        self.signal_new_frame_received.emit()
-
-        # measure real fps
-        timestamp_now = round(time.time())
-        if timestamp_now == self.timestamp_last:
-            self.counter = self.counter + 1
-        else:
-            self.timestamp_last = timestamp_now
-            self.fps_real = self.counter
-            self.counter = 0
-            if PRINT_CAMERA_FPS:
-                print("real camera fps is " + str(self.fps_real))
-
-        # crop image
-        image = np.squeeze(frame.frame)
-
-        # send image to display
-        time_now = time.time()
-        if time_now - self.timestamp_last_display >= 1 / self.fps_display:
-            self.image_to_display.emit(
-                utils.crop_image(
-                    image,
-                    round(image.shape[1] * self.display_resolution_scaling),
-                    round(image.shape[0] * self.display_resolution_scaling),
-                )
-            )
-            self.timestamp_last_display = time_now
-
-        # send image to write
-        if self.save_image_flag and time_now - self.timestamp_last_save >= 1 / self.fps_save:
-            if frame.is_color():
-                image = cv2.cvtColor(image, cv2.COLOR_RGB2BGR)
-            self.packet_image_to_write.emit(image, frame.frame_id, frame.timestamp)
-            self.timestamp_last_save = time_now
-
-        self.handler_busy = False
+        self._handler.set_display_resolution_scaling(display_resolution_scaling)
 
 
 class ImageSaver(QObject):
-
     stop_recording = Signal()
 
     def __init__(self, image_format=Acquisition.IMAGE_FORMAT):
@@ -330,7 +248,6 @@ class ImageSaver_Tracking(QObject):
 
 
 class ImageDisplay(QObject):
-
     image_to_display = Signal(np.ndarray)
 
     def __init__(self):
@@ -375,340 +292,7 @@ class ImageDisplay(QObject):
         self.thread.join()
 
 
-class LiveController(QObject):
-    def __init__(
-        self,
-        camera: AbstractCamera,
-        microcontroller,
-        illuminationController,
-        parent=None,
-        control_illumination=True,
-        use_internal_timer_for_hardware_trigger=True,
-        for_displacement_measurement=False,
-    ):
-        QObject.__init__(self)
-        self._log = squid.logging.get_logger(self.__class__.__name__)
-        self.microscope = parent
-        self.camera: AbstractCamera = camera
-        self.microcontroller = microcontroller
-        self.currentConfiguration = None
-        self.trigger_mode = TriggerMode.SOFTWARE  # @@@ change to None
-        self.is_live = False
-        self.control_illumination = control_illumination
-        self.illumination_on = False
-        self.illuminationController = illuminationController
-        self.use_internal_timer_for_hardware_trigger = (
-            use_internal_timer_for_hardware_trigger  # use QTimer vs timer in the MCU
-        )
-        self.for_displacement_measurement = for_displacement_measurement
-
-        self.fps_trigger = 1
-        self.timer_trigger_interval = (1 / self.fps_trigger) * 1000
-
-        self.timer_trigger = QTimer()
-        self.timer_trigger.setInterval(int(self.timer_trigger_interval))
-        self.timer_trigger.timeout.connect(self.trigger_acquisition)
-
-        self.trigger_ID = -1
-
-        self.fps_real = 0
-        self.counter = 0
-        self.timestamp_last = 0
-
-        self.display_resolution_scaling = 1
-
-        self.enable_channel_auto_filter_switching = True
-
-        if SUPPORT_SCIMICROSCOPY_LED_ARRAY:
-            # to do: add error handling
-            self.led_array = serial_peripherals.SciMicroscopyLEDArray(
-                SCIMICROSCOPY_LED_ARRAY_SN, SCIMICROSCOPY_LED_ARRAY_DISTANCE, SCIMICROSCOPY_LED_ARRAY_TURN_ON_DELAY
-            )
-            self.led_array.set_NA(SCIMICROSCOPY_LED_ARRAY_DEFAULT_NA)
-
-    # illumination control
-    def turn_on_illumination(self):
-        if not "LED matrix" in self.currentConfiguration.name:
-            self.illuminationController.turn_on_illumination(
-                int(utils_channel.extract_wavelength_from_config_name(self.currentConfiguration.name))
-            )
-        elif SUPPORT_SCIMICROSCOPY_LED_ARRAY and "LED matrix" in self.currentConfiguration.name:
-            self.led_array.turn_on_illumination()
-        # LED matrix
-        else:
-            self.microcontroller.turn_on_illumination()  # to wrap microcontroller in Squid_led_array
-        self.illumination_on = True
-
-    def turn_off_illumination(self):
-        if not "LED matrix" in self.currentConfiguration.name:
-            self.illuminationController.turn_off_illumination(
-                int(utils_channel.extract_wavelength_from_config_name(self.currentConfiguration.name))
-            )
-        elif SUPPORT_SCIMICROSCOPY_LED_ARRAY and "LED matrix" in self.currentConfiguration.name:
-            self.led_array.turn_off_illumination()
-        # LED matrix
-        else:
-            self.microcontroller.turn_off_illumination()  # to wrap microcontroller in Squid_led_array
-        self.illumination_on = False
-
-    def update_illumination(self):
-        illumination_source = self.currentConfiguration.illumination_source
-        intensity = self.currentConfiguration.illumination_intensity
-        if illumination_source < 10:  # LED matrix
-            if SUPPORT_SCIMICROSCOPY_LED_ARRAY:
-                # set color
-                if "BF LED matrix full_R" in self.currentConfiguration.name:
-                    self.led_array.set_color((1, 0, 0))
-                elif "BF LED matrix full_G" in self.currentConfiguration.name:
-                    self.led_array.set_color((0, 1, 0))
-                elif "BF LED matrix full_B" in self.currentConfiguration.name:
-                    self.led_array.set_color((0, 0, 1))
-                else:
-                    self.led_array.set_color(SCIMICROSCOPY_LED_ARRAY_DEFAULT_COLOR)
-                # set intensity
-                self.led_array.set_brightness(intensity)
-                # set mode
-                if "BF LED matrix left half" in self.currentConfiguration.name:
-                    self.led_array.set_illumination("dpc.l")
-                if "BF LED matrix right half" in self.currentConfiguration.name:
-                    self.led_array.set_illumination("dpc.r")
-                if "BF LED matrix top half" in self.currentConfiguration.name:
-                    self.led_array.set_illumination("dpc.t")
-                if "BF LED matrix bottom half" in self.currentConfiguration.name:
-                    self.led_array.set_illumination("dpc.b")
-                if "BF LED matrix full" in self.currentConfiguration.name:
-                    self.led_array.set_illumination("bf")
-                if "DF LED matrix" in self.currentConfiguration.name:
-                    self.led_array.set_illumination("df")
-            else:
-                if "BF LED matrix full_R" in self.currentConfiguration.name:
-                    self.microcontroller.set_illumination_led_matrix(illumination_source, r=(intensity / 100), g=0, b=0)
-                elif "BF LED matrix full_G" in self.currentConfiguration.name:
-                    self.microcontroller.set_illumination_led_matrix(illumination_source, r=0, g=(intensity / 100), b=0)
-                elif "BF LED matrix full_B" in self.currentConfiguration.name:
-                    self.microcontroller.set_illumination_led_matrix(illumination_source, r=0, g=0, b=(intensity / 100))
-                else:
-                    self.microcontroller.set_illumination_led_matrix(
-                        illumination_source,
-                        r=(intensity / 100) * LED_MATRIX_R_FACTOR,
-                        g=(intensity / 100) * LED_MATRIX_G_FACTOR,
-                        b=(intensity / 100) * LED_MATRIX_B_FACTOR,
-                    )
-        else:
-            # update illumination
-            wavelength = int(utils_channel.extract_wavelength_from_config_name(self.currentConfiguration.name))
-            self.illuminationController.set_intensity(wavelength, intensity)
-            if ENABLE_NL5 and NL5_USE_DOUT and "Fluorescence" in self.currentConfiguration.name:
-                self.microscope.nl5.set_active_channel(NL5_WAVENLENGTH_MAP[wavelength])
-                if NL5_USE_AOUT:
-                    self.microscope.nl5.set_laser_power(NL5_WAVENLENGTH_MAP[wavelength], int(intensity))
-                if ENABLE_CELLX:
-                    self.microscope.cellx.set_laser_power(NL5_WAVENLENGTH_MAP[wavelength], int(intensity))
-
-        # set emission filter position
-        if ENABLE_SPINNING_DISK_CONFOCAL:
-            try:
-                self.microscope.xlight.set_emission_filter(
-                    XLIGHT_EMISSION_FILTER_MAPPING[illumination_source],
-                    extraction=False,
-                    validate=XLIGHT_VALIDATE_WHEEL_POS,
-                )
-            except Exception as e:
-                print("not setting emission filter position due to " + str(e))
-
-        if USE_ZABER_EMISSION_FILTER_WHEEL and self.enable_channel_auto_filter_switching:
-            try:
-                if (
-                    self.currentConfiguration.emission_filter_position
-                    != self.microscope.emission_filter_wheel.current_index
-                ):
-                    if ZABER_EMISSION_FILTER_WHEEL_BLOCKING_CALL:
-                        self.microscope.emission_filter_wheel.set_emission_filter(
-                            self.currentConfiguration.emission_filter_position, blocking=True
-                        )
-                    else:
-                        self.microscope.emission_filter_wheel.set_emission_filter(
-                            self.currentConfiguration.emission_filter_position, blocking=False
-                        )
-                        if self.trigger_mode == TriggerMode.SOFTWARE:
-                            time.sleep(ZABER_EMISSION_FILTER_WHEEL_DELAY_MS / 1000)
-                        else:
-                            time.sleep(
-                                max(
-                                    0, ZABER_EMISSION_FILTER_WHEEL_DELAY_MS / 1000 - self.camera.get_strobe_time() / 1e3
-                                )
-                            )
-            except Exception as e:
-                print("not setting emission filter position due to " + str(e))
-
-        if (
-            USE_OPTOSPIN_EMISSION_FILTER_WHEEL
-            and self.enable_channel_auto_filter_switching
-            and OPTOSPIN_EMISSION_FILTER_WHEEL_TTL_TRIGGER == False
-        ):
-            try:
-                if (
-                    self.currentConfiguration.emission_filter_position
-                    != self.microscope.emission_filter_wheel.current_index
-                ):
-                    self.microscope.emission_filter_wheel.set_emission_filter(
-                        self.currentConfiguration.emission_filter_position
-                    )
-                    if self.trigger_mode == TriggerMode.SOFTWARE:
-                        time.sleep(OPTOSPIN_EMISSION_FILTER_WHEEL_DELAY_MS / 1000)
-                    elif self.trigger_mode == TriggerMode.HARDWARE:
-                        time.sleep(
-                            max(0, OPTOSPIN_EMISSION_FILTER_WHEEL_DELAY_MS / 1000 - self.camera.get_strobe_time() / 1e3)
-                        )
-            except Exception as e:
-                print("not setting emission filter position due to " + str(e))
-
-        if USE_SQUID_FILTERWHEEL and self.enable_channel_auto_filter_switching:
-            try:
-                self.microscope.squid_filter_wheel.set_emission(self.currentConfiguration.emission_filter_position)
-            except Exception as e:
-                print("not setting emission filter position due to " + str(e))
-
-    def start_live(self):
-        self.is_live = True
-        self.camera.start_streaming()
-        if self.trigger_mode == TriggerMode.SOFTWARE or (
-            self.trigger_mode == TriggerMode.HARDWARE and self.use_internal_timer_for_hardware_trigger
-        ):
-            self.camera.enable_callbacks(True)  # in case it's disabled e.g. by the laser AF controller
-            self._start_triggerred_acquisition()
-        # if controlling the laser displacement measurement camera
-        if self.for_displacement_measurement:
-            self.microcontroller.set_pin_level(MCU_PINS.AF_LASER, 1)
-
-    def stop_live(self):
-        if self.is_live:
-            self.is_live = False
-            if self.trigger_mode == TriggerMode.SOFTWARE:
-                self._stop_triggerred_acquisition()
-            if self.trigger_mode == TriggerMode.CONTINUOUS:
-                self.camera.stop_streaming()
-            if (self.trigger_mode == TriggerMode.SOFTWARE) or (
-                self.trigger_mode == TriggerMode.HARDWARE and self.use_internal_timer_for_hardware_trigger
-            ):
-                self._stop_triggerred_acquisition()
-            if self.control_illumination:
-                self.turn_off_illumination()
-            # if controlling the laser displacement measurement camera
-            if self.for_displacement_measurement:
-                self.microcontroller.set_pin_level(MCU_PINS.AF_LASER, 0)
-
-    # software trigger related
-    def trigger_acquisition(self):
-        if not self.camera.get_ready_for_trigger():
-            # TODO(imo): Before, send_trigger would pass silently for this case.  Now
-            # we do the same here.  Should this warn?  I didn't add a warning because it seems like
-            # we over-trigger as standard practice (eg: we trigger at our exposure time frequency, but
-            # the cameras can't give us images that fast so we essentially always have at least 1 skipped trigger)
-            self._log.debug("Not ready for trigger, skipping.")
-            return
-        if self.trigger_mode == TriggerMode.SOFTWARE and self.control_illumination:
-            if not self.illumination_on:
-                self.turn_on_illumination()
-
-        self.trigger_ID = self.trigger_ID + 1
-
-        self.camera.send_trigger(self.camera.get_exposure_time())
-
-        if self.trigger_mode == TriggerMode.SOFTWARE:
-            if self.control_illumination and self.illumination_on == False:
-                self.turn_on_illumination()
-
-    def _start_triggerred_acquisition(self):
-        if not self.timer_trigger.isActive():
-            self.timer_trigger.start()
-
-    def _set_trigger_fps(self, fps_trigger):
-        self.fps_trigger = fps_trigger
-        self.timer_trigger_interval = (1 / self.fps_trigger) * 1000
-        self.timer_trigger.setInterval(int(self.timer_trigger_interval))
-
-    def _stop_triggerred_acquisition(self):
-        self.timer_trigger.stop()
-
-    # trigger mode and settings
-    def set_trigger_mode(self, mode):
-        if mode == TriggerMode.SOFTWARE:
-            if self.is_live and (
-                self.trigger_mode == TriggerMode.HARDWARE and self.use_internal_timer_for_hardware_trigger
-            ):
-                self._stop_triggerred_acquisition()
-            self.camera.set_acquisition_mode(CameraAcquisitionMode.SOFTWARE_TRIGGER)
-            if self.is_live:
-                self._start_triggerred_acquisition()
-        if mode == TriggerMode.HARDWARE:
-            if self.trigger_mode == TriggerMode.SOFTWARE and self.is_live:
-                self._stop_triggerred_acquisition()
-            self.camera.set_acquisition_mode(CameraAcquisitionMode.HARDWARE_TRIGGER)
-            self.camera.set_exposure_time(self.currentConfiguration.exposure_time)
-
-            if self.is_live and self.use_internal_timer_for_hardware_trigger:
-                self._start_triggerred_acquisition()
-        if mode == TriggerMode.CONTINUOUS:
-            if (self.trigger_mode == TriggerMode.SOFTWARE) or (
-                self.trigger_mode == TriggerMode.HARDWARE and self.use_internal_timer_for_hardware_trigger
-            ):
-                self._stop_triggerred_acquisition()
-            self.camera.set_acquisition_mode(CameraAcquisitionMode.CONTINUOUS)
-        self.trigger_mode = mode
-
-    def set_trigger_fps(self, fps):
-        if (self.trigger_mode == TriggerMode.SOFTWARE) or (
-            self.trigger_mode == TriggerMode.HARDWARE and self.use_internal_timer_for_hardware_trigger
-        ):
-            self._set_trigger_fps(fps)
-
-    # set microscope mode
-    # @@@ to do: change softwareTriggerGenerator to TriggerGeneratror
-    def set_microscope_mode(self, configuration):
-
-        self.currentConfiguration = configuration
-        self._log.info("setting microscope mode to " + self.currentConfiguration.name)
-
-        # temporarily stop live while changing mode
-        if self.is_live is True:
-            self.timer_trigger.stop()
-            if self.control_illumination:
-                self.turn_off_illumination()
-
-        # set camera exposure time and analog gain
-        self.camera.set_exposure_time(self.currentConfiguration.exposure_time)
-        try:
-            self.camera.set_analog_gain(self.currentConfiguration.analog_gain)
-        except NotImplementedError:
-            pass
-
-        # set illumination
-        if self.control_illumination:
-            self.update_illumination()
-
-        # restart live
-        if self.is_live is True:
-            if self.control_illumination:
-                self.turn_on_illumination()
-            self.timer_trigger.start()
-        self._log.info("Done setting microscope mode.")
-
-    def get_trigger_mode(self):
-        return self.trigger_mode
-
-    # slot
-    def on_new_frame(self):
-        if self.fps_trigger <= 5:
-            if self.control_illumination and self.illumination_on == True:
-                self.turn_off_illumination()
-
-    def set_display_resolution_scaling(self, display_resolution_scaling):
-        self.display_resolution_scaling = display_resolution_scaling / 100
-
-
 class SlidePositionControlWorker(QObject):
-
     finished = Signal()
     signal_stop_live = Signal()
     signal_resume_live = Signal()
@@ -853,7 +437,6 @@ class SlidePositionControlWorker(QObject):
 
 
 class SlidePositionController(QObject):
-
     signal_slide_loading_position_reached = Signal()
     signal_slide_scanning_position_reached = Signal()
     signal_clear_slide = Signal()
@@ -922,7 +505,6 @@ class SlidePositionController(QObject):
 
 
 class AutofocusWorker(QObject):
-
     finished = Signal()
     image_to_display = Signal(np.ndarray)
 
@@ -1018,7 +600,6 @@ class AutofocusWorker(QObject):
 
 
 class AutoFocusController(QObject):
-
     z_pos = Signal(float)
     autofocusFinished = Signal()
     image_to_display = Signal(np.ndarray)
@@ -1214,135 +795,7 @@ class AutoFocusController(QObject):
         print(f"Added triple ({x},{y},{z}) to focus map")
 
 
-class ConfigType(Enum):
-    CHANNEL = "channel"
-    CONFOCAL = "confocal"
-    WIDEFIELD = "widefield"
-
-
-class ChannelConfigurationManager:
-    def __init__(self):
-        self._log = squid.logging.get_logger(self.__class__.__name__)
-        self.config_root = None
-        self.all_configs: Dict[ConfigType, Dict[str, ChannelConfig]] = {
-            ConfigType.CHANNEL: {},
-            ConfigType.CONFOCAL: {},
-            ConfigType.WIDEFIELD: {},
-        }
-        self.active_config_type = ConfigType.CHANNEL if not ENABLE_SPINNING_DISK_CONFOCAL else ConfigType.CONFOCAL
-
-    def set_profile_path(self, profile_path: Path) -> None:
-        """Set the root path for configurations"""
-        self.config_root = profile_path
-
-    def _load_xml_config(self, objective: str, config_type: ConfigType) -> None:
-        """Load XML configuration for a specific config type, generating default if needed"""
-        config_file = self.config_root / objective / f"{config_type.value}_configurations.xml"
-
-        if not config_file.exists():
-            utils_config.generate_default_configuration(str(config_file))
-
-        xml_content = config_file.read_bytes()
-        self.all_configs[config_type][objective] = ChannelConfig.from_xml(xml_content)
-
-    def load_configurations(self, objective: str) -> None:
-        """Load available configurations for an objective"""
-        if ENABLE_SPINNING_DISK_CONFOCAL:
-            # Load both confocal and widefield configurations
-            self._load_xml_config(objective, ConfigType.CONFOCAL)
-            self._load_xml_config(objective, ConfigType.WIDEFIELD)
-        else:
-            # Load only channel configurations
-            self._load_xml_config(objective, ConfigType.CHANNEL)
-
-    def _save_xml_config(self, objective: str, config_type: ConfigType) -> None:
-        """Save XML configuration for a specific config type"""
-        if objective not in self.all_configs[config_type]:
-            return
-
-        config = self.all_configs[config_type][objective]
-        save_path = self.config_root / objective / f"{config_type.value}_configurations.xml"
-
-        if not save_path.parent.exists():
-            save_path.parent.mkdir(parents=True)
-
-        xml_str = config.to_xml(pretty_print=True, encoding="utf-8")
-        save_path.write_bytes(xml_str)
-
-    def save_configurations(self, objective: str) -> None:
-        """Save configurations based on spinning disk configuration"""
-        if ENABLE_SPINNING_DISK_CONFOCAL:
-            # Save both confocal and widefield configurations
-            self._save_xml_config(objective, ConfigType.CONFOCAL)
-            self._save_xml_config(objective, ConfigType.WIDEFIELD)
-        else:
-            # Save only channel configurations
-            self._save_xml_config(objective, ConfigType.CHANNEL)
-
-    def save_current_configuration_to_path(self, objective: str, path: Path) -> None:
-        """Only used in TrackingController. Might be temporary."""
-        config = self.all_configs[self.active_config_type][objective]
-        xml_str = config.to_xml(pretty_print=True, encoding="utf-8")
-        path.write_bytes(xml_str)
-
-    def get_configurations(self, objective: str) -> List[ChannelMode]:
-        """Get channel modes for current active type"""
-        config = self.all_configs[self.active_config_type].get(objective)
-        if not config:
-            return []
-        return config.modes
-
-    def update_configuration(self, objective: str, config_id: str, attr_name: str, value: Any) -> None:
-        """Update a specific configuration in current active type"""
-        config = self.all_configs[self.active_config_type].get(objective)
-        if not config:
-            self._log.error(f"Objective {objective} not found")
-            return
-
-        for mode in config.modes:
-            if mode.id == config_id:
-                setattr(mode, utils_config.get_attr_name(attr_name), value)
-                break
-
-        self.save_configurations(objective)
-
-    def write_configuration_selected(
-        self, objective: str, selected_configurations: List[ChannelMode], filename: str
-    ) -> None:
-        """Write selected configurations to a file"""
-        config = self.all_configs[self.active_config_type].get(objective)
-        if not config:
-            raise ValueError(f"Objective {objective} not found")
-
-        # Update selected status
-        for mode in config.modes:
-            mode.selected = any(conf.id == mode.id for conf in selected_configurations)
-
-        # Save to specified file
-        xml_str = config.to_xml(pretty_print=True, encoding="utf-8")
-        filename = Path(filename)
-        filename.write_bytes(xml_str)
-
-        # Reset selected status
-        for mode in config.modes:
-            mode.selected = False
-        self.save_configurations(objective)
-
-    def get_channel_configurations_for_objective(self, objective: str) -> List[ChannelMode]:
-        """Get Configuration objects for current active type (alias for get_configurations)"""
-        return self.get_configurations(objective)
-
-    def get_channel_configuration_by_name(self, objective: str, name: str) -> ChannelMode:
-        """Get Configuration object by name"""
-        return next((mode for mode in self.get_configurations(objective) if mode.name == name), None)
-
-    def toggle_confocal_widefield(self, confocal: bool) -> None:
-        """Toggle between confocal and widefield configurations"""
-        self.active_config_type = ConfigType.CONFOCAL if confocal else ConfigType.WIDEFIELD
-
-
 class ScanCoordinates(QObject):
-
     signal_scan_coordinates_updated = Signal()
 
     def __init__(self, objectiveStore, navigationViewer, stage: AbstractStage):
@@ -1928,7 +1381,6 @@ class ScanCoordinates(QObject):
 
 
 class MultiPointController(QObject):
-
     acquisition_finished = Signal()
     image_to_display = Signal(np.ndarray)
     image_to_display_multi = Signal(np.ndarray, int)
@@ -2507,7 +1959,6 @@ class MultiPointController(QObject):
 
 
 class TrackingController(QObject):
-
     signal_tracking_stopped = Signal()
     image_to_display = Signal(np.ndarray)
     image_to_display_multi = Signal(np.ndarray, int)
@@ -2694,7 +2145,6 @@ class TrackingController(QObject):
 
 
 class TrackingWorker(QObject):
-
     finished = Signal()
     image_to_display = Signal(np.ndarray)
     image_to_display_multi = Signal(np.ndarray, int)
@@ -2879,7 +2329,6 @@ class TrackingWorker(QObject):
 
 
 class ImageDisplayWindow(QMainWindow):
-
     image_click_coordinates = Signal(int, int, int, int)
 
     def __init__(
@@ -3088,7 +2537,7 @@ class ImageDisplayWindow(QMainWindow):
                 else:
                     self.stage_position_label.setText("Stage: N/A")
 
-                piezo = self.liveController.microscope.piezo
+                piezo = self.liveController.microscope.addons.piezo_stage
                 if piezo:
                     try:
                         piezo_pos = piezo.position
@@ -3547,7 +2996,6 @@ class ImageDisplayWindow(QMainWindow):
 
 
 class NavigationViewer(QFrame):
-
     signal_coordinates_clicked = Signal(float, float)  # Will emit x_mm, y_mm when clicked
 
     def __init__(self, objectivestore, camera_pixel_size, sample="glass slide", invertX=False, *args, **kwargs):
@@ -3901,187 +3349,6 @@ class ImageArrayDisplayWindow(QMainWindow):
             self.graphics_widget_4.img.setImage(image, autoLevels=False)
 
 
-class LaserAFSettingManager:
-    """Manages JSON-based laser autofocus configurations."""
-
-    def __init__(self):
-        self.autofocus_configurations: Dict[str, LaserAFConfig] = {}  # Dict[str, Dict[str, Any]]
-        self.current_profile_path = None
-
-    def set_profile_path(self, profile_path: Path) -> None:
-        self.current_profile_path = profile_path
-
-    def load_configurations(self, objective: str) -> None:
-        """Load autofocus configurations for a specific objective."""
-        config_file = self.current_profile_path / objective / "laser_af_settings.json"
-        if config_file.exists():
-            with open(config_file, "r") as f:
-                config_dict = json.load(f)
-                self.autofocus_configurations[objective] = LaserAFConfig(**config_dict)
-
-    def save_configurations(self, objective: str) -> None:
-        """Save autofocus configurations for a specific objective."""
-        if objective not in self.autofocus_configurations:
-            return
-
-        objective_path = self.current_profile_path / objective
-        if not objective_path.exists():
-            objective_path.mkdir(parents=True)
-        config_file = objective_path / "laser_af_settings.json"
-
-        config_dict = self.autofocus_configurations[objective].model_dump(serialize=True)
-        with open(config_file, "w") as f:
-            json.dump(config_dict, f, indent=4)
-
-    def get_settings_for_objective(self, objective: str) -> Dict[str, Any]:
-        if objective not in self.autofocus_configurations:
-            raise ValueError(f"No configuration found for objective {objective}")
-        return self.autofocus_configurations[objective]
-
-    def get_laser_af_settings(self) -> Dict[str, Any]:
-        return self.autofocus_configurations
-
-    def update_laser_af_settings(
-        self, objective: str, updates: Dict[str, Any], crop_image: Optional[np.ndarray] = None
-    ) -> None:
-        if objective not in self.autofocus_configurations:
-            self.autofocus_configurations[objective] = LaserAFConfig(**updates)
-        else:
-            config = self.autofocus_configurations[objective]
-            self.autofocus_configurations[objective] = config.model_copy(update=updates)
-        if crop_image is not None:
-            self.autofocus_configurations[objective].set_reference_image(crop_image)
-
-
-class ConfigurationManager:
-    """Main configuration manager that coordinates channel and autofocus configurations."""
-
-    def __init__(
-        self,
-        channel_manager: ChannelConfigurationManager,
-        laser_af_manager: Optional[LaserAFSettingManager] = None,
-        base_config_path: Path = Path("acquisition_configurations"),
-        profile: str = "default_profile",
-    ):
-        super().__init__()
-        self.base_config_path = Path(base_config_path)
-        self.current_profile = profile
-        self.available_profiles = self._get_available_profiles()
-
-        self.channel_manager = channel_manager
-        self.laser_af_manager = laser_af_manager
-
-        self.load_profile(profile)
-
-    def _get_available_profiles(self) -> List[str]:
-        """Get all available user profile names in the base config path. Use default profile if no other profiles exist."""
-        if not self.base_config_path.exists():
-            os.makedirs(self.base_config_path)
-            os.makedirs(self.base_config_path / "default_profile")
-            for objective in OBJECTIVES:
-                os.makedirs(self.base_config_path / "default_profile" / objective)
-        return [d.name for d in self.base_config_path.iterdir() if d.is_dir()]
-
-    def _get_available_objectives(self, profile_path: Path) -> List[str]:
-        """Get all available objective names in a profile."""
-        return [d.name for d in profile_path.iterdir() if d.is_dir()]
-
-    def load_profile(self, profile_name: str) -> None:
-        """Load all configurations from a specific profile."""
-        profile_path = self.base_config_path / profile_name
-        if not profile_path.exists():
-            raise ValueError(f"Profile {profile_name} does not exist")
-
-        self.current_profile = profile_name
-        if self.channel_manager:
-            self.channel_manager.set_profile_path(profile_path)
-        if self.laser_af_manager:
-            self.laser_af_manager.set_profile_path(profile_path)
-
-        # Load configurations for each objective
-        for objective in self._get_available_objectives(profile_path):
-            if self.channel_manager:
-                self.channel_manager.load_configurations(objective)
-            if self.laser_af_manager:
-                self.laser_af_manager.load_configurations(objective)
-
-    def create_new_profile(self, profile_name: str) -> None:
-        """Create a new profile using current configurations."""
-        new_profile_path = self.base_config_path / profile_name
-        if new_profile_path.exists():
-            raise ValueError(f"Profile {profile_name} already exists")
-        os.makedirs(new_profile_path)
-
-        objectives = OBJECTIVES
-
-        self.current_profile = profile_name
-        if self.channel_manager:
-            self.channel_manager.set_profile_path(new_profile_path)
-        if self.laser_af_manager:
-            self.laser_af_manager.set_profile_path(new_profile_path)
-
-        for objective in objectives:
-            os.makedirs(new_profile_path / objective)
-            if self.channel_manager:
-                self.channel_manager.save_configurations(objective)
-            if self.laser_af_manager:
-                self.laser_af_manager.save_configurations(objective)
-
-        self.available_profiles = self._get_available_profiles()
-
-
-class ContrastManager:
-    def __init__(self):
-        self.contrast_limits = {}
-        self.acquisition_dtype = None
-
-    def update_limits(self, channel, min_val, max_val):
-        self.contrast_limits[channel] = (min_val, max_val)
-
-    def get_limits(self, channel, dtype=None):
-        if dtype is not None:
-            if self.acquisition_dtype is None:
-                self.acquisition_dtype = dtype
-            elif self.acquisition_dtype != dtype:
-                self.scale_contrast_limits(dtype)
-        return self.contrast_limits.get(channel, self.get_default_limits())
-
-    def get_default_limits(self):
-        if self.acquisition_dtype is None:
-            return (0, 1)
-        elif np.issubdtype(self.acquisition_dtype, np.integer):
-            info = np.iinfo(self.acquisition_dtype)
-            return (info.min, info.max)
-        elif np.issubdtype(self.acquisition_dtype, np.floating):
-            return (0.0, 1.0)
-        else:
-            return (0, 1)
-
-    def get_scaled_limits(self, channel, target_dtype):
-        min_val, max_val = self.get_limits(channel)
-        if self.acquisition_dtype == target_dtype:
-            return min_val, max_val
-
-        source_info = np.iinfo(self.acquisition_dtype)
-        target_info = np.iinfo(target_dtype)
-
-        scaled_min = (min_val - source_info.min) / (source_info.max - source_info.min) * (
-            target_info.max - target_info.min
-        ) + target_info.min
-        scaled_max = (max_val - source_info.min) / (source_info.max - source_info.min) * (
-            target_info.max - target_info.min
-        ) + target_info.min
-
-        return scaled_min, scaled_max
-
-    def scale_contrast_limits(self, target_dtype):
-        print(f"{self.acquisition_dtype} -> {target_dtype}")
-        for channel in self.contrast_limits.keys():
-            self.contrast_limits[channel] = self.get_scaled_limits(channel, target_dtype)
-
-        self.acquisition_dtype = target_dtype
-
-
 from scipy.interpolate import SmoothBivariateSpline, RBFInterpolator
 
 
@@ -4383,7 +3650,6 @@ class FocusMap:
 
 
 class LaserAutofocusController(QObject):
-
     image_to_display = Signal(np.ndarray)
     signal_displacement_um = Signal(float)
     signal_cross_correlation = Signal(float)
@@ -4887,7 +4153,7 @@ class LaserAutofocusController(QObject):
             try:
                 image = self.get_new_frame()
                 if image is None:
-                    self._log.warning(f"Failed to read frame {i+1}/{self.laser_af_properties.laser_af_averaging_n}")
+                    self._log.warning(f"Failed to read frame {i + 1}/{self.laser_af_properties.laser_af_averaging_n}")
                     continue
 
                 self.image = image  # store for debugging # TODO: add to return instead of storing
@@ -4918,7 +4184,7 @@ class LaserAutofocusController(QObject):
                 )
                 if result is None:
                     self._log.warning(
-                        f"No spot detected in frame {i+1}/{self.laser_af_properties.laser_af_averaging_n}"
+                        f"No spot detected in frame {i + 1}/{self.laser_af_properties.laser_af_averaging_n}"
                     )
                     continue
 
@@ -4936,7 +4202,7 @@ class LaserAutofocusController(QObject):
 
             except Exception as e:
                 self._log.error(
-                    f"Error processing frame {i+1}/{self.laser_af_properties.laser_af_averaging_n}: {str(e)}"
+                    f"Error processing frame {i + 1}/{self.laser_af_properties.laser_af_averaging_n}: {str(e)}"
                 )
                 continue
 

--- a/software/control/core/core.py
+++ b/software/control/core/core.py
@@ -40,7 +40,7 @@ try:
 except:
     pass
 
-from typing import List, Tuple, Optional, Dict, Any, Callable
+from typing import List, Tuple, Optional, Dict, Any, Callable, TypeVar
 from queue import Queue
 from threading import Thread, Lock
 from pathlib import Path

--- a/software/control/core/laser_af_settings_manager.py
+++ b/software/control/core/laser_af_settings_manager.py
@@ -1,0 +1,59 @@
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import numpy as np
+
+from control.utils_config import LaserAFConfig
+
+
+class LaserAFSettingManager:
+    """Manages JSON-based laser autofocus configurations."""
+
+    def __init__(self):
+        self.autofocus_configurations: Dict[str, LaserAFConfig] = {}  # Dict[str, Dict[str, Any]]
+        self.current_profile_path = None
+
+    def set_profile_path(self, profile_path: Path) -> None:
+        self.current_profile_path = profile_path
+
+    def load_configurations(self, objective: str) -> None:
+        """Load autofocus configurations for a specific objective."""
+        config_file = self.current_profile_path / objective / "laser_af_settings.json"
+        if config_file.exists():
+            with open(config_file, "r") as f:
+                config_dict = json.load(f)
+                self.autofocus_configurations[objective] = LaserAFConfig(**config_dict)
+
+    def save_configurations(self, objective: str) -> None:
+        """Save autofocus configurations for a specific objective."""
+        if objective not in self.autofocus_configurations:
+            return
+
+        objective_path = self.current_profile_path / objective
+        if not objective_path.exists():
+            objective_path.mkdir(parents=True)
+        config_file = objective_path / "laser_af_settings.json"
+
+        config_dict = self.autofocus_configurations[objective].model_dump(serialize=True)
+        with open(config_file, "w") as f:
+            json.dump(config_dict, f, indent=4)
+
+    def get_settings_for_objective(self, objective: str) -> LaserAFConfig:
+        if objective not in self.autofocus_configurations:
+            raise ValueError(f"No configuration found for objective {objective}")
+        return self.autofocus_configurations[objective]
+
+    def get_laser_af_settings(self) -> Dict[str, Any]:
+        return self.autofocus_configurations
+
+    def update_laser_af_settings(
+        self, objective: str, updates: Dict[str, Any], crop_image: Optional[np.ndarray] = None
+    ) -> None:
+        if objective not in self.autofocus_configurations:
+            self.autofocus_configurations[objective] = LaserAFConfig(**updates)
+        else:
+            config = self.autofocus_configurations[objective]
+            self.autofocus_configurations[objective] = config.model_copy(update=updates)
+        if crop_image is not None:
+            self.autofocus_configurations[objective].set_reference_image(crop_image)

--- a/software/control/core/live_controller.py
+++ b/software/control/core/live_controller.py
@@ -15,7 +15,7 @@ from control import utils_channel
 class LiveController:
     def __init__(
         self,
-        microscope: "Microscope",
+        microscope: "Microscope",  # NOTE(imo): Right now, Microscope needs to import LiveController.  So we can't properly annotate it here.
         control_illumination: bool = True,
         use_internal_timer_for_hardware_trigger: bool = True,
         for_displacement_measurement: bool = False,
@@ -35,8 +35,8 @@ class LiveController:
         self.fps_trigger = 1
         self.timer_trigger_interval = (1.0 / self.fps_trigger) * 1000
 
-        self.timer_trigger: threading.Timer = threading.Timer(self.timer_trigger_interval, self.trigger_acquisition)
-        self.timer_trigger.start()
+        self.timer_trigger: Optional[threading.Timer] = None
+        self._start_new_timer()
 
         self.trigger_ID = -1
 
@@ -269,6 +269,7 @@ class LiveController:
         self._stop_existing_timer()
         interval_s = self.timer_trigger_interval / 1000.0
         self.timer_trigger = threading.Timer(interval_s, self.trigger_acquisition)
+        self.timer_trigger.daemon = True
         self.timer_trigger.start()
 
     def _start_triggerred_acquisition(self):

--- a/software/control/core/live_controller.py
+++ b/software/control/core/live_controller.py
@@ -235,12 +235,14 @@ class LiveController:
 
     def _trigger_acquisition_timer_fn(self):
         if self.trigger_acquisition():
-            self._start_new_timer()
+            if self.is_live:
+                self._start_new_timer()
         else:
-            # It failed, try again real soon
-            # Use a short period so we get back here fast and check again.
-            re_check_period_ms = 10
-            self._start_new_timer(maybe_custom_interval_ms=re_check_period_ms)
+            if self.is_live:
+                # It failed, try again real soon
+                # Use a short period so we get back here fast and check again.
+                re_check_period_ms = 10
+                self._start_new_timer(maybe_custom_interval_ms=re_check_period_ms)
 
     # software trigger related
     def trigger_acquisition(self):

--- a/software/control/core/live_controller.py
+++ b/software/control/core/live_controller.py
@@ -294,6 +294,7 @@ class LiveController:
     def _set_trigger_fps(self, fps_trigger):
         if fps_trigger <= 0:
             raise ValueError(f"fps_trigger must be > 0, but {fps_trigger=}")
+        self._log.debug(f"Setting {fps_trigger=}")
         self.fps_trigger = fps_trigger
         self.timer_trigger_interval = (1 / self.fps_trigger) * 1000
         self._start_new_timer()

--- a/software/control/core/live_controller.py
+++ b/software/control/core/live_controller.py
@@ -45,7 +45,7 @@ class LiveController:
 
         self.display_resolution_scaling = 1
 
-        self.enable_channel_auto_filter_switching = True
+        self.enable_channel_auto_filter_switching: bool = True
 
     # illumination control
     def turn_on_illumination(self):
@@ -206,13 +206,10 @@ class LiveController:
 
     def start_live(self):
         self.is_live = True
-        self._log.error("start_live entry")
         self.microscope.camera.start_streaming()
-        self._log.error("after start_streaming")
         if self.trigger_mode == TriggerMode.SOFTWARE or (
             self.trigger_mode == TriggerMode.HARDWARE and self.use_internal_timer_for_hardware_trigger
         ):
-            self._log.error("STARTING LIVE")
             self.microscope.camera.enable_callbacks(True)  # in case it's disabled e.g. by the laser AF controller
             self._start_triggerred_acquisition()
         # if controlling the laser displacement measurement camera

--- a/software/control/core/live_controller.py
+++ b/software/control/core/live_controller.py
@@ -253,7 +253,9 @@ class LiveController:
             # the cameras can't give us images that fast so we essentially always have at least 1 skipped trigger)
             self._trigger_skip_count += 1
             if self._trigger_skip_count % 100 == 1:
-                self._log.debug(f"Not ready for trigger, skipping (_trigger_skip_count={self._trigger_skip_count}, total frame time = {self.microscope.camera.get_total_frame_time()} [ms]).")
+                self._log.debug(
+                    f"Not ready for trigger, skipping (_trigger_skip_count={self._trigger_skip_count}, total frame time = {self.microscope.camera.get_total_frame_time()} [ms])."
+                )
             return False
 
         self._trigger_skip_count = 0
@@ -276,7 +278,7 @@ class LiveController:
             self.timer_trigger.cancel()
         self.timer_trigger = None
 
-    def _start_new_timer(self, maybe_custom_interval_ms = None):
+    def _start_new_timer(self, maybe_custom_interval_ms=None):
         self._stop_existing_timer()
         if maybe_custom_interval_ms:
             interval_s = maybe_custom_interval_ms / 1000.0

--- a/software/control/core/live_controller.py
+++ b/software/control/core/live_controller.py
@@ -1,0 +1,360 @@
+from __future__ import annotations
+
+import time
+import threading
+from typing import Optional
+
+import squid.logging
+from control.microcontroller import Microcontroller
+from squid.abc import CameraAcquisitionMode
+
+from control._def import *
+from control import utils_channel
+
+
+class LiveController:
+    def __init__(
+        self,
+        microscope: "Microscope",
+        control_illumination: bool = True,
+        use_internal_timer_for_hardware_trigger: bool = True,
+        for_displacement_measurement: bool = False,
+    ):
+        self._log = squid.logging.get_logger(self.__class__.__name__)
+        self.microscope = microscope
+        self.currentConfiguration = None
+        self.trigger_mode: Optional[TriggerMode] = TriggerMode.SOFTWARE  # @@@ change to None
+        self.is_live = False
+        self.control_illumination = control_illumination
+        self.illumination_on = False
+        self.use_internal_timer_for_hardware_trigger = (
+            use_internal_timer_for_hardware_trigger  # use QTimer vs timer in the MCU
+        )
+        self.for_displacement_measurement = for_displacement_measurement
+
+        self.fps_trigger = 1
+        self.timer_trigger_interval = (1.0 / self.fps_trigger) * 1000
+
+        self.timer_trigger: threading.Timer = threading.Timer(self.timer_trigger_interval, self.trigger_acquisition)
+        self.timer_trigger.start()
+
+        self.trigger_ID = -1
+
+        self.fps_real = 0
+        self.counter = 0
+        self.timestamp_last = 0
+
+        self.display_resolution_scaling = 1
+
+        self.enable_channel_auto_filter_switching = True
+
+    # illumination control
+    def turn_on_illumination(self):
+        if not "LED matrix" in self.currentConfiguration.name:
+            self.microscope.illumination_controller.turn_on_illumination(
+                int(utils_channel.extract_wavelength_from_config_name(self.currentConfiguration.name))
+            )
+        elif self.microscope.addons.sci_microscopy_led_array and "LED matrix" in self.currentConfiguration.name:
+            self.microscope.addons.sci_microscopy_led_array.turn_on_illumination()
+        # LED matrix
+        else:
+            self.microscope.low_level_drivers.microcontroller.turn_on_illumination()  # to wrap microcontroller in Squid_led_array
+        self.illumination_on = True
+
+    def turn_off_illumination(self):
+        if not "LED matrix" in self.currentConfiguration.name:
+            self.microscope.illumination_controller.turn_off_illumination(
+                int(utils_channel.extract_wavelength_from_config_name(self.currentConfiguration.name))
+            )
+        elif self.microscope.addons.sci_microscopy_led_array and "LED matrix" in self.currentConfiguration.name:
+            self.microscope.addons.sci_microscopy_led_array.turn_off_illumination()
+        # LED matrix
+        else:
+            self.microscope.low_level_drivers.microcontroller.turn_off_illumination()  # to wrap microcontroller in Squid_led_array
+        self.illumination_on = False
+
+    def update_illumination(self):
+        illumination_source = self.currentConfiguration.illumination_source
+        intensity = self.currentConfiguration.illumination_intensity
+        if illumination_source < 10:  # LED matrix
+            if self.microscope.addons.sci_microscopy_led_array:
+                # set color
+                led_array = self.microscope.addons.sci_microscopy_led_array
+                if "BF LED matrix full_R" in self.currentConfiguration.name:
+                    led_colors = (1, 0, 0)
+                elif "BF LED matrix full_G" in self.currentConfiguration.name:
+                    led_colors = (0, 1, 0)
+                elif "BF LED matrix full_B" in self.currentConfiguration.name:
+                    led_colors = (0, 0, 1)
+                else:
+                    led_colors = SCIMICROSCOPY_LED_ARRAY_DEFAULT_COLOR
+
+                # set mode
+                if "BF LED matrix left half" in self.currentConfiguration.name:
+                    led_mode = "dpc.l"
+                elif "BF LED matrix right half" in self.currentConfiguration.name:
+                    led_mode = "dpc.r"
+                elif "BF LED matrix top half" in self.currentConfiguration.name:
+                    led_mode = "dpc.t"
+                elif "BF LED matrix bottom half" in self.currentConfiguration.name:
+                    led_mode = "dpc.b"
+                elif "BF LED matrix full" in self.currentConfiguration.name:
+                    led_mode = "bf"
+                elif "DF LED matrix" in self.currentConfiguration.name:
+                    led_mode = "df"
+                else:
+                    self._log.warning("Unknown configuration name, using default mode 'bf'.")
+                    led_mode = "bf"
+
+                led_array.set_color(led_colors)
+                led_array.set_brightness(intensity)
+                led_array.set_illumination(led_mode)
+            else:
+                micro: Microcontroller = self.microscope.low_level_drivers.microcontroller
+                if "BF LED matrix full_R" in self.currentConfiguration.name:
+                    micro.set_illumination_led_matrix(illumination_source, r=(intensity / 100), g=0, b=0)
+                elif "BF LED matrix full_G" in self.currentConfiguration.name:
+                    micro.set_illumination_led_matrix(illumination_source, r=0, g=(intensity / 100), b=0)
+                elif "BF LED matrix full_B" in self.currentConfiguration.name:
+                    micro.set_illumination_led_matrix(illumination_source, r=0, g=0, b=(intensity / 100))
+                else:
+                    micro.set_illumination_led_matrix(
+                        illumination_source,
+                        r=(intensity / 100) * LED_MATRIX_R_FACTOR,
+                        g=(intensity / 100) * LED_MATRIX_G_FACTOR,
+                        b=(intensity / 100) * LED_MATRIX_B_FACTOR,
+                    )
+        else:
+            # update illumination
+            wavelength = int(utils_channel.extract_wavelength_from_config_name(self.currentConfiguration.name))
+            self.microscope.illumination_controller.set_intensity(wavelength, intensity)
+            if self.microscope.addons.nl5 and NL5_USE_DOUT and "Fluorescence" in self.currentConfiguration.name:
+                self.microscope.addons.nl5.set_active_channel(NL5_WAVENLENGTH_MAP[wavelength])
+                if NL5_USE_AOUT:
+                    self.microscope.addons.nl5.set_laser_power(NL5_WAVENLENGTH_MAP[wavelength], int(intensity))
+                if self.microscope.addons.cellx and ENABLE_CELLX:
+                    self.microscope.addons.cellx.set_laser_power(NL5_WAVENLENGTH_MAP[wavelength], int(intensity))
+
+        # set emission filter position
+        if ENABLE_SPINNING_DISK_CONFOCAL and self.microscope.addons.xlight:
+            try:
+                self.microscope.addons.xlight.set_emission_filter(
+                    XLIGHT_EMISSION_FILTER_MAPPING[illumination_source],
+                    extraction=False,
+                    validate=XLIGHT_VALIDATE_WHEEL_POS,
+                )
+            except Exception as e:
+                print("not setting emission filter position due to " + str(e))
+
+        if self.microscope.addons.emission_filter_wheel and self.enable_channel_auto_filter_switching:
+            try:
+                if (
+                    self.currentConfiguration.emission_filter_position
+                    != self.microscope.addons.emission_filter_wheel.current_index
+                ):
+                    if ZABER_EMISSION_FILTER_WHEEL_BLOCKING_CALL:
+                        self.microscope.addons.emission_filter_wheel.set_emission_filter(
+                            self.currentConfiguration.emission_filter_position, blocking=True
+                        )
+                    else:
+                        self.microscope.addons.emission_filter_wheel.set_emission_filter(
+                            self.currentConfiguration.emission_filter_position, blocking=False
+                        )
+                        if self.trigger_mode == TriggerMode.SOFTWARE:
+                            time.sleep(ZABER_EMISSION_FILTER_WHEEL_DELAY_MS / 1000)
+                        else:
+                            time.sleep(
+                                max(
+                                    0,
+                                    ZABER_EMISSION_FILTER_WHEEL_DELAY_MS / 1000
+                                    - self.microscope.camera.get_strobe_time() / 1e3,
+                                )
+                            )
+            except Exception as e:
+                print("not setting emission filter position due to " + str(e))
+
+        if (
+            USE_OPTOSPIN_EMISSION_FILTER_WHEEL
+            and self.enable_channel_auto_filter_switching
+            and OPTOSPIN_EMISSION_FILTER_WHEEL_TTL_TRIGGER == False
+        ):
+            try:
+                if (
+                    self.currentConfiguration.emission_filter_position
+                    != self.microscope.addons.emission_filter_wheel.current_index
+                ):
+                    self.microscope.addons.emission_filter_wheel.set_emission_filter(
+                        self.currentConfiguration.emission_filter_position
+                    )
+                    if self.trigger_mode == TriggerMode.SOFTWARE:
+                        time.sleep(OPTOSPIN_EMISSION_FILTER_WHEEL_DELAY_MS / 1000)
+                    elif self.trigger_mode == TriggerMode.HARDWARE:
+                        time.sleep(
+                            max(
+                                0,
+                                OPTOSPIN_EMISSION_FILTER_WHEEL_DELAY_MS / 1000
+                                - self.microscope.camera.get_strobe_time() / 1e3,
+                            )
+                        )
+            except Exception as e:
+                print("not setting emission filter position due to " + str(e))
+
+        if self.microscope.addons.filter_wheel and self.enable_channel_auto_filter_switching:
+            try:
+                self.microscope.addons.filter_wheel.set_emission(self.currentConfiguration.emission_filter_position)
+            except Exception as e:
+                print("not setting emission filter position due to " + str(e))
+
+    def start_live(self):
+        self.is_live = True
+        self._log.error("start_live entry")
+        self.microscope.camera.start_streaming()
+        self._log.error("after start_streaming")
+        if self.trigger_mode == TriggerMode.SOFTWARE or (
+            self.trigger_mode == TriggerMode.HARDWARE and self.use_internal_timer_for_hardware_trigger
+        ):
+            self._log.error("STARTING LIVE")
+            self.microscope.camera.enable_callbacks(True)  # in case it's disabled e.g. by the laser AF controller
+            self._start_triggerred_acquisition()
+        # if controlling the laser displacement measurement camera
+        if self.for_displacement_measurement:
+            self.microscope.low_level_drivers.microcontroller.set_pin_level(MCU_PINS.AF_LASER, 1)
+
+    def stop_live(self):
+        if self.is_live:
+            self.is_live = False
+            if self.trigger_mode == TriggerMode.SOFTWARE:
+                self._stop_triggerred_acquisition()
+            if self.trigger_mode == TriggerMode.CONTINUOUS:
+                self.microscope.camera.stop_streaming()
+            if (self.trigger_mode == TriggerMode.SOFTWARE) or (
+                self.trigger_mode == TriggerMode.HARDWARE and self.use_internal_timer_for_hardware_trigger
+            ):
+                self._stop_triggerred_acquisition()
+            if self.control_illumination:
+                self.turn_off_illumination()
+            # if controlling the laser displacement measurement camera
+            if self.for_displacement_measurement:
+                self.microscope.low_level_drivers.microcontroller.set_pin_level(MCU_PINS.AF_LASER, 0)
+
+    # software trigger related
+    def trigger_acquisition(self):
+        if not self.microscope.camera.get_ready_for_trigger():
+            # TODO(imo): Before, send_trigger would pass silently for this case.  Now
+            # we do the same here.  Should this warn?  I didn't add a warning because it seems like
+            # we over-trigger as standard practice (eg: we trigger at our exposure time frequency, but
+            # the cameras can't give us images that fast so we essentially always have at least 1 skipped trigger)
+            self._log.debug("Not ready for trigger, skipping.")
+            return
+        if self.trigger_mode == TriggerMode.SOFTWARE and self.control_illumination:
+            if not self.illumination_on:
+                self.turn_on_illumination()
+
+        self.trigger_ID = self.trigger_ID + 1
+
+        self.microscope.camera.send_trigger(self.microscope.camera.get_exposure_time())
+
+        if self.trigger_mode == TriggerMode.SOFTWARE:
+            if self.control_illumination and self.illumination_on == False:
+                self.turn_on_illumination()
+
+        self._start_new_timer()
+
+    def _stop_existing_timer(self):
+        if self.timer_trigger and self.timer_trigger.is_alive():
+            self.timer_trigger.cancel()
+        self.timer_trigger = None
+
+    def _start_new_timer(self):
+        self._stop_existing_timer()
+        interval_s = self.timer_trigger_interval / 1000.0
+        self.timer_trigger = threading.Timer(interval_s, self.trigger_acquisition)
+        self.timer_trigger.start()
+
+    def _start_triggerred_acquisition(self):
+        self._start_new_timer()
+
+    def _set_trigger_fps(self, fps_trigger):
+        if fps_trigger <= 0:
+            raise ValueError(f"fps_trigger must be > 0, but {fps_trigger=}")
+        self.fps_trigger = fps_trigger
+        self.timer_trigger_interval = (1 / self.fps_trigger) * 1000
+        self._start_new_timer()
+
+    def _stop_triggerred_acquisition(self):
+        self._stop_existing_timer()
+
+    # trigger mode and settings
+    def set_trigger_mode(self, mode):
+        if mode == TriggerMode.SOFTWARE:
+            if self.is_live and (
+                self.trigger_mode == TriggerMode.HARDWARE and self.use_internal_timer_for_hardware_trigger
+            ):
+                self._stop_triggerred_acquisition()
+            self.microscope.camera.set_acquisition_mode(CameraAcquisitionMode.SOFTWARE_TRIGGER)
+            if self.is_live:
+                self._start_triggerred_acquisition()
+        if mode == TriggerMode.HARDWARE:
+            if self.trigger_mode == TriggerMode.SOFTWARE and self.is_live:
+                self._stop_triggerred_acquisition()
+            self.microscope.camera.set_acquisition_mode(CameraAcquisitionMode.HARDWARE_TRIGGER)
+            self.microscope.camera.set_exposure_time(self.currentConfiguration.exposure_time)
+
+            if self.is_live and self.use_internal_timer_for_hardware_trigger:
+                self._start_triggerred_acquisition()
+        if mode == TriggerMode.CONTINUOUS:
+            if (self.trigger_mode == TriggerMode.SOFTWARE) or (
+                self.trigger_mode == TriggerMode.HARDWARE and self.use_internal_timer_for_hardware_trigger
+            ):
+                self._stop_triggerred_acquisition()
+            self.microscope.camera.set_acquisition_mode(CameraAcquisitionMode.CONTINUOUS)
+        self.trigger_mode = mode
+
+    def set_trigger_fps(self, fps):
+        if (self.trigger_mode == TriggerMode.SOFTWARE) or (
+            self.trigger_mode == TriggerMode.HARDWARE and self.use_internal_timer_for_hardware_trigger
+        ):
+            self._set_trigger_fps(fps)
+
+    # set microscope mode
+    # @@@ to do: change softwareTriggerGenerator to TriggerGeneratror
+    def set_microscope_mode(self, configuration):
+
+        self.currentConfiguration = configuration
+        self._log.info("setting microscope mode to " + self.currentConfiguration.name)
+
+        # temporarily stop live while changing mode
+        if self.is_live is True:
+            self._stop_existing_timer()
+            if self.control_illumination:
+                self.turn_off_illumination()
+
+        # set camera exposure time and analog gain
+        self.microscope.camera.set_exposure_time(self.currentConfiguration.exposure_time)
+        try:
+            self.microscope.camera.set_analog_gain(self.currentConfiguration.analog_gain)
+        except NotImplementedError:
+            pass
+
+        # set illumination
+        if self.control_illumination:
+            self.update_illumination()
+
+        # restart live
+        if self.is_live is True:
+            if self.control_illumination:
+                self.turn_on_illumination()
+            self._start_new_timer()
+        self._log.info("Done setting microscope mode.")
+
+    def get_trigger_mode(self):
+        return self.trigger_mode
+
+    # slot
+    def on_new_frame(self):
+        if self.fps_trigger <= 5:
+            if self.control_illumination and self.illumination_on == True:
+                self.turn_off_illumination()
+
+    def set_display_resolution_scaling(self, display_resolution_scaling):
+        self.display_resolution_scaling = display_resolution_scaling / 100

--- a/software/control/core/live_controller.py
+++ b/software/control/core/live_controller.py
@@ -28,7 +28,7 @@ class LiveController:
         self.control_illumination = control_illumination
         self.illumination_on = False
         self.use_internal_timer_for_hardware_trigger = (
-            use_internal_timer_for_hardware_trigger  # use QTimer vs timer in the MCU
+            use_internal_timer_for_hardware_trigger  # use Timer vs timer in the MCU
         )
         self.for_displacement_measurement = for_displacement_measurement
 
@@ -241,6 +241,7 @@ class LiveController:
             # we over-trigger as standard practice (eg: we trigger at our exposure time frequency, but
             # the cameras can't give us images that fast so we essentially always have at least 1 skipped trigger)
             self._log.debug("Not ready for trigger, skipping.")
+            self._start_new_timer()
             return
         if self.trigger_mode == TriggerMode.SOFTWARE and self.control_illumination:
             if not self.illumination_on:

--- a/software/control/core/live_controller.py
+++ b/software/control/core/live_controller.py
@@ -36,7 +36,6 @@ class LiveController:
         self.timer_trigger_interval = (1.0 / self.fps_trigger) * 1000
 
         self.timer_trigger: Optional[threading.Timer] = None
-        self._start_new_timer()
 
         self.trigger_ID = -1
 

--- a/software/control/core/objective_store.py
+++ b/software/control/core/objective_store.py
@@ -1,0 +1,32 @@
+from control import _def
+
+
+class ObjectiveStore:
+    def __init__(self, objectives_dict=_def.OBJECTIVES, default_objective=_def.DEFAULT_OBJECTIVE):
+        self.objectives_dict = objectives_dict
+        self.default_objective = default_objective
+        self.current_objective = default_objective
+        objective = self.objectives_dict[self.current_objective]
+        self.pixel_size_factor = ObjectiveStore.calculate_pixel_size_factor(objective, _def.TUBE_LENS_MM)
+
+    def get_pixel_size_factor(self):
+        return self.pixel_size_factor
+
+    @staticmethod
+    def calculate_pixel_size_factor(objective, tube_lens_mm):
+        """pixel_size_um = sensor_pixel_size * binning_factor * lens_factor"""
+        magnification = objective["magnification"]
+        objective_tube_lens_mm = objective["tube_lens_f_mm"]
+        lens_factor = objective_tube_lens_mm / magnification / tube_lens_mm
+        return lens_factor
+
+    def set_current_objective(self, objective_name):
+        if objective_name in self.objectives_dict:
+            self.current_objective = objective_name
+            objective = self.objectives_dict[objective_name]
+            self.pixel_size_factor = ObjectiveStore.calculate_pixel_size_factor(objective, _def.TUBE_LENS_MM)
+        else:
+            raise ValueError(f"Objective {objective_name} not found in the store.")
+
+    def get_current_objective_info(self):
+        return self.objectives_dict[self.current_objective]

--- a/software/control/core/stream_handler.py
+++ b/software/control/core/stream_handler.py
@@ -1,0 +1,113 @@
+from dataclasses import dataclass
+import time
+from typing import Callable
+
+import numpy as np
+import cv2
+
+from control import utils
+from control import _def
+from squid.abc import CameraFrame
+
+
+@dataclass
+class StreamHandlerFunctions:
+    image_to_display: Callable[[np.ndarray], None]
+    packet_image_to_write: Callable[[np.ndarray, int, float], None]
+    signal_new_frame_received: Callable[[], None]
+    accept_new_frame: Callable[[], bool]
+
+
+NoOpStreamHandlerFunctions = StreamHandlerFunctions(
+    image_to_display=lambda x: None,
+    packet_image_to_write=lambda a, i, f: None,
+    signal_new_frame_received=lambda: None,
+    accept_new_frame=lambda: True,
+)
+
+
+class StreamHandler:
+    def __init__(
+        self,
+        handler_functions: StreamHandlerFunctions,
+        display_resolution_scaling=1,
+    ):
+        self.fps_display = 1
+        self.fps_save = 1
+        self.fps_track = 1
+        self.timestamp_last_display = 0
+        self.timestamp_last_save = 0
+        self.timestamp_last_track = 0
+
+        self.display_resolution_scaling = display_resolution_scaling
+
+        self.save_image_flag = False
+        self.handler_busy = False
+
+        # for fps measurement
+        self.timestamp_last = 0
+        self.counter = 0
+        self.fps_real = 0
+
+        self._fns: StreamHandlerFunctions = handler_functions
+
+    def start_recording(self):
+        self.save_image_flag = True
+
+    def stop_recording(self):
+        self.save_image_flag = False
+
+    def set_display_fps(self, fps):
+        self.fps_display = fps
+
+    def set_save_fps(self, fps):
+        self.fps_save = fps
+
+    def set_display_resolution_scaling(self, display_resolution_scaling):
+        self.display_resolution_scaling = display_resolution_scaling / 100
+        print(self.display_resolution_scaling)
+
+    def set_functions(self, functions: StreamHandlerFunctions):
+        self._fns = functions
+
+    def on_new_frame(self, frame: CameraFrame):
+        if not self._fns.accept_new_frame():
+            return
+
+        self.handler_busy = True
+        self._fns.signal_new_frame_received()
+
+        # measure real fps
+        timestamp_now = round(time.time())
+        if timestamp_now == self.timestamp_last:
+            self.counter = self.counter + 1
+        else:
+            self.timestamp_last = timestamp_now
+            self.fps_real = self.counter
+            self.counter = 0
+            if _def.PRINT_CAMERA_FPS:
+                print("real camera fps is " + str(self.fps_real))
+
+        # crop image
+        image = np.squeeze(frame.frame)
+
+        # send image to display
+        time_now = time.time()
+        if time_now - self.timestamp_last_display >= 1 / self.fps_display:
+            self._fns.image_to_display(
+                utils.crop_image(
+                    image,
+                    round(image.shape[1] * self.display_resolution_scaling),
+                    round(image.shape[0] * self.display_resolution_scaling),
+                )
+            )
+            self.timestamp_last_display = time_now
+
+        # send image to write
+        if self.save_image_flag and time_now - self.timestamp_last_save >= 1 / self.fps_save:
+            if frame.is_color():
+                image = cv2.cvtColor(image, cv2.COLOR_RGB2BGR)
+            self._fns.packet_image_to_write(image, frame.frame_id, frame.timestamp)
+            self.timestamp_last_save = time_now
+
+        self.handler_busy = False

--- a/software/control/core/stream_handler.py
+++ b/software/control/core/stream_handler.py
@@ -49,7 +49,7 @@ class StreamHandler:
         self.counter = 0
         self.fps_real = 0
 
-        self._fns: StreamHandlerFunctions = handler_functions
+        self._fns: StreamHandlerFunctions = handler_functions if handler_functions else NoOpStreamHandlerFunctions
 
     def start_recording(self):
         self.save_image_flag = True
@@ -68,6 +68,8 @@ class StreamHandler:
         print(self.display_resolution_scaling)
 
     def set_functions(self, functions: StreamHandlerFunctions):
+        if not functions:
+            functions = NoOpStreamHandlerFunctions
         self._fns = functions
 
     def on_new_frame(self, frame: CameraFrame):

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -226,7 +226,6 @@ class HighContentScreeningGui(QMainWindow):
         self.imageArrayDisplayWindow: Optional[core.ImageArrayDisplayWindow] = None
         self.zPlotWidget: Optional[widgets.SurfacePlotWidget] = None
 
-
         self.recordTabWidget: QTabWidget = QTabWidget()
         self.cameraTabWidget: QTabWidget = QTabWidget()
         self.load_widgets()
@@ -418,6 +417,7 @@ class HighContentScreeningGui(QMainWindow):
             self.spinningDiskConfocalWidget = widgets.SpinningDiskConfocalWidget(self.xlight)
         if ENABLE_NL5:
             import control.NL5Widget as NL5Widget
+
             self.nl5Wdiget = NL5Widget.NL5Widget(self.nl5)
 
         if CAMERA_TYPE in ["Toupcam", "Tucsen", "Kinetix"]:

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -1,12 +1,13 @@
 # set QT_API environment variable
 import os
 
-import control.lighting
+from control.NL5Widget import NL5Widget
+from control.filterwheel import SquidFilterWheelWrapper
 
 os.environ["QT_API"] = "pyqt5"
 import serial
 import time
-from typing import Optional
+from typing import Any, Optional
 
 # qt libraries
 from qtpy.QtCore import *
@@ -16,15 +17,26 @@ from qtpy.QtGui import *
 from control._def import *
 
 # app specific libraries
+from control.core.live_controller import LiveController
+from control.core.configuration_mananger import ConfigurationManager
+from control.core.channel_configuration_mananger import ChannelConfigurationManager
+from control.core.laser_af_settings_manager import LaserAFSettingManager
+from control.core.contrast_manager import ContrastManager
+from control.core.objective_store import ObjectiveStore
+from control.core.stream_handler import StreamHandler
+from control.lighting import LightSourceType, IntensityControlMode, ShutterControlMode, IlluminationController
+from control.microcontroller import Microcontroller
+from control.microscope import Microscope
+from squid.abc import AbstractCamera, AbstractStage
+import control.lighting
+import control.microscope
 import control.widgets as widgets
 import pyqtgraph.dockarea as dock
 import squid.abc
-import squid.logging
-import squid.config
-import squid.stage.utils
-import control.microscope
-from control.lighting import LightSourceType, IntensityControlMode, ShutterControlMode, IlluminationController
 import squid.camera.utils
+import squid.config
+import squid.logging
+import squid.stage.utils
 
 log = squid.logging.get_logger(__name__)
 
@@ -68,7 +80,7 @@ class MovementUpdater(QObject):
     position_after_move = Signal(squid.abc.Pos)
     position = Signal(squid.abc.Pos)
 
-    def __init__(self, stage: squid.abc.AbstractStage, movement_threshhold_mm=0.0001, *args, **kwargs):
+    def __init__(self, stage: AbstractStage, movement_threshhold_mm=0.0001, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.stage = stage
         self.movement_threshhold_mm = movement_threshhold_mm
@@ -108,30 +120,114 @@ class HighContentScreeningGui(QMainWindow):
     fps_software_trigger = 100
     LASER_BASED_FOCUS_TAB_NAME = "Laser-Based Focus"
 
-    def __init__(self, is_simulation=False, live_only_mode=False, *args, **kwargs):
+    def __init__(
+        self, microscope: control.microscope.Microscope, is_simulation=False, live_only_mode=False, *args, **kwargs
+    ):
         super().__init__(*args, **kwargs)
-        self.microcontroller: Optional[microcontroller.Microcontroller] = None
 
         self.log = squid.logging.get_logger(self.__class__.__name__)
+
+        self.microscope: control.microscope.Microscope = microscope
+        self.stage: AbstractStage = microscope.stage
+        self.camera: AbstractCamera = microscope.camera
+        self.microcontroller: Microcontroller = microscope.low_level_drivers.microcontroller
+
+        self.xlight: Optional[serial_peripherals.XLight] = microscope.addons.xlight
+        self.nl5: Optional[Any] = microscope.addons.nl5
+        self.cellx: Optional[serial_peripherals.CellX] = microscope.addons.cellx
+        self.emission_filter_wheel: Optional[serial_peripherals.Optospin | serial_peripherals.FilterController] = (
+            microscope.addons.emission_filter_wheel
+        )
+        self.squid_filter_wheel: Optional[SquidFilterWheelWrapper] = microscope.addons.filter_wheel
+        self.objective_changer: Optional[Any] = microscope.addons.objective_changer
+        self.camera_focus: Optional[AbstractCamera] = microscope.addons.camera_focus
+        self.fluidics: Optional[Fluidics] = microscope.addons.fluidics
+        self.piezo: Optional[PiezoStage] = microscope.addons.piezo_stage
+
+        self.channelConfigurationManager: ChannelConfigurationManager = microscope.channel_configuration_manager
+        self.laserAFSettingManager: LaserAFSettingManager = microscope.laser_af_settings_manager
+        self.configurationManager: ConfigurationManager = microscope.configuration_manager
+        self.contrastManager: ContrastManager = microscope.contrast_manager
+        self.liveController: LiveController = microscope.live_controller
+        self.objectiveStore: ObjectiveStore = microscope.objective_store
+
+        self.liveController_focus_camera: Optional[AbstractCamera] = None
+        self.streamHandler_focus_camera: Optional[StreamHandler] = None
+        self.imageDisplayWindow_focus: Optional[core.ImageDisplayWindow] = None
+        self.displacementMeasurementController: Optional[
+            core_displacement_measurement.DisplacementMeasurementController
+        ] = None
+        self.laserAutofocusController: Optional[core.LaserAutofocusController] = None
+
+        if SUPPORT_LASER_AUTOFOCUS:
+            self.liveController_focus_camera = self.microscope.live_controller_focus
+            self.streamHandler_focus_camera = core.QtStreamHandler(
+                accept_new_frame_fn=lambda: self.liveController_focus_camera.is_live
+            )
+            self.imageDisplayWindow_focus = core.ImageDisplayWindow(show_LUT=False, autoLevels=False)
+            self.displacementMeasurementController = core_displacement_measurement.DisplacementMeasurementController()
+            self.laserAutofocusController = core.LaserAutofocusController(
+                self.microcontroller,
+                self.camera_focus,
+                self.liveController_focus_camera,
+                self.stage,
+                self.piezo,
+                self.objectiveStore,
+                self.laserAFSettingManager,
+            )
+
         self.live_only_mode = live_only_mode or LIVE_ONLY_MODE
         self.is_live_scan_grid_on = False
         self.performance_mode = False
         self.napari_connections = {}
         self.well_selector_visible = False  # Add this line to track well selector visibility
 
-        self.loadObjects(is_simulation)
-
-        self.setupHardware()
+        self.load_objects(is_simulation=is_simulation)
+        self.setup_hardware()
 
         self.setup_movement_updater()
 
-        self.loadWidgets()
+        # Pre-declare and give types to all our widgets so type hinting tools work.  You should
+        # add to this as you add widgets.
+        self.spinningDiskConfocalWidget: Optional[widgets.SpinningDiskConfocalWidget] = None
+        self.nl5Wdiget: Optional[NL5Widget] = None
+        self.cameraSettingWidget: Optional[widgets.CameraSettingsWidget] = None
+        self.profileWidget: Optional[widgets.ProfileWidget] = None
+        self.liveControlWidget: Optional[widgets.LiveControlWidget] = None
+        self.navigationWidget: Optional[widgets.NavigationWidget] = None
+        self.stageUtils: Optional[widgets.StageUtils] = None
+        self.dacControlWidget: Optional[widgets.DACControWidget] = None
+        self.autofocusWidget: Optional[widgets.AutoFocusWidget] = None
+        self.piezoWidget: Optional[widgets.PiezoWidget] = None
+        self.objectivesWidget: Optional[widgets.ObjectivesWidget] = None
+        self.filterControllerWidget: Optional[widgets.FilterControllerWidget] = None
+        self.squidFilterWidget: Optional[widgets.SquidFilterWidget] = None
+        self.recordingControlWidget: Optional[widgets.RecordingWidget] = None
+        self.wellplateFormatWidget: Optional[widgets.WellplateFormatWidget] = None
+        self.wellSelectionWidget: Optional[widgets.WellSelectionWidget] = None
+        self.focusMapWidget: Optional[widgets.FocusMapWidget] = None
+        self.cameraSettingWidget_focus_camera: Optional[widgets.CameraSettingsWidget] = None
+        self.laserAutofocusSettingWidget: Optional[widgets.LaserAutofocusSettingWidget] = None
+        self.waveformDisplay: Optional[widgets.WaveformDisplay] = None
+        self.displacementMeasurementWidget: Optional[widgets.DisplacementMeasurementWidget] = None
+        self.laserAutofocusControlWidget: Optional[widgets.LaserAutofocusControlWidget] = None
+        self.fluidicsWidget: Optional[widgets.FluidicsWidget] = None
+        self.flexibleMultiPointWidget: Optional[widgets.FlexibleMultiPointWidget] = None
+        self.wellplateMultiPointWidget: Optional[widgets.WellplateMultiPointWidget] = None
+        self.templateMultiPointWidget: Optional[TemplateMultiPointWidget] = None
+        self.multiPointWithFluidicsWidget: Optional[widgets.MultiPointWithFluidicsWidget] = None
+        self.sampleSettingsWidget: Optional[widgets.SampleSettingsWidget] = None
+        self.trackingControlWidget: Optional[widgets.TrackingControllerWidget] = None
+        self.stitcherWidget: Optional[widgets.StitcherWidget] = None
+        self.napariLiveWidget: Optional[widgets.NapariLiveWidget] = None
+        self.imageDisplayWindow: Optional[core.ImageDisplayWindow] = None
+        self.napariMultiChannelWidget: Optional[widgets.NapariMultiChannelWidget] = None
+        self.imageArrayDisplayWindow: Optional[core.ImageArrayDisplayWindow] = None
+        self.zPlotWidget: Optional[widgets.SurfacePlotWidget] = None
 
-        self.setupLayout()
-
-        self.makeConnections()
-
-        self.microscope = control.microscope.Microscope(microscope=self, is_simulation=is_simulation)
+        self.load_widgets()
+        self.setup_layout()
+        self.make_connections()
 
         # TODO(imo): Why is moving to the cached position after boot hidden behind homing?
         if HOMING_ENABLED_X and HOMING_ENABLED_Y and HOMING_ENABLED_Z:
@@ -167,79 +263,8 @@ class HighContentScreeningGui(QMainWindow):
             self.jupyter_dock.setWidget(self.jupyter_widget)
             self.addDockWidget(Qt.LeftDockWidgetArea, self.jupyter_dock)
 
-    def loadObjects(self, is_simulation):
-        if is_simulation:
-            self.loadSimulationObjects()
-        else:
-            try:
-                self.loadHardwareObjects()
-            except Exception:
-                self.log.error("---- !! ERROR CONNECTING TO HARDWARE !! ----", stack_info=True, exc_info=True)
-                raise
-
-        if HAS_OBJECTIVE_PIEZO:
-            self.piezo = PiezoStage(
-                self.microcontroller,
-                {
-                    "OBJECTIVE_PIEZO_HOME_UM": OBJECTIVE_PIEZO_HOME_UM,
-                    "OBJECTIVE_PIEZO_RANGE_UM": OBJECTIVE_PIEZO_RANGE_UM,
-                    "OBJECTIVE_PIEZO_CONTROL_VOLTAGE_RANGE": OBJECTIVE_PIEZO_CONTROL_VOLTAGE_RANGE,
-                    "OBJECTIVE_PIEZO_FLIP_DIR": OBJECTIVE_PIEZO_FLIP_DIR,
-                },
-            )
-            self.piezo.home()
-        else:
-            self.piezo = None
-
-        def acquisition_camera_hw_trigger_fn(illumination_time: Optional[float]) -> bool:
-            # NOTE(imo): If this succeeds, it means means we sent the request,
-            # but we didn't necessarily get confirmation of success.
-            if ENABLE_NL5 and NL5_USE_DOUT:
-                self.nl5.start_acquisition()
-            else:
-                illumination_time_us = 1000.0 * illumination_time if illumination_time else 0
-                self.log.debug(
-                    f"Sending hw trigger with illumination_time={illumination_time_us if illumination_time else None} [us]"
-                )
-                self.microcontroller.send_hardware_trigger(True if illumination_time else False, illumination_time_us)
-            return True
-
-        def acquisition_camera_hw_strobe_delay_fn(strobe_delay_ms: float) -> bool:
-            strobe_delay_us = int(1000 * strobe_delay_ms)
-            self.log.debug(f"Setting microcontroller strobe delay to {strobe_delay_us} [us]")
-            self.microcontroller.set_strobe_delay_us(strobe_delay_us)
-            self.microcontroller.wait_till_operation_is_completed()
-
-            return True
-
-        self.camera: squid.abc.AbstractCamera = squid.camera.utils.get_camera(
-            squid.config.get_camera_config(),
-            simulated=is_simulation,
-            hw_trigger_fn=acquisition_camera_hw_trigger_fn,
-            hw_set_strobe_delay_ms_fn=acquisition_camera_hw_strobe_delay_fn,
-        )
-        self.camera_focus: Optional[squid.abc.AbstractCamera] = None
-        if SUPPORT_LASER_AUTOFOCUS:
-            self.camera_focus = squid.camera.utils.get_camera(
-                squid.config.get_autofocus_camera_config(), simulated=is_simulation
-            )
-
-        # Common object initialization
-        self.objectiveStore = core.ObjectiveStore()
-        self.channelConfigurationManager = core.ChannelConfigurationManager()
-        if SUPPORT_LASER_AUTOFOCUS:
-            self.laserAFSettingManager = core.LaserAFSettingManager()
-        else:
-            self.laserAFSettingManager = None
-        self.configurationManager = core.ConfigurationManager(
-            channel_manager=self.channelConfigurationManager, laser_af_manager=self.laserAFSettingManager
-        )
-        self.contrastManager = core.ContrastManager()
-
-        self.liveController = core.LiveController(
-            self.camera, self.microcontroller, self.illuminationController, parent=self
-        )
-        self.streamHandler = core.StreamHandler(accept_new_frame_fn=lambda: self.liveController.is_live)
+    def load_objects(self, is_simulation):
+        self.streamHandler = core.QtStreamHandler(accept_new_frame_fn=lambda: self.liveController.is_live)
 
         self.slidePositionController = core.SlidePositionController(
             self.stage, self.liveController, is_for_wellplate=True
@@ -286,206 +311,8 @@ class HighContentScreeningGui(QMainWindow):
             parent=self,
         )
 
-        if SUPPORT_LASER_AUTOFOCUS:
-            self.liveController_focus_camera = core.LiveController(
-                self.camera_focus,
-                self.microcontroller,
-                self,
-                control_illumination=False,
-                for_displacement_measurement=True,
-            )
-            self.streamHandler_focus_camera = core.StreamHandler(
-                accept_new_frame_fn=lambda: self.liveController_focus_camera.is_live
-            )
-            self.imageDisplayWindow_focus = core.ImageDisplayWindow(show_LUT=False, autoLevels=False)
-            self.displacementMeasurementController = core_displacement_measurement.DisplacementMeasurementController()
-            self.laserAutofocusController = core.LaserAutofocusController(
-                self.microcontroller,
-                self.camera_focus,
-                self.liveController_focus_camera,
-                self.stage,
-                self.piezo,
-                self.objectiveStore,
-                self.laserAFSettingManager,
-            )
-        else:
-            self.liveController_focus_camera = None
-            self.streamHandler_focus_camera = None
-            self.imageDisplayWindow_focus = None
-            self.displacementMeasurementController = None
-            self.laserAutofocusController = None
-
-        if USE_SQUID_FILTERWHEEL:
-            self.squid_filter_wheel = filterwheel.SquidFilterWheelWrapper(self.microcontroller)
-
-    def loadSimulationObjects(self):
-        self.log.debug("Loading simulated hardware objects...")
-        self.microcontroller = microcontroller.Microcontroller(
-            serial_device=microcontroller.get_microcontroller_serial_device(simulated=True)
-        )
-        self.illuminationController = IlluminationController(self.microcontroller)
-        if USE_PRIOR_STAGE:
-            self.stage: squid.abc.AbstractStage = squid.stage.prior.PriorStage(
-                sn=PRIOR_STAGE_SN, stage_config=squid.config.get_stage_config()
-            )
-
-        else:
-            self.stage: squid.abc.AbstractStage = squid.stage.cephla.CephlaStage(
-                microcontroller=self.microcontroller, stage_config=squid.config.get_stage_config()
-            )
-        # Initialize simulation objects
-        if ENABLE_SPINNING_DISK_CONFOCAL:
-            self.xlight = serial_peripherals.XLight_Simulation()
-        if ENABLE_NL5:
-            import control.NL5 as NL5
-
-            self.nl5 = NL5.NL5_Simulation()
-        if ENABLE_CELLX:
-            self.cellx = serial_peripherals.CellX_Simulation()
-
-        if USE_LDI_SERIAL_CONTROL:
-            self.ldi = serial_peripherals.LDI_Simulation()
-            self.illuminationController = control.lighting.IlluminationController(
-                self.microcontroller, self.ldi.intensity_mode, self.ldi.shutter_mode, LightSourceType.LDI, self.ldi
-            )
-        if USE_ZABER_EMISSION_FILTER_WHEEL:
-            self.emission_filter_wheel = serial_peripherals.FilterController_Simulation(
-                115200, 8, serial.PARITY_NONE, serial.STOPBITS_ONE
-            )
-        if USE_OPTOSPIN_EMISSION_FILTER_WHEEL:
-            self.emission_filter_wheel = serial_peripherals.Optospin_Simulation(SN=None)
-        if USE_SQUID_FILTERWHEEL:
-            self.squid_filter_wheel = filterwheel.SquidFilterWheelWrapper_Simulation(None)
-        if USE_XERYON:
-            self.objective_changer = ObjectiveChanger2PosController_Simulation(
-                sn=XERYON_SERIAL_NUMBER, stage=self.stage
-            )
-        if RUN_FLUIDICS:
-            self.fluidics = Fluidics(
-                config_path=FLUIDICS_CONFIG_PATH,
-                simulation=True,
-            )
-        else:
-            self.fluidics = None
-
-    def loadHardwareObjects(self):
-        # Initialize hardware objects
-        try:
-            self.microcontroller = microcontroller.Microcontroller(
-                serial_device=microcontroller.get_microcontroller_serial_device(
-                    version=CONTROLLER_VERSION, sn=CONTROLLER_SN
-                )
-            )
-        except Exception:
-            self.log.error(f"Error initializing Microcontroller")
-            raise
-
-        self.illuminationController = IlluminationController(self.microcontroller)
-
-        if USE_PRIOR_STAGE:
-            self.stage: squid.abc.AbstractStage = squid.stage.prior.PriorStage(
-                sn=PRIOR_STAGE_SN, stage_config=squid.config.get_stage_config()
-            )
-
-        else:
-            self.stage: squid.abc.AbstractStage = squid.stage.cephla.CephlaStage(
-                microcontroller=self.microcontroller, stage_config=squid.config.get_stage_config()
-            )
-
-        if ENABLE_SPINNING_DISK_CONFOCAL:
-            try:
-                self.xlight = serial_peripherals.XLight(XLIGHT_SERIAL_NUMBER, XLIGHT_SLEEP_TIME_FOR_WHEEL)
-            except Exception:
-                self.log.error("Error initializing Spinning Disk Confocal")
-                raise
-
-        if ENABLE_NL5:
-            try:
-                import control.NL5 as NL5
-
-                self.nl5 = NL5.NL5()
-            except Exception:
-                self.log.error("Error initializing NL5")
-                raise
-
-        if ENABLE_CELLX:
-            try:
-                self.cellx = serial_peripherals.CellX(CELLX_SN)
-                for channel in [1, 2, 3, 4]:
-                    self.cellx.set_modulation(channel, CELLX_MODULATION)
-                    self.cellx.turn_on(channel)
-            except Exception:
-                self.log.error("Error initializing CellX")
-                raise
-
-        if USE_LDI_SERIAL_CONTROL:
-            try:
-                self.ldi = serial_peripherals.LDI()
-                self.illuminationController = IlluminationController(
-                    self.microcontroller, self.ldi.intensity_mode, self.ldi.shutter_mode, LightSourceType.LDI, self.ldi
-                )
-            except Exception:
-                self.log.error("Error initializing LDI")
-                raise
-
-        if USE_CELESTA_ETHENET_CONTROL:
-            try:
-                import control.celesta
-
-                self.celesta = control.celesta.CELESTA()
-                self.illuminationController = IlluminationController(
-                    self.microcontroller,
-                    IntensityControlMode.Software,
-                    ShutterControlMode.TTL,
-                    LightSourceType.CELESTA,
-                    self.celesta,
-                )
-            except Exception:
-                self.log.error("Error initializing CELESTA")
-                raise
-
-        if USE_ZABER_EMISSION_FILTER_WHEEL:
-            try:
-                self.emission_filter_wheel = serial_peripherals.FilterController(
-                    FILTER_CONTROLLER_SERIAL_NUMBER, 115200, 8, serial.PARITY_NONE, serial.STOPBITS_ONE
-                )
-            except Exception:
-                self.log.error("Error initializing Zaber Emission Filter Wheel")
-                raise
-
-        if USE_OPTOSPIN_EMISSION_FILTER_WHEEL:
-            try:
-                self.emission_filter_wheel = serial_peripherals.Optospin(SN=FILTER_CONTROLLER_SERIAL_NUMBER)
-            except Exception:
-                self.log.error("Error initializing Optospin Emission Filter Wheel")
-                raise
-
-        if USE_XERYON:
-            try:
-                self.objective_changer = ObjectiveChanger2PosController(sn=XERYON_SERIAL_NUMBER, stage=self.stage)
-            except Exception:
-                self.log.error("Error initializing Xeryon objective switcher")
-                raise
-
-        if RUN_FLUIDICS:
-            try:
-                self.fluidics = Fluidics(
-                    config_path=FLUIDICS_CONFIG_PATH,
-                    simulation=False,
-                )
-            except Exception:
-                self.log.error("Error initializing Fluidics")
-                raise
-        else:
-            self.fluidics = None
-
-    def setupHardware(self):
+    def setup_hardware(self):
         # Setup hardware components
-        if USE_ZABER_EMISSION_FILTER_WHEEL:
-            self.emission_filter_wheel.start_homing()
-        if USE_OPTOSPIN_EMISSION_FILTER_WHEEL:
-            self.emission_filter_wheel.set_speed(OPTOSPIN_EMISSION_FILTER_WHEEL_SPEED_HZ)
-
         if not self.microcontroller:
             raise ValueError("Microcontroller must be none-None for hardware setup.")
 
@@ -551,22 +378,22 @@ class HighContentScreeningGui(QMainWindow):
             self.camera.set_acquisition_mode(squid.abc.CameraAcquisitionMode.HARDWARE_TRIGGER)
         else:
             self.camera.set_acquisition_mode(squid.abc.CameraAcquisitionMode.SOFTWARE_TRIGGER)
-        self.camera.add_frame_callback(self.streamHandler.on_new_frame)
+        self.camera.add_frame_callback(self.streamHandler.get_frame_callback())
         self.camera.enable_callbacks(enabled=True)
 
-        if SUPPORT_LASER_AUTOFOCUS:
+        if self.camera_focus:
             self.camera_focus.set_acquisition_mode(
                 squid.abc.CameraAcquisitionMode.SOFTWARE_TRIGGER
             )  # self.camera.set_continuous_acquisition()
-            self.camera_focus.add_frame_callback(self.streamHandler_focus_camera.on_new_frame)
+            self.camera_focus.add_frame_callback(self.streamHandler_focus_camera.get_frame_callback())
             self.camera_focus.enable_callbacks(enabled=True)
             self.camera_focus.start_streaming()
 
-        if USE_SQUID_FILTERWHEEL:
+        if self.squid_filter_wheel:
             if SQUID_FILTERWHEEL_HOMING_ENABLED:
                 self.squid_filter_wheel.homing()
 
-        if USE_XERYON:
+        if self.objective_changer:
             self.objective_changer.home()
             self.objective_changer.setSpeed(XERYON_SPEED)
             if DEFAULT_OBJECTIVE in XERYON_OBJECTIVE_SWITCHER_POS_1:
@@ -581,7 +408,7 @@ class HighContentScreeningGui(QMainWindow):
             self.log.error(error_message or "Microcontroller operation timed out!")
             raise e
 
-    def loadWidgets(self):
+    def load_widgets(self):
         # Initialize all GUI widgets
         if ENABLE_SPINNING_DISK_CONFOCAL:
             self.spinningDiskConfocalWidget = widgets.SpinningDiskConfocalWidget(self.xlight)
@@ -683,7 +510,7 @@ class HighContentScreeningGui(QMainWindow):
         if RUN_FLUIDICS:
             self.fluidicsWidget = widgets.FluidicsWidget(self.fluidics)
 
-        self.imageDisplayTabs = QTabWidget()
+        self.imageDisplayTabs = QTabWidget(parent=self)
         if self.live_only_mode:
             if ENABLE_TRACKING:
                 self.imageDisplayWindow = core.ImageDisplayWindow(self.liveController, self.contrastManager)
@@ -750,10 +577,10 @@ class HighContentScreeningGui(QMainWindow):
                 self.objectiveStore, self.channelConfigurationManager, self.contrastManager
             )
 
-        self.recordTabWidget = QTabWidget()
+        self.recordTabWidget: QTabWidget = QTabWidget()
         self.setupRecordTabWidget()
 
-        self.cameraTabWidget = QTabWidget()
+        self.cameraTabWidget: QTabWidget = QTabWidget()
         self.setupCameraTabWidget()
 
     def setupImageDisplayTabs(self):
@@ -883,7 +710,7 @@ class HighContentScreeningGui(QMainWindow):
         self.cameraTabWidget.currentChanged.connect(lambda: self.resizeCurrentTab(self.cameraTabWidget))
         self.resizeCurrentTab(self.cameraTabWidget)
 
-    def setupLayout(self):
+    def setup_layout(self):
         layout = QVBoxLayout()
 
         if USE_NAPARI_FOR_LIVE_CONTROL and not self.live_only_mode:
@@ -972,7 +799,7 @@ class HighContentScreeningGui(QMainWindow):
         self.tabbedImageDisplayWindow.setFixedSize(width_min, height_min)
         self.tabbedImageDisplayWindow.show()
 
-    def makeConnections(self):
+    def make_connections(self):
         self.streamHandler.signal_new_frame_received.connect(self.liveController.on_new_frame)
         self.streamHandler.packet_image_to_write.connect(self.imageSaver.enqueue)
 

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -221,10 +221,14 @@ class HighContentScreeningGui(QMainWindow):
         self.stitcherWidget: Optional[widgets.StitcherWidget] = None
         self.napariLiveWidget: Optional[widgets.NapariLiveWidget] = None
         self.imageDisplayWindow: Optional[core.ImageDisplayWindow] = None
+        self.imageDisplayWindow_focus: Optional[core.ImageDisplayWindow] = None
         self.napariMultiChannelWidget: Optional[widgets.NapariMultiChannelWidget] = None
         self.imageArrayDisplayWindow: Optional[core.ImageArrayDisplayWindow] = None
         self.zPlotWidget: Optional[widgets.SurfacePlotWidget] = None
 
+
+        self.recordTabWidget: QTabWidget = QTabWidget()
+        self.cameraTabWidget: QTabWidget = QTabWidget()
         self.load_widgets()
         self.setup_layout()
         self.make_connections()
@@ -270,7 +274,7 @@ class HighContentScreeningGui(QMainWindow):
             self.stage, self.liveController, is_for_wellplate=True
         )
         self.autofocusController = core.AutoFocusController(
-            self.camera, self.stage, self.liveController, self.microcontroller
+            self.camera, self.stage, self.liveController, self.microcontroller, self.nl5
         )
 
         self.imageSaver = core.ImageSaver()
@@ -414,7 +418,6 @@ class HighContentScreeningGui(QMainWindow):
             self.spinningDiskConfocalWidget = widgets.SpinningDiskConfocalWidget(self.xlight)
         if ENABLE_NL5:
             import control.NL5Widget as NL5Widget
-
             self.nl5Wdiget = NL5Widget.NL5Widget(self.nl5)
 
         if CAMERA_TYPE in ["Toupcam", "Tucsen", "Kinetix"]:
@@ -449,8 +452,7 @@ class HighContentScreeningGui(QMainWindow):
         self.autofocusWidget = widgets.AutoFocusWidget(self.autofocusController)
         if self.piezo:
             self.piezoWidget = widgets.PiezoWidget(self.piezo)
-        else:
-            self.piezoWidget = None
+
         if USE_XERYON:
             self.objectivesWidget = widgets.ObjectivesWidget(self.objectiveStore, self.objective_changer)
         else:
@@ -577,10 +579,7 @@ class HighContentScreeningGui(QMainWindow):
                 self.objectiveStore, self.channelConfigurationManager, self.contrastManager
             )
 
-        self.recordTabWidget: QTabWidget = QTabWidget()
         self.setupRecordTabWidget()
-
-        self.cameraTabWidget: QTabWidget = QTabWidget()
         self.setupCameraTabWidget()
 
     def setupImageDisplayTabs(self):

--- a/software/control/lighting.py
+++ b/software/control/lighting.py
@@ -5,6 +5,8 @@ import numpy as np
 import pandas as pd
 from pathlib import Path
 
+from control.microcontroller import Microcontroller
+
 
 class LightSourceType(Enum):
     SquidLED = 0
@@ -28,7 +30,7 @@ class ShutterControlMode(Enum):
 class IlluminationController:
     def __init__(
         self,
-        microcontroller,
+        microcontroller: Microcontroller,
         intensity_control_mode=IntensityControlMode.SquidControllerDAC,
         shutter_control_mode=ShutterControlMode.TTL,
         light_source_type=None,

--- a/software/control/lighting.py
+++ b/software/control/lighting.py
@@ -109,21 +109,6 @@ class IlluminationController:
         self.light_source.set_shutter_control_mode(mode)
         self.shutter_control_mode = mode
 
-    # current not used
-    """
-    def get_intensity_control_mode(self):
-        mode = self.light_source.get_intensity_control_mode()
-        if mode is not None:
-            self.intensity_control_mode = mode
-            return mode
-
-    def get_shutter_control_mode(self):
-        mode = self.light_source.get_shutter_control_mode()
-        if mode is not None:
-            self.shutter_control_mode = mode
-            return mode
-    """
-
     def get_intensity(self, channel):
         if self.intensity_control_mode == IntensityControlMode.Software:
             intensity = self.light_source.get_intensity(self.channel_mappings_software[channel])

--- a/software/control/microcontroller.py
+++ b/software/control/microcontroller.py
@@ -318,6 +318,9 @@ class MicrocontrollerSerial(AbstractCephlaMicroSerial):
         self._baudrate = baudrate
         self._serial = serial.Serial(port, baudrate)
 
+    def __del__(self):
+        self.close()
+
     def close(self) -> None:
         return self._serial.close()
 

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -218,7 +218,9 @@ class Microscope:
                 raise ValueError("For a cephla stage microscope, you must provide a microcontroller.")
             stage = CephlaStage(low_level_devices.microcontroller, stage_config)
 
-        addons = MicroscopeAddons.build_from_global_config(stage, low_level_devices.microcontroller, simulated=simulated)
+        addons = MicroscopeAddons.build_from_global_config(
+            stage, low_level_devices.microcontroller, simulated=simulated
+        )
 
         cam_trigger_log = squid.logging.get_logger("camera hw functions")
 

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -286,9 +286,9 @@ class Microscope:
         illumination_controller: IlluminationController,
         addons: MicroscopeAddons,
         low_level_drivers: LowLevelDrivers,
-        stream_handler_callbacks: Optional[StreamHandlerFunctions] = None,
+        stream_handler_callbacks: Optional[StreamHandlerFunctions] = NoOpStreamHandlerFunctions,
         simulated: bool = False,
-        skip_prepare_for_use: bool = False
+        skip_prepare_for_use: bool = False,
     ):
         super().__init__()
         self._log = squid.logging.get_logger(self.__class__.__name__)

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -1,346 +1,372 @@
 import math
 import re
 import serial
-from typing import Optional
+from typing import Optional, TypeVar
 
-from PyQt5.QtCore import QObject
-
-import control.core.core as core
 from control._def import *
-import squid.camera.utils
-from squid.abc import CameraAcquisitionMode
-import squid.stage.cephla
-import squid.abc
-import squid.logging
-import squid.config
-import squid.stage.utils
+from control.core.channel_configuration_mananger import ChannelConfigurationManager
+from control.core.configuration_mananger import ConfigurationManager
+from control.core.contrast_manager import ContrastManager
+from control.core.laser_af_settings_manager import LaserAFSettingManager
+from control.core.live_controller import LiveController
+from control.core.objective_store import ObjectiveStore
+from control.core.stream_handler import StreamHandler, StreamHandlerFunctions, NoOpStreamHandlerFunctions
+from control.filterwheel import SquidFilterWheelWrapper
 
-import control.microcontroller as microcontroller
 from control.lighting import LightSourceType, IntensityControlMode, ShutterControlMode, IlluminationController
+from control.microcontroller import Microcontroller
 from control.piezo import PiezoStage
-import control.serial_peripherals as serial_peripherals
+from control.serial_peripherals import SciMicroscopyLEDArray
+from squid.abc import CameraAcquisitionMode, AbstractCamera, AbstractStage
+from squid.stage.cephla import CephlaStage
+from squid.stage.prior import PriorStage
+import control.celesta
 import control.filterwheel as filterwheel
+import control.microcontroller as microcontroller
+import control.serial_peripherals as serial_peripherals
+import squid.camera.utils
+import squid.config
+import squid.logging
+import squid.stage.cephla
+import squid.stage.utils
 
 if USE_XERYON:
     from control.objective_changer_2_pos_controller import (
         ObjectiveChanger2PosController,
         ObjectiveChanger2PosController_Simulation,
     )
+else:
+    ObjectiveChanger2PosController = TypeVar("ObjectiveChanger2PosController")
 
-if SUPPORT_LASER_AUTOFOCUS:
-    import control.core_displacement_measurement as core_displacement_measurement
+if RUN_FLUIDICS:
+    from control.fluidics import Fluidics
+else:
+    Fluidics = TypeVar("Fluidics")
+
+if ENABLE_NL5:
+    import control.NL5 as NL5
+else:
+    NL5 = TypeVar("NL5")
 
 
-class Microscope(QObject):
+class MicroscopeAddons:
+    @staticmethod
+    def build_from_global_config(
+        stage: AbstractStage, micro: Optional[Microcontroller], simulated: bool = False
+    ) -> "MicroscopeAddons":
 
-    def __init__(self, microscope=None, is_simulation=False):
-        super().__init__()
-        self._log = squid.logging.get_logger(self.__class__.__name__)
-        if microscope is None:
-            self.initialize_microcontroller(is_simulation=is_simulation)
-            self.initialize_camera(is_simulation=is_simulation)
-            self.initialize_core_components()
-            if not is_simulation:
-                self.initialize_peripherals()
-            else:
-                self.initialize_simulation_objects()
-            self.setup_hardware()
-            self.performance_mode = True
-        else:
-            self.camera = microscope.camera
-            self.camera_focus = microscope.camera_focus
-            self.stage = microscope.stage
-            self.microcontroller = microscope.microcontroller
-            self.configurationManager = microscope.configurationManager
-            self.objectiveStore = microscope.objectiveStore
-            self.streamHandler = microscope.streamHandler
-            self.liveController = microscope.liveController
-            self.multipointController = microscope.multipointController
-            self.illuminationController = microscope.illuminationController
-            self.performance_mode = microscope.performance_mode
+        xlight = None
+        if ENABLE_SPINNING_DISK_CONFOCAL:
+            xlight = (
+                serial_peripherals.XLight(XLIGHT_SERIAL_NUMBER, XLIGHT_SLEEP_TIME_FOR_WHEEL)
+                if not simulated
+                else serial_peripherals.XLight_Simulation()
+            )
 
-            if SUPPORT_LASER_AUTOFOCUS:
-                self.laserAutofocusController = microscope.laserAutofocusController
-            self.slidePositionController = microscope.slidePositionController
+        nl5 = None
+        if ENABLE_NL5:
+            nl5 = NL5.NL5() if not simulated else NL5.NL5_Simulation()
 
-            if ENABLE_SPINNING_DISK_CONFOCAL:
-                self.xlight = microscope.xlight
+        cellx = None
+        if ENABLE_CELLX:
+            cellx = serial_peripherals.CellX(CELLX_SN) if not simulated else serial_peripherals.CellX_Simulation()
 
-            if ENABLE_NL5:
-                self.nl5 = microscope.nl5
-
-            if ENABLE_CELLX:
-                self.cellx = microscope.cellx
-
-            if USE_LDI_SERIAL_CONTROL:
-                self.ldi = microscope.ldi
-
-            if USE_CELESTA_ETHENET_CONTROL:
-                self.celesta = microscope.celesta
-
-            if USE_ZABER_EMISSION_FILTER_WHEEL or USE_OPTOSPIN_EMISSION_FILTER_WHEEL:
-                self.emission_filter_wheel = microscope.emission_filter_wheel
-
-            if USE_XERYON:
-                self.objective_changer = microscope.objective_changer
-
-    def initialize_camera(self, is_simulation):
-        def acquisition_camera_hw_trigger_fn(illumination_time: Optional[float]) -> bool:
-            # NOTE(imo): If this succeeds, it means means we sent the request,
-            # but we didn't necessarily get confirmation of success.
-            if ENABLE_NL5 and NL5_USE_DOUT:
-                self.nl5.start_acquisition()
-            else:
-                illumination_time_us = 1000.0 * illumination_time if illumination_time else 0
-                self._log.debug(
-                    f"Sending hw trigger with illumination_time={illumination_time_us if illumination_time else None} [us]"
+        emission_filter_wheel = None
+        if USE_ZABER_EMISSION_FILTER_WHEEL:
+            emission_filter_wheel = (
+                serial_peripherals.FilterController(
+                    FILTER_CONTROLLER_SERIAL_NUMBER, 115200, 8, serial.PARITY_NONE, serial.STOPBITS_ONE
                 )
-                self.microcontroller.send_hardware_trigger(True if illumination_time else False, illumination_time_us)
-            return True
+                if not simulated
+                else serial_peripherals.FilterController_Simulation(115200, 8, serial.PARITY_NONE, serial.STOPBITS_ONE)
+            )
+        elif USE_OPTOSPIN_EMISSION_FILTER_WHEEL:
+            emission_filter_wheel = (
+                serial_peripherals.Optospin(SN=FILTER_CONTROLLER_SERIAL_NUMBER)
+                if not simulated
+                else serial_peripherals.Optospin_Simulation(SN=None)
+            )
 
-        def acquisition_camera_hw_strobe_delay_fn(strobe_delay_ms: float) -> bool:
-            strobe_delay_us = int(1000 * strobe_delay_ms)
-            self._log.debug(f"Setting microcontroller strobe delay to {strobe_delay_us} [us]")
-            self.microcontroller.set_strobe_delay_us(strobe_delay_us)
-            self.microcontroller.wait_till_operation_is_completed()
+        squid_filter_wheel = None
+        if USE_SQUID_FILTERWHEEL:
+            squid_filter_wheel = (
+                filterwheel.SquidFilterWheelWrapper(microcontroller)
+                if not simulated
+                else filterwheel.SquidFilterWheelWrapper_Simulation(None)
+            )
 
-            return True
+        objective_changer = None
+        if USE_XERYON:
+            objective_changer = (
+                ObjectiveChanger2PosController(sn=XERYON_SERIAL_NUMBER, stage=stage)
+                if not simulated
+                else ObjectiveChanger2PosController_Simulation(sn=XERYON_SERIAL_NUMBER, stage=stage)
+            )
 
-        self.camera = squid.camera.utils.get_camera(
-            squid.config.get_camera_config(),
-            simulated=is_simulation,
-            hw_trigger_fn=acquisition_camera_hw_trigger_fn,
-            hw_set_strobe_delay_ms_fn=acquisition_camera_hw_strobe_delay_fn,
-        )
-
-        self.camera.set_pixel_format(squid.config.CameraPixelFormat.from_string(CAMERA_CONFIG.PIXEL_FORMAT_DEFAULT))
-        self.camera.set_acquisition_mode(CameraAcquisitionMode.SOFTWARE_TRIGGER)
-
+        camera_focus = None
         if SUPPORT_LASER_AUTOFOCUS:
-            self.camera_focus = squid.camera.utils.get_camera(
-                squid.config.get_autofocus_camera_config(), simulated=is_simulation
-            )
-            self.camera_focus.set_pixel_format(squid.config.CameraPixelFormat.from_string("MONO8"))
-            self.camera_focus.set_acquisition_mode(CameraAcquisitionMode.SOFTWARE_TRIGGER)
-        else:
-            self.camera_focus = None
-
-    def initialize_microcontroller(self, is_simulation):
-        self.microcontroller = microcontroller.Microcontroller(
-            serial_device=microcontroller.get_microcontroller_serial_device(
-                version=CONTROLLER_VERSION, sn=CONTROLLER_SN, simulated=is_simulation
-            )
-        )
-        self.illuminationController = IlluminationController(self.microcontroller)
-        if not USE_PRIOR_STAGE or is_simulation:  # TODO: Simulated Prior stage is not implemented yet
-            self.stage = squid.stage.cephla.CephlaStage(
-                microcontroller=self.microcontroller, stage_config=squid.config.get_stage_config()
+            camera_focus = squid.camera.utils.get_camera(
+                squid.config.get_autofocus_camera_config(), simulated=simulated
             )
 
-        self.home_x_and_y_separately = False
+        fluidics = None
+        if RUN_FLUIDICS:
+            fluidics = Fluidics(config_path=FLUIDICS_CONFIG_PATH, simulation=simulated)
 
-    def initialize_core_components(self):
+        piezo_stage = None
         if HAS_OBJECTIVE_PIEZO:
-            self.piezo = PiezoStage(
-                self.microcontroller,
-                {
+            if not micro:
+                raise ValueError("Cannot create PiezoStage without a Microcontroller.")
+            piezo_stage = PiezoStage(
+                microcontroller=micro,
+                config={
                     "OBJECTIVE_PIEZO_HOME_UM": OBJECTIVE_PIEZO_HOME_UM,
                     "OBJECTIVE_PIEZO_RANGE_UM": OBJECTIVE_PIEZO_RANGE_UM,
                     "OBJECTIVE_PIEZO_CONTROL_VOLTAGE_RANGE": OBJECTIVE_PIEZO_CONTROL_VOLTAGE_RANGE,
                     "OBJECTIVE_PIEZO_FLIP_DIR": OBJECTIVE_PIEZO_FLIP_DIR,
                 },
             )
-            self.piezo.home()
-        else:
-            self.piezo = None
 
-        self.objectiveStore = core.ObjectiveStore()
-        self.channelConfigurationManager = core.ChannelConfigurationManager()
-        if SUPPORT_LASER_AUTOFOCUS:
-            self.laserAFSettingManager = core.LaserAFSettingManager()
-        else:
-            self.laserAFSettingManager = None
-        self.configurationManager = core.ConfigurationManager(
-            self.channelConfigurationManager, self.laserAFSettingManager
+        sci_microscopy_led_array = None
+        if SUPPORT_SCIMICROSCOPY_LED_ARRAY:
+            # to do: add error handling
+            sci_microscopy_led_array = serial_peripherals.SciMicroscopyLEDArray(
+                SCIMICROSCOPY_LED_ARRAY_SN, SCIMICROSCOPY_LED_ARRAY_DISTANCE, SCIMICROSCOPY_LED_ARRAY_TURN_ON_DELAY
+            )
+            sci_microscopy_led_array.set_NA(SCIMICROSCOPY_LED_ARRAY_DEFAULT_NA)
+
+        return MicroscopeAddons(
+            xlight,
+            nl5,
+            cellx,
+            emission_filter_wheel,
+            squid_filter_wheel,
+            objective_changer,
+            camera_focus,
+            fluidics,
+            piezo_stage,
+            sci_microscopy_led_array,
         )
 
-        self.liveController = core.LiveController(self.camera, self.microcontroller, self.illuminationController, self)
-        self.streamHandler = core.StreamHandler(accept_new_frame_fn=lambda: self.liveController.is_live)
-        self.slidePositionController = core.SlidePositionController(self.stage, self.liveController)
+    def __init__(
+        self,
+        xlight: Optional[serial_peripherals.XLight] = None,
+        nl5: Optional[NL5] = None,
+        cellx: Optional[serial_peripherals.CellX] = None,
+        emission_filter_wheel: Optional[serial_peripherals.Optospin | serial_peripherals.FilterController] = None,
+        filter_wheel: Optional[SquidFilterWheelWrapper] = None,
+        objective_changer: Optional[ObjectiveChanger2PosController] = None,
+        camera_focus: Optional[AbstractCamera] = None,
+        fluidics: Optional[Fluidics] = None,
+        piezo_stage: Optional[PiezoStage] = None,
+        sci_microscopy_led_array: Optional[SciMicroscopyLEDArray] = None,
+    ):
+        self.xlight: Optional[serial_peripherals.XLight] = xlight
+        self.nl5: Optional[NL5] = nl5
+        self.cellx: Optional[serial_peripherals.CellX] = cellx
+        self.emission_filter_wheel = emission_filter_wheel
+        self.filter_wheel = filter_wheel
+        self.objective_changer = objective_changer
+        self.camera_focus: Optional[AbstractCamera] = camera_focus
+        self.fluidics = fluidics
+        self.piezo_stage = piezo_stage
+        self.sci_microscopy_led_array = sci_microscopy_led_array
 
-        if SUPPORT_LASER_AUTOFOCUS:
-            self.liveController_focus_camera = core.LiveController(
-                self.camera_focus,
-                self.microcontroller,
-                None,
-                self,
-                control_illumination=False,
-                for_displacement_measurement=True,
+    def prepare_for_use(self):
+        """
+        Prepare all the addon hardware for immediate use.
+
+        NOTE(imo): The emission_filter wheel is confusing - there's no base class but it can be multiple
+        different variants with different methods.  For now leave as is just to make progress, but
+        we need to fix this.
+        """
+        if USE_ZABER_EMISSION_FILTER_WHEEL:
+            self.emission_filter_wheel.start_homing()
+        if USE_OPTOSPIN_EMISSION_FILTER_WHEEL:
+            self.emission_filter_wheel.set_speed(OPTOSPIN_EMISSION_FILTER_WHEEL_SPEED_HZ)
+
+
+class LowLevelDrivers:
+    @staticmethod
+    def build_from_global_config(simulated: bool = False) -> "LowLevelDrivers":
+        micro_serial_device = (
+            microcontroller.get_microcontroller_serial_device(version=CONTROLLER_VERSION, sn=CONTROLLER_SN)
+            if not simulated
+            else microcontroller.get_microcontroller_serial_device(simulated=True)
+        )
+        micro = microcontroller.Microcontroller(serial_device=micro_serial_device)
+
+        return LowLevelDrivers(microcontroller=micro)
+
+    def __init__(self, microcontroller: Optional[Microcontroller] = None):
+        self.microcontroller: Optional[Microcontroller] = microcontroller
+
+    def prepare_for_use(self):
+        pass
+
+
+class Microscope:
+    @staticmethod
+    def build_from_global_config(simulated: bool = False):
+        low_level_devices = LowLevelDrivers.build_from_global_config(simulated)
+
+        stage_config = squid.config.get_stage_config()
+        if USE_PRIOR_STAGE:
+            stage = PriorStage(sn=PRIOR_STAGE_SN, stage_config=stage_config)
+        else:
+            if microcontroller is None:
+                raise ValueError("For a cephla stage microscope, you must provide a microcontroller.")
+            stage = CephlaStage(low_level_devices.microcontroller, stage_config)
+
+        addons = MicroscopeAddons.build_from_global_config(stage, low_level_devices.microcontroller)
+
+        cam_trigger_log = squid.logging.get_logger("camera hw functions")
+
+        def acquisition_camera_hw_trigger_fn(illumination_time: Optional[float]) -> bool:
+            # NOTE(imo): If this succeeds, it means we sent the request,
+            # but we didn't necessarily get confirmation of success.
+            if addons.nl5 and NL5_USE_DOUT:
+                addons.nl5.start_acquisition()
+            else:
+                illumination_time_us = 1000.0 * illumination_time if illumination_time else 0
+                cam_trigger_log.debug(
+                    f"Sending hw trigger with illumination_time={illumination_time_us if illumination_time else None} [us]"
+                )
+                low_level_devices.microcontroller.send_hardware_trigger(
+                    True if illumination_time else False, illumination_time_us
+                )
+            return True
+
+        def acquisition_camera_hw_strobe_delay_fn(strobe_delay_ms: float) -> bool:
+            strobe_delay_us = int(1000 * strobe_delay_ms)
+            cam_trigger_log.debug(f"Setting microcontroller strobe delay to {strobe_delay_us} [us]")
+            low_level_devices.microcontroller.set_strobe_delay_us(strobe_delay_us)
+            low_level_devices.microcontroller.wait_till_operation_is_completed()
+
+            return True
+
+        camera = squid.camera.utils.get_camera(
+            config=squid.config.get_camera_config(),
+            simulated=simulated,
+            hw_trigger_fn=acquisition_camera_hw_trigger_fn,
+            hw_set_strobe_delay_ms_fn=acquisition_camera_hw_strobe_delay_fn,
+        )
+
+        if USE_LDI_SERIAL_CONTROL and not simulated:
+            ldi = serial_peripherals.LDI()
+
+            illumination_controller = IlluminationController(
+                microcontroller, ldi.intensity_mode, ldi.shutter_mode, LightSourceType.LDI, ldi
             )
-            self.streamHandler_focus_camera = core.StreamHandler(
-                accept_new_frame_fn=lambda: self.liveController_focus_camera.is_live
-            )
-            self.displacementMeasurementController = core_displacement_measurement.DisplacementMeasurementController()
-            self.laserAutofocusController = core.LaserAutofocusController(
-                self.microcontroller,
-                self.camera_focus,
-                self.liveController_focus_camera,
-                self.stage,
-                self.piezo,
-                self.objectiveStore,
-                self.laserAFSettingManager,
+        elif USE_CELESTA_ETHENET_CONTROL and not simulated:
+            celesta = control.celesta.CELESTA()
+            illumination_controller = IlluminationController(
+                microcontroller,
+                IntensityControlMode.Software,
+                ShutterControlMode.TTL,
+                LightSourceType.CELESTA,
+                celesta,
             )
         else:
-            self.laserAutofocusController = None
+            illumination_controller = IlluminationController(microcontroller)
 
-        self.multipointController = core.MultiPointController(
-            self.camera,
-            self.stage,
-            self.piezo,
-            self.microcontroller,
-            self.liveController,
-            self.laserAutofocusController,
-            self.objectiveStore,
-            self.channelConfigurationManager,
-            scan_coordinates=None,
-            parent=self,
-            headless=True,
+        return Microscope(
+            stage=stage,
+            camera=camera,
+            illumination_controller=illumination_controller,
+            addons=addons,
+            low_level_drivers=low_level_devices,
+            simulated=simulated,
         )
+
+    def __init__(
+        self,
+        stage: AbstractStage,
+        camera: AbstractCamera,
+        illumination_controller: IlluminationController,
+        addons: MicroscopeAddons,
+        low_level_drivers: LowLevelDrivers,
+        stream_handler_callbacks: Optional[StreamHandlerFunctions] = None,
+        simulated: bool = False,
+    ):
+        super().__init__()
+        self._log = squid.logging.get_logger(self.__class__.__name__)
+
+        self.stage: AbstractStage = stage
+        self.camera: AbstractCamera = camera
+        self.illumination_controller: IlluminationController = illumination_controller
+
+        self.addons = addons
+        self.low_level_drivers = low_level_drivers
+
+        self._simulated = simulated
+
+        self.objective_store: ObjectiveStore = ObjectiveStore()
+        self.channel_configuration_manager: ChannelConfigurationManager = ChannelConfigurationManager()
+        self.laser_af_settings_manager: Optional[LaserAFSettingManager] = None
+        if SUPPORT_LASER_AUTOFOCUS:
+            self.laser_af_settings_manager = LaserAFSettingManager()
+
+        self.configuration_manager: ConfigurationManager = ConfigurationManager(
+            self.channel_configuration_manager, self.laser_af_settings_manager
+        )
+        self.contrast_manager: ContrastManager = ContrastManager()
+        self.stream_handler: StreamHandler = StreamHandler(handler_functions=stream_handler_callbacks)
+
+        self.stream_handler_focus: Optional[StreamHandler] = None
+        self.live_controller_focus: Optional[LiveController] = None
+        if self.addons.camera_focus:
+            self.stream_handler_focus = StreamHandler(handler_functions=NoOpStreamHandlerFunctions)
+            self.live_controller_focus = LiveController(
+                microscope=self, control_illumination=False, for_displacement_measurement=True
+            )
+
+        self.live_controller: LiveController = LiveController(microscope=self)
+
+    def update_camera_functions(self, functions: StreamHandlerFunctions):
+        self.stream_handler.set_functions(functions)
+
+    def update_camera_focus_functions(self, functions: StreamHandlerFunctions):
+        if not self.addons.camera_focus:
+            raise ValueError("No focus camera, cannot change its stream handler functions.")
+
+        self.stream_handler_focus.set_functions(functions)
+
+    def prepare_for_use(self):
+        self.low_level_drivers.prepare_for_use()
+        self.addons.prepare_for_use()
+
+        self.camera.set_pixel_format(squid.config.CameraPixelFormat.from_string(CAMERA_CONFIG.PIXEL_FORMAT_DEFAULT))
+        self.camera.set_acquisition_mode(CameraAcquisitionMode.SOFTWARE_TRIGGER)
+
+        if self.addons.camera_focus:
+            self.addons.camera_focus = squid.camera.utils.get_camera(
+                squid.config.get_autofocus_camera_config(), simulated=self._simulated
+            )
+            self.addons.camera_focus.set_pixel_format(squid.config.CameraPixelFormat.from_string("MONO8"))
+            self.addons.camera_focus.set_acquisition_mode(CameraAcquisitionMode.SOFTWARE_TRIGGER)
+
+    def initialize_core_components(self):
+        if self.addons.piezo_stage:
+            self.addons.piezo_stage.home()
 
     def setup_hardware(self):
-        self.camera.add_frame_callback(self.streamHandler.on_new_frame)
+        self.camera.add_frame_callback(self.stream_handler.on_new_frame)
         self.camera.enable_callbacks(True)
 
-        if SUPPORT_LASER_AUTOFOCUS:
-            self.camera_focus.set_acquisition_mode(CameraAcquisitionMode.SOFTWARE_TRIGGER)
-            self.camera_focus.add_frame_callback(self.streamHandler_focus_camera.on_new_frame)
-            self.camera_focus.enable_callbacks(True)
-            self.camera_focus.start_streaming()
-
-    def initialize_peripherals(self):
-        if USE_PRIOR_STAGE:
-            self.stage: squid.abc.AbstractStage = squid.stage.prior.PriorStage(
-                sn=PRIOR_STAGE_SN, stage_config=squid.config.get_stage_config()
-            )
-
-        if ENABLE_SPINNING_DISK_CONFOCAL:
-            try:
-                self.xlight = serial_peripherals.XLight(XLIGHT_SERIAL_NUMBER, XLIGHT_SLEEP_TIME_FOR_WHEEL)
-            except Exception:
-                self._log.error("Error initializing Spinning Disk Confocal")
-                raise
-
-        if ENABLE_NL5:
-            try:
-                import control.NL5 as NL5
-
-                self.nl5 = NL5.NL5()
-            except Exception:
-                self._log.error("Error initializing NL5")
-                raise
-
-        if ENABLE_CELLX:
-            try:
-                self.cellx = serial_peripherals.CellX(CELLX_SN)
-                for channel in [1, 2, 3, 4]:
-                    self.cellx.set_modulation(channel, CELLX_MODULATION)
-                    self.cellx.turn_on(channel)
-            except Exception:
-                self._log.error("Error initializing CellX")
-                raise
-
-        if USE_LDI_SERIAL_CONTROL:
-            try:
-                self.ldi = serial_peripherals.LDI()
-                self.illuminationController = IlluminationController(
-                    self.microcontroller, self.ldi.intensity_mode, self.ldi.shutter_mode, LightSourceType.LDI, self.ldi
-                )
-            except Exception:
-                self._log.error("Error initializing LDI")
-                raise
-
-        if USE_CELESTA_ETHENET_CONTROL:
-            try:
-                import control.celesta
-
-                self.celesta = control.celesta.CELESTA()
-                self.illuminationController = IlluminationController(
-                    self.microcontroller,
-                    IntensityControlMode.Software,
-                    ShutterControlMode.TTL,
-                    LightSourceType.CELESTA,
-                    self.celesta,
-                )
-            except Exception:
-                self._log.error("Error initializing CELESTA")
-                raise
-
-        if USE_ZABER_EMISSION_FILTER_WHEEL:
-            try:
-                self.emission_filter_wheel = serial_peripherals.FilterController(
-                    FILTER_CONTROLLER_SERIAL_NUMBER, 115200, 8, serial.PARITY_NONE, serial.STOPBITS_ONE
-                )
-                self.emission_filter_wheel.start_homing()
-            except Exception:
-                self._log.error("Error initializing Zaber Emission Filter Wheel")
-                raise
-        if USE_OPTOSPIN_EMISSION_FILTER_WHEEL:
-            try:
-                self.emission_filter_wheel = serial_peripherals.Optospin(SN=FILTER_CONTROLLER_SERIAL_NUMBER)
-                self.emission_filter_wheel.set_speed(OPTOSPIN_EMISSION_FILTER_WHEEL_SPEED_HZ)
-            except Exception:
-                self._log.error("Error initializing Optospin Emission Filter Wheel")
-                raise
-
-        if USE_SQUID_FILTERWHEEL:
-            self.squid_filter_wheel = filterwheel.SquidFilterWheelWrapper(self.microcontroller)
-
-        if USE_XERYON:
-            try:
-                self.objective_changer = ObjectiveChanger2PosController(sn=XERYON_SERIAL_NUMBER, stage=self.stage)
-            except Exception:
-                self._log.error("Error initializing Xeryon objective switcher")
-                raise
-
-    def initialize_simulation_objects(self):
-        if ENABLE_SPINNING_DISK_CONFOCAL:
-            self.xlight = serial_peripherals.XLight_Simulation()
-        if ENABLE_NL5:
-            import control.NL5 as NL5
-
-            self.nl5 = NL5.NL5_Simulation()
-        if ENABLE_CELLX:
-            self.cellx = serial_peripherals.CellX_Simulation()
-
-        if USE_LDI_SERIAL_CONTROL:
-            self.ldi = serial_peripherals.LDI_Simulation()
-            self.illuminationController = IlluminationController(
-                self.microcontroller, self.ldi.intensity_mode, self.ldi.shutter_mode, LightSourceType.LDI, self.ldi
-            )
-        if USE_ZABER_EMISSION_FILTER_WHEEL:
-            self.emission_filter_wheel = serial_peripherals.FilterController_Simulation(
-                115200, 8, serial.PARITY_NONE, serial.STOPBITS_ONE
-            )
-        if USE_OPTOSPIN_EMISSION_FILTER_WHEEL:
-            self.emission_filter_wheel = serial_peripherals.Optospin_Simulation(SN=None)
-        if USE_SQUID_FILTERWHEEL:
-            self.squid_filter_wheel = filterwheel.SquidFilterWheelWrapper_Simulation(None)
-        if USE_XERYON:
-            self.objective_changer = ObjectiveChanger2PosController_Simulation(
-                sn=XERYON_SERIAL_NUMBER, stage=self.stage
-            )
-
-    def set_channel(self, channel):
-        self.liveController.set_channel(channel)
+        if self.addons.camera_focus:
+            self.addons.camera_focus.add_frame_callback(self.stream_handler_focus.on_new_frame)
+            self.addons.camera_focus.enable_callbacks(True)
+            self.addons.camera_focus.start_streaming()
 
     def acquire_image(self):
         # turn on illumination and send trigger
-        if self.liveController.trigger_mode == TriggerMode.SOFTWARE:
-            self.liveController.turn_on_illumination()
+        if self.live_controller.trigger_mode == TriggerMode.SOFTWARE:
+            self.live_controller.turn_on_illumination()
             self.waitForMicrocontroller()
             self.camera.send_trigger()
-        elif self.liveController.trigger_mode == TriggerMode.HARDWARE:
-            self.microcontroller.send_hardware_trigger(
+        elif self.live_controller.trigger_mode == TriggerMode.HARDWARE:
+            self.low_level_drivers.microcontroller.send_hardware_trigger(
                 control_illumination=True, illumination_on_time_us=self.camera.get_exposure_time() * 1000
             )
 
@@ -349,9 +375,9 @@ class Microscope(QObject):
         if image is None:
             print("self.camera.read_frame() returned None")
 
-        # tunr off the illumination if using software trigger
-        if self.liveController.trigger_mode == TriggerMode.SOFTWARE:
-            self.liveController.turn_off_illumination()
+        # turn off the illumination if using software trigger
+        if self.live_controller.trigger_mode == TriggerMode.SOFTWARE:
+            self.live_controller.turn_off_illumination()
 
         return image
 
@@ -362,7 +388,6 @@ class Microscope(QObject):
             self.stage.move_x(20)
             self.stage.home(x=False, y=True, z=False, theta=False)
             self.stage.home(x=True, y=False, z=False, theta=False)
-            self.slidePositionController.homing_done = True
 
     def move_x(self, distance, blocking=True):
         self.stage.move_x(distance, blocking=blocking)
@@ -390,152 +415,27 @@ class Microscope(QObject):
 
     def start_live(self):
         self.camera.start_streaming()
-        self.liveController.start_live()
+        self.live_controller.start_live()
 
     def stop_live(self):
-        self.liveController.stop_live()
+        self.live_controller.stop_live()
         self.camera.stop_streaming()
 
     def waitForMicrocontroller(self, timeout=5.0, error_message=None):
         try:
-            self.microcontroller.wait_till_operation_is_completed(timeout)
+            self.low_level_drivers.microcontroller.wait_till_operation_is_completed(timeout)
         except TimeoutError as e:
             self._log.error(error_message or "Microcontroller operation timed out!")
             raise e
 
     def close(self):
         self.stop_live()
-        self.microcontroller.close()
-        if USE_ZABER_EMISSION_FILTER_WHEEL or USE_OPTOSPIN_EMISSION_FILTER_WHEEL:
-            self.emission_filter_wheel.close()
+        self.low_level_drivers.microcontroller.close()
+        if self.addons.emission_filter_wheel:
+            self.addons.emission_filter_wheel.close()
+        if self.addons.camera_focus:
+            self.addons.camera_focus.close()
         self.camera.close()
-
-    def to_loading_position(self):
-        was_live = self.liveController.is_live
-        if was_live:
-            self.liveController.stop_live()
-
-        # retract z
-        self.slidePositionController.z_pos = self.stage.get_pos().z_mm  # zpos at the beginning of the scan
-        self.stage.move_z_to(OBJECTIVE_RETRACTED_POS_MM, blocking=False)
-        self.stage.wait_for_idle(SLIDE_POTISION_SWITCHING_TIMEOUT_LIMIT_S)
-
-        print("z retracted")
-        self.slidePositionController.objective_retracted = True
-
-        # move to position
-        # for well plate
-        if self.slidePositionController.is_for_wellplate:
-            # So we can home without issue, set our limits to something large.  Then later reset them back to
-            # the safe values.
-            a_large_limit_mm = 100
-            self.stage.set_limits(
-                x_pos_mm=a_large_limit_mm,
-                x_neg_mm=-a_large_limit_mm,
-                y_pos_mm=a_large_limit_mm,
-                y_neg_mm=-a_large_limit_mm,
-            )
-
-            # home for the first time
-            if not self.slidePositionController.homing_done:
-                print("running homing first")
-                # x needs to be at > + 20 mm when homing y
-                self.stage.move_x(20)
-                self.stage.home(x=False, y=True, z=False, theta=False)
-                self.stage.home(x=True, y=False, z=False, theta=False)
-
-                self.slidePositionController.homing_done = True
-            # homing done previously
-            else:
-                self.stage.move_x_to(20)
-                self.stage.move_y_to(SLIDE_POSITION.LOADING_Y_MM)
-                self.stage.move_x_to(SLIDE_POSITION.LOADING_X_MM)
-            # set limits again
-            self.stage.set_limits(
-                x_pos_mm=self.stage.get_config().X_AXIS.MAX_POSITION,
-                x_neg_mm=self.stage.get_config().X_AXIS.MIN_POSITION,
-                y_pos_mm=self.stage.get_config().Y_AXIS.MAX_POSITION,
-                y_neg_mm=self.stage.get_config().Y_AXIS.MIN_POSITION,
-            )
-        else:
-
-            # for glass slide
-            if self.slidePositionController.homing_done == False or SLIDE_POTISION_SWITCHING_HOME_EVERYTIME:
-                if self.home_x_and_y_separately:
-                    self.stage.home(x=True, y=False, z=False, theta=False)
-                    self.stage.move_x_to(SLIDE_POSITION.LOADING_X_MM)
-
-                    self.stage.home(x=False, y=True, z=False, theta=False)
-                    self.stage.move_y_to(SLIDE_POSITION.LOADING_Y_MM)
-                else:
-                    self.stage.home(x=True, y=True, z=False, theta=False)
-
-                    self.stage.move_x_to(SLIDE_POSITION.LOADING_X_MM)
-                    self.stage.move_y_to(SLIDE_POSITION.LOADING_Y_MM)
-                self.slidePositionController.homing_done = True
-            else:
-                self.stage.move_y_to(SLIDE_POSITION.LOADING_Y_MM)
-                self.stage.move_x_to(SLIDE_POSITION.LOADING_X_MM)
-
-        if was_live:
-            self.liveController.start_live()
-
-        self.slidePositionController.slide_loading_position_reached = True
-
-    def to_scanning_position(self):
-        was_live = self.liveController.is_live
-        if was_live:
-            self.liveController.stop_live()
-
-        # move to position
-        # for well plate
-        if self.slidePositionController.is_for_wellplate:
-            # home for the first time
-            if not self.slidePositionController.homing_done:
-
-                # x needs to be at > + 20 mm when homing y
-                self.stage.move_x_to(20)
-                # home y
-                self.stage.home(x=False, y=True, z=False, theta=False)
-                # home x
-                self.stage.home(x=True, y=False, z=False, theta=False)
-                self.slidePositionController.homing_done = True
-
-                # move to scanning position
-                self.stage.move_x_to(SLIDE_POSITION.SCANNING_X_MM)
-                self.stage.move_y_to(SLIDE_POSITION.SCANNING_Y_MM)
-            else:
-                self.stage.move_x_to(SLIDE_POSITION.SCANNING_X_MM)
-                self.stage.move_y_to(SLIDE_POSITION.SCANNING_Y_MM)
-        else:
-            if self.slidePositionController.homing_done == False or SLIDE_POTISION_SWITCHING_HOME_EVERYTIME:
-                if self.home_x_and_y_separately:
-                    self.stage.home(x=False, y=True, z=False, theta=False)
-
-                    self.stage.move_y_to(SLIDE_POSITION.SCANNING_Y_MM)
-
-                    self.stage.home(x=True, y=False, z=False, theta=False)
-                    self.stage.move_x_to(SLIDE_POSITION.SCANNING_X_MM)
-                else:
-                    self.stage.home(x=True, y=True, z=False, theta=False)
-
-                    self.stage.move_y_to(SLIDE_POSITION.SCANNING_Y_MM)
-                    self.stage.move_x_to(SLIDE_POSITION.SCANNING_X_MM)
-                self.slidePositionController.homing_done = True
-            else:
-                self.stage.move_y_to(SLIDE_POSITION.SCANNING_Y_MM)
-                self.stage.move_x_to(SLIDE_POSITION.SCANNING_X_MM)
-
-        # restore z
-        if self.slidePositionController.objective_retracted:
-            self.stage.move_z_to(self.slidePositionController.z_pos)
-            self.slidePositionController.objective_retracted = False
-            print("z position restored")
-
-        if was_live:
-            self.liveController.start_live()
-
-        self.slidePositionController.slide_scanning_position_reached = True
 
     def move_to_position(self, x, y, z):
         self.move_x_to(x)
@@ -543,41 +443,27 @@ class Microscope(QObject):
         self.move_z_to(z)
 
     def set_objective(self, objective):
-        self.objectiveStore.set_current_objective(objective)
+        self.objective_store.set_current_objective(objective)
 
     def set_coordinates(self, wellplate_format, selected, scan_size_mm, overlap_percent):
-        self.scanCoordinates = ScanCoordinatesSiLA2(self.objectiveStore, self.camera.get_pixel_size_unbinned_um())
+        self.scanCoordinates = ScanCoordinatesSiLA2(self.objective_store, self.camera.get_pixel_size_unbinned_um())
         self.scanCoordinates.get_scan_coordinates_from_selected_wells(
             wellplate_format, selected, scan_size_mm, overlap_percent
         )
 
-    def perform_scanning(self, path, experiment_ID, z_pos_um, channels, use_laser_af=False, dz=1.5, Nz=1):
-        if self.scanCoordinates is not None:
-            self.multipointController.scanCoordinates = self.scanCoordinates
-        self.move_z_to(z_pos_um / 1000)
-        self.multipointController.set_deltaZ(dz)
-        self.multipointController.set_NZ(Nz)
-        self.multipointController.set_z_range(z_pos_um / 1000, z_pos_um / 1000 + dz / 1000 * (Nz - 1))
-        self.multipointController.set_base_path(path)
-        if use_laser_af:
-            self.multipointController.set_reflection_af_flag(True)
-        self.multipointController.set_selected_configurations(channels)
-        self.multipointController.start_new_experiment(experiment_ID)
-        self.multipointController.run_acquisition()
-
     def set_illumination_intensity(self, channel, intensity, objective=None):
         if objective is None:
-            objective = self.objectiveStore.current_objective
-        channel_config = self.channelConfigurationManager.get_channel_configuration_by_name(objective, channel)
+            objective = self.objective_store.current_objective
+        channel_config = self.channel_configuration_manager.get_channel_configuration_by_name(objective, channel)
         channel_config.illumination_intensity = intensity
-        self.liveController.set_microscope_mode(channel_config)
+        self.live_controller.set_microscope_mode(channel_config)
 
     def set_exposure_time(self, channel, exposure_time, objective=None):
         if objective is None:
-            objective = self.objectiveStore.current_objective
-        channel_config = self.channelConfigurationManager.get_channel_configuration_by_name(objective, channel)
+            objective = self.objective_store.current_objective
+        channel_config = self.channel_configuration_manager.get_channel_configuration_by_name(objective, channel)
         channel_config.exposure_time = exposure_time
-        self.liveController.set_microscope_mode(channel_config)
+        self.live_controller.set_microscope_mode(channel_config)
 
 
 class ScanCoordinatesSiLA2:

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -335,9 +335,6 @@ class Microscope:
         self.camera.set_acquisition_mode(CameraAcquisitionMode.SOFTWARE_TRIGGER)
 
         if self.addons.camera_focus:
-            self.addons.camera_focus = squid.camera.utils.get_camera(
-                squid.config.get_autofocus_camera_config(), simulated=self._simulated
-            )
             self.addons.camera_focus.set_pixel_format(squid.config.CameraPixelFormat.from_string("MONO8"))
             self.addons.camera_focus.set_acquisition_mode(CameraAcquisitionMode.SOFTWARE_TRIGGER)
 

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -218,7 +218,7 @@ class Microscope:
                 raise ValueError("For a cephla stage microscope, you must provide a microcontroller.")
             stage = CephlaStage(low_level_devices.microcontroller, stage_config)
 
-        addons = MicroscopeAddons.build_from_global_config(stage, low_level_devices.microcontroller)
+        addons = MicroscopeAddons.build_from_global_config(stage, low_level_devices.microcontroller, simulated=simulated)
 
         cam_trigger_log = squid.logging.get_logger("camera hw functions")
 

--- a/software/control/serial_peripherals.py
+++ b/software/control/serial_peripherals.py
@@ -1,3 +1,5 @@
+import abc
+
 import serial
 from serial.tools import list_ports
 import time
@@ -763,7 +765,7 @@ class CellX:
 
     """Wrapper for communicating with LDI over serial"""
 
-    def __init__(self, SN=""):
+    def __init__(self, SN="", initial_modulation=CELLX_MODULATION):
         self.serial_connection = SerialDevice(
             SN=SN,
             baudrate=115200,
@@ -776,6 +778,10 @@ class CellX:
         )
         self.serial_connection.open_ser()
         self.power = {}
+
+        for channel in [1, 2, 3, 4]:
+            self.set_modulation(channel, initial_modulation)
+            self.turn_on(channel)
 
     def turn_on(self, channel):
         self.serial_connection.write_and_check(

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -603,7 +603,7 @@ class LaserAutofocusSettingWidget(QWidget):
         exposure_layout.addWidget(QLabel("Focus Camera Exposure (ms):"))
         self.exposure_spinbox = QDoubleSpinBox()
         self.exposure_spinbox.setSingleStep(0.1)
-        self.exposure_spinbox.setRange(*self.liveController.camera.get_exposure_limits())
+        self.exposure_spinbox.setRange(*self.liveController.microscope.camera.get_exposure_limits())
         self.exposure_spinbox.setValue(self.laserAutofocusController.laser_af_properties.focus_camera_exposure_time_ms)
         exposure_layout.addWidget(self.exposure_spinbox)
 
@@ -859,7 +859,7 @@ class LaserAutofocusSettingWidget(QWidget):
         self.liveController.trigger_acquisition()
 
         try:
-            frame = self.liveController.camera.read_frame()
+            frame = self.liveController.microscope.camera.read_frame()
         finally:
             self.liveController.microcontroller.turn_off_AF_laser()
             self.liveController.microcontroller.wait_till_operation_is_completed()
@@ -1553,6 +1553,7 @@ class LiveControlWidget(QFrame):
         super().__init__(*args, **kwargs)
         self._log = squid.logging.get_logger(self.__class__.__name__)
         self.liveController: LiveController = liveController
+        self.camera = self.liveController.microscope.camera
         self.streamHandler = streamHandler
         self.objectiveStore = objectiveStore
         self.channelConfigurationManager = channelConfigurationManager
@@ -1576,7 +1577,7 @@ class LiveControlWidget(QFrame):
         # line 0: trigger mode
         self.dropdown_triggerManu = QComboBox()
         self.dropdown_triggerManu.addItems([TriggerMode.SOFTWARE, TriggerMode.HARDWARE, TriggerMode.CONTINUOUS])
-        self.dropdown_triggerManu.setCurrentText(self.liveController.camera.get_acquisition_mode().value)
+        self.dropdown_triggerManu.setCurrentText(self.camera.get_acquisition_mode().value)
         sizePolicy = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         self.dropdown_triggerManu.setSizePolicy(sizePolicy)
 
@@ -1606,8 +1607,8 @@ class LiveControlWidget(QFrame):
 
         # line 3: exposure time and analog gain associated with the current mode
         self.entry_exposureTime = QDoubleSpinBox()
-        self.entry_exposureTime.setMinimum(self.liveController.camera.get_exposure_limits()[0])
-        self.entry_exposureTime.setMaximum(self.liveController.camera.get_exposure_limits()[1])
+        self.entry_exposureTime.setMinimum(self.camera.get_exposure_limits()[0])
+        self.entry_exposureTime.setMaximum(self.camera.get_exposure_limits()[1])
         self.entry_exposureTime.setSingleStep(1)
         self.entry_exposureTime.setSuffix(" ms")
         self.entry_exposureTime.setValue(0)
@@ -1617,13 +1618,13 @@ class LiveControlWidget(QFrame):
         # Not all cameras support analog gain, so attempt to get the gain
         # to check this
         try:
-            gain_range = self.liveController.camera.get_gain_range()
+            gain_range = self.camera.get_gain_range()
             self.entry_analogGain.setMinimum(gain_range.min_gain)
             self.entry_analogGain.setMaximum(gain_range.max_gain)
             self.entry_analogGain.setSingleStep(gain_range.gain_step)
             self.entry_analogGain.setValue(gain_range.min_gain)
             self.entry_analogGain.setSizePolicy(sizePolicy)
-            self.liveController.camera.set_analog_gain(gain_range.min_gain)
+            self.camera.set_analog_gain(gain_range.min_gain)
         except NotImplementedError:
             self._log.info("Analog gain not supported,  disabling it in live control widget.")
             self.entry_analogGain.setValue(0)
@@ -6433,7 +6434,7 @@ class NapariLiveWidget(QWidget):
 
         # Exposure Time
         self.entry_exposureTime = QDoubleSpinBox()
-        self.entry_exposureTime.setRange(*self.liveController.camera.get_exposure_limits())
+        self.entry_exposureTime.setRange(*self.camera.get_exposure_limits())
         self.entry_exposureTime.setValue(self.live_configuration.exposure_time)
         self.entry_exposureTime.setSuffix(" ms")
         self.entry_exposureTime.valueChanged.connect(self.update_config_exposure_time)

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -854,15 +854,15 @@ class LaserAutofocusSettingWidget(QWidget):
     def illuminate_and_get_frame(self):
         # Get a frame from the live controller.  We need to reach deep into the liveController here which
         # is not ideal.
-        self.liveController.microcontroller.turn_on_AF_laser()
-        self.liveController.microcontroller.wait_till_operation_is_completed()
+        self.liveController.microscope.low_level_drivers.microcontroller.turn_on_AF_laser()
+        self.liveController.microscope.low_level_drivers.microcontroller.wait_till_operation_is_completed()
         self.liveController.trigger_acquisition()
 
         try:
             frame = self.liveController.microscope.camera.read_frame()
         finally:
-            self.liveController.microcontroller.turn_off_AF_laser()
-            self.liveController.microcontroller.wait_till_operation_is_completed()
+            self.liveController.microscope.low_level_drivers.microcontroller.turn_off_AF_laser()
+            self.liveController.microscope.low_level_drivers.microcontroller.wait_till_operation_is_completed()
 
         return frame
 
@@ -2385,7 +2385,7 @@ class FilterControllerWidget(QFrame):
     def __init__(self, filterController, liveController, main=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.filterController = filterController
-        self.liveController = liveController
+        self.liveController: LiveController = liveController
         self.add_components()
         self.setFrameStyle(QFrame.Panel | QFrame.Raised)
 
@@ -6319,7 +6319,7 @@ class NapariLiveWidget(QWidget):
         super().__init__(parent)
         self._log = squid.logging.get_logger(self.__class__.__name__)
         self.streamHandler = streamHandler
-        self.liveController = liveController
+        self.liveController: LiveController = liveController
         self.stage = stage
         self.objectiveStore = objectiveStore
         self.channelConfigurationManager = channelConfigurationManager
@@ -6469,9 +6469,6 @@ class NapariLiveWidget(QWidget):
         for display_name, mode in trigger_modes:
             self.dropdown_triggerMode.addItem(display_name, mode)
         self.dropdown_triggerMode.currentIndexChanged.connect(self.on_trigger_mode_changed)
-        # self.dropdown_triggerMode = QComboBox()
-        # self.dropdown_triggerMode.addItems([TriggerMode.SOFTWARE, TriggerMode.HARDWARE, TriggerMode.CONTINUOUS])
-        # self.dropdown_triggerMode.currentTextChanged.connect(self.liveController.set_trigger_mode)
 
         # Trigger FPS
         self.entry_triggerFPS = QDoubleSpinBox()
@@ -8455,7 +8452,7 @@ class WellplateCalibration(QDialog):
         self.stage = stage
         self.navigationViewer = navigationViewer
         self.streamHandler = streamHandler
-        self.liveController = liveController
+        self.liveController: LiveController = liveController
         self.was_live = self.liveController.is_live
         self.corners = [None, None, None]
         self.show_virtual_joystick = True  # FLAG
@@ -8655,7 +8652,7 @@ class WellplateCalibration(QDialog):
     def viewerClicked(self, x, y, width, height):
         pixel_size_um = (
             self.navigationViewer.objectiveStore.get_pixel_size_factor()
-            * self.liveController.camera.get_pixel_size_binned_um()
+            * self.liveController.microscope.camera.get_pixel_size_binned_um()
         )
 
         pixel_sign_x = 1

--- a/software/main_hcs.py
+++ b/software/main_hcs.py
@@ -23,6 +23,7 @@ from control.widgets import ConfigEditorBackwardsCompatible, StageUtils
 from control._def import CACHED_CONFIG_FILE_PATH
 from control._def import USE_TERMINAL_CONSOLE
 import control.utils
+import control.microscope
 
 
 if USE_TERMINAL_CONSOLE:
@@ -66,7 +67,10 @@ if __name__ == "__main__":
     # This allows shutdown via ctrl+C even after the gui has popped up.
     signal.signal(signal.SIGINT, signal.SIG_DFL)
 
-    win = gui.HighContentScreeningGui(is_simulation=args.simulation, live_only_mode=args.live_only)
+    microscope = control.microscope.Microscope.build_from_global_config(args.simulation)
+    win = gui.HighContentScreeningGui(
+        microscope=microscope, is_simulation=args.simulation, live_only_mode=args.live_only
+    )
 
     file_menu = QMenu("File", win)
 

--- a/software/squid/stage/utils.py
+++ b/software/squid/stage/utils.py
@@ -2,11 +2,12 @@ from typing import Optional
 import os
 
 import squid.logging
-from squid.abc import Pos
+from squid.abc import Pos, AbstractStage
 from squid.config import StageConfig
 
 _log = squid.logging.get_logger(__package__)
 _DEFAULT_CACHE_PATH = "cache/last_coords.txt"
+
 """
 Attempts to load a cached stage position and return it.
 """

--- a/software/tests/control/gui_test_stubs.py
+++ b/software/tests/control/gui_test_stubs.py
@@ -1,6 +1,7 @@
 import pathlib
 
 import control.core.core
+import control.core.objective_store
 import control.microcontroller
 import control.lighting
 import squid.abc
@@ -54,7 +55,7 @@ def get_test_autofocus_controller(
 
 
 def get_test_scan_coordinates(
-    objective_store: control.core.core.ObjectiveStore,
+    objective_store: control.core.objective_store.ObjectiveStore,
     navigation_viewer: control.core.core.NavigationViewer,
     stage: squid.abc.AbstractStage,
 ):
@@ -62,12 +63,12 @@ def get_test_scan_coordinates(
 
 
 def get_test_objective_store():
-    return control.core.core.ObjectiveStore(
+    return control.core.objective_store.ObjectiveStore(
         objectives_dict=control._def.OBJECTIVES, default_objective=control._def.DEFAULT_OBJECTIVE
     )
 
 
-def get_test_navigation_viewer(objective_store: control.core.core.ObjectiveStore, camera_pixel_size: float):
+def get_test_navigation_viewer(objective_store: control.core.objective_store.ObjectiveStore, camera_pixel_size: float):
     return control.core.core.NavigationViewer(objective_store, camera_pixel_size)
 
 

--- a/software/tests/control/gui_test_stubs.py
+++ b/software/tests/control/gui_test_stubs.py
@@ -54,7 +54,7 @@ def get_test_autofocus_controller(
     microcontroller: control.microcontroller.Microcontroller,
 ):
     return control.core.core.AutoFocusController(
-        camera=camera, stage=stage, liveController=live_controller, microcontroller=microcontroller
+        camera=camera, stage=stage, liveController=live_controller, microcontroller=microcontroller, nl5=None
     )
 
 

--- a/software/tests/control/gui_test_stubs.py
+++ b/software/tests/control/gui_test_stubs.py
@@ -1,5 +1,6 @@
 import pathlib
 
+import control.microscope
 import control.core.core
 import control.core.objective_store
 import control.microcontroller
@@ -7,15 +8,16 @@ import control.lighting
 import squid.abc
 
 import control._def
-from tests.tools import get_test_microcontroller, get_test_camera, get_test_stage, get_repo_root, get_test_piezo_stage
+from control.microscope import Microscope
+from tests.tools import get_repo_root, get_test_piezo_stage
 
 
 def get_test_live_controller(
-    camera, microcontroller, config_manager, illumination_controller, starting_objective
+    microscope: control.microscope.Microscope, starting_objective
 ) -> control.core.core.LiveController:
-    controller = control.core.core.LiveController(camera, microcontroller, config_manager, illumination_controller)
+    controller = control.core.core.LiveController(microscope=microscope)
 
-    controller.set_microscope_mode(config_manager.channel_manager.get_configurations(objective=starting_objective)[0])
+    controller.set_microscope_mode(microscope.configuration_manager.channel_manager.get_configurations(objective=starting_objective)[0])
     return controller
 
 
@@ -72,32 +74,21 @@ def get_test_navigation_viewer(objective_store: control.core.objective_store.Obj
     return control.core.core.NavigationViewer(objective_store, camera_pixel_size)
 
 
-def get_test_multi_point_controller() -> control.core.core.MultiPointController:
-    microcontroller = get_test_microcontroller()
-    camera = get_test_camera()
-    stage = get_test_stage(microcontroller)
-    config_manager = get_test_configuration_manager()
-    objective_store = get_test_objective_store()
-    live_controller = get_test_live_controller(
-        camera,
-        microcontroller,
-        config_manager,
-        get_test_illumination_controller(microcontroller),
-        objective_store.current_objective,
-    )
+def get_test_multi_point_controller(microscope: Microscope) -> control.core.core.MultiPointController:
+    live_controller = get_test_live_controller(microscope=microscope, starting_objective=microscope.objective_store.default_objective)
 
     multi_point_controller = control.core.core.MultiPointController(
-        camera=camera,
-        stage=stage,
-        microcontroller=microcontroller,
+        camera=microscope.camera,
+        stage=microscope.stage,
+        microcontroller=microscope.low_level_drivers.microcontroller,
         live_controller=live_controller,
-        autofocus_controller=get_test_autofocus_controller(camera, stage, live_controller, microcontroller),
-        channel_configuration_manager=config_manager.channel_manager,
+        autofocus_controller=get_test_autofocus_controller(microscope.camera, microscope.stage, live_controller, microscope.low_level_drivers.microcontroller),
+        channel_configuration_manager=microscope.channel_configuration_manager,
         scan_coordinates=get_test_scan_coordinates(
-            objective_store, get_test_navigation_viewer(objective_store, camera.get_pixel_size_unbinned_um()), stage
+            microscope.objective_store, get_test_navigation_viewer(microscope.objective_store, microscope.camera.get_pixel_size_unbinned_um()), microscope.stage
         ),
-        piezo=get_test_piezo_stage(microcontroller),
-        objective_store=objective_store,
+        piezo=get_test_piezo_stage(microscope.low_level_drivers.microcontroller),
+        objective_store=microscope.objective_store,
     )
 
     multi_point_controller.set_base_path("/tmp/")

--- a/software/tests/control/gui_test_stubs.py
+++ b/software/tests/control/gui_test_stubs.py
@@ -17,7 +17,9 @@ def get_test_live_controller(
 ) -> control.core.core.LiveController:
     controller = control.core.core.LiveController(microscope=microscope)
 
-    controller.set_microscope_mode(microscope.configuration_manager.channel_manager.get_configurations(objective=starting_objective)[0])
+    controller.set_microscope_mode(
+        microscope.configuration_manager.channel_manager.get_configurations(objective=starting_objective)[0]
+    )
     return controller
 
 
@@ -75,17 +77,23 @@ def get_test_navigation_viewer(objective_store: control.core.objective_store.Obj
 
 
 def get_test_multi_point_controller(microscope: Microscope) -> control.core.core.MultiPointController:
-    live_controller = get_test_live_controller(microscope=microscope, starting_objective=microscope.objective_store.default_objective)
+    live_controller = get_test_live_controller(
+        microscope=microscope, starting_objective=microscope.objective_store.default_objective
+    )
 
     multi_point_controller = control.core.core.MultiPointController(
         camera=microscope.camera,
         stage=microscope.stage,
         microcontroller=microscope.low_level_drivers.microcontroller,
         live_controller=live_controller,
-        autofocus_controller=get_test_autofocus_controller(microscope.camera, microscope.stage, live_controller, microscope.low_level_drivers.microcontroller),
+        autofocus_controller=get_test_autofocus_controller(
+            microscope.camera, microscope.stage, live_controller, microscope.low_level_drivers.microcontroller
+        ),
         channel_configuration_manager=microscope.channel_configuration_manager,
         scan_coordinates=get_test_scan_coordinates(
-            microscope.objective_store, get_test_navigation_viewer(microscope.objective_store, microscope.camera.get_pixel_size_unbinned_um()), microscope.stage
+            microscope.objective_store,
+            get_test_navigation_viewer(microscope.objective_store, microscope.camera.get_pixel_size_unbinned_um()),
+            microscope.stage,
         ),
         piezo=get_test_piezo_stage(microscope.low_level_drivers.microcontroller),
         objective_store=microscope.objective_store,

--- a/software/tests/control/test_HighContentScreeningGui.py
+++ b/software/tests/control/test_HighContentScreeningGui.py
@@ -3,6 +3,8 @@ import control._def
 import control.gui_hcs
 from PyQt5.QtWidgets import QMessageBox
 
+import control.microscope
+
 
 def test_create_simulated_hcs_with_or_without_piezo(qtbot, monkeypatch):
     # This just tests to make sure we can successfully create a simulated hcs gui with or without
@@ -17,9 +19,11 @@ def test_create_simulated_hcs_with_or_without_piezo(qtbot, monkeypatch):
     monkeypatch.setattr(QMessageBox, "question", confirm_exit)
 
     control._def.HAS_OBJECTIVE_PIEZO = True
-    with_piezo = control.gui_hcs.HighContentScreeningGui(is_simulation=True)
+    scope_with = control.microscope.Microscope.build_from_global_config(True)
+    with_piezo = control.gui_hcs.HighContentScreeningGui(microscope=scope_with, is_simulation=True)
     qtbot.add_widget(with_piezo)
 
     control._def.HAS_OBJECTIVE_PIEZO = False
-    without_piezo = control.gui_hcs.HighContentScreeningGui(is_simulation=True)
+    scope_without = control.microscope.Microscope.build_from_global_config(True)
+    without_piezo = control.gui_hcs.HighContentScreeningGui(microscope=scope_without, is_simulation=True)
     qtbot.add_widget(without_piezo)

--- a/software/tests/control/test_MultiPointController.py
+++ b/software/tests/control/test_MultiPointController.py
@@ -1,10 +1,11 @@
 import tests.control.gui_test_stubs as gts
-import pytest
 import control._def
+import control.microscope
 
 
 def test_multi_point_controller_image_count_calculation(qtbot):
-    mpc = gts.get_test_multi_point_controller()
+    scope = control.microscope.Microscope.build_from_global_config(True)
+    mpc = gts.get_test_multi_point_controller(microscope=scope)
 
     control._def.MERGE_CHANNELS = False
     all_configuration_names = [
@@ -55,8 +56,9 @@ def test_multi_point_controller_image_count_calculation(qtbot):
     assert mpc.get_acquisition_image_count() == final_number_of_fov * (all_config_count + 1)
 
 
-def test_multi_point_controller_disk_space_esimate(qtbot):
-    mpc = gts.get_test_multi_point_controller()
+def test_multi_point_controller_disk_space_estimate(qtbot):
+    scope = control.microscope.Microscope.build_from_global_config(True)
+    mpc = gts.get_test_multi_point_controller(microscope=scope)
 
     control._def.MERGE_CHANNELS = False
     all_configuration_names = [

--- a/software/tests/control/test_MultiPointWorker.py
+++ b/software/tests/control/test_MultiPointWorker.py
@@ -1,5 +1,9 @@
+from sympy.physics.units import micro
+
 import tests.control.gui_test_stubs as gts
 import pytest
+
+import control.microscope
 
 
 # Make sure we can create a multi point controller and worker with out default config
@@ -7,9 +11,11 @@ import pytest
     "This fails because of the QApplicateion.processEvents() in _on_acqusition_complete.  Not sure why we need that."
 )
 def test_multi_point_worker_with_default_config(qtbot):
-    multi_point_controller = gts.get_test_multi_point_controller()
+    scope = control.microscope.Microscope.build_from_global_config(True)
+    multi_point_controller = gts.get_test_multi_point_controller(microscope=scope)
     multi_point_controller.run_acquisition()
     multi_point_controller.request_abort_aquisition()
+    scope.close()
 
 
 @pytest.mark.skip(
@@ -25,14 +31,16 @@ def test_multi_point_worker_init_bugs(qtbot):
     # so make sure that it is initialized regardless of that config value.
 
     USE_NAPARI_FOR_MULTIPOINT = False
-    multi_point_controller_for_false = gts.get_test_multi_point_controller()
+    scope_false = control.microscope.Microscope.build_from_global_config(True)
+    multi_point_controller_for_false = gts.get_test_multi_point_controller(microscope=scope_false)
     multi_point_controller_for_false.run_acquisition()
     multi_point_controller_for_false.request_abort_aquisition()
     # This will throw if the attribute doesn't exist
     napari_layer_for_false = multi_point_controller_for_false.multiPointWorker.init_napari_layers
 
     USE_NAPARI_FOR_MULTIPOINT = True
-    multi_point_controller_for_true = gts.get_test_multi_point_controller()
+    scope_true = control.microscope.Microscope.build_from_global_config(True)
+    multi_point_controller_for_true = gts.get_test_multi_point_controller(microscope=scope_true)
     multi_point_controller_for_true.run_acquisition()
     multi_point_controller_for_true.request_abort_aquisition()
     # This will throw if the attribute doesn't exist

--- a/software/tests/control/test_microcontroller.py
+++ b/software/tests/control/test_microcontroller.py
@@ -99,6 +99,7 @@ def test_microcontroller_simulated_positions():
     micro.home_xy()
     micro.wait_till_operation_is_completed()
     assert_pos_almost_equal((0, 0, 3000, 0), micro.get_pos())
+    micro.close()
 
 
 @pytest.mark.skip(
@@ -152,6 +153,7 @@ def test_microcontroller_absolute_and_relative_match():
     micro.move_z_usteps(-abs_position)
     wait()
     assert_pos_almost_equal((0, 0, 0, 0), micro.get_pos())
+    micro.close()
 
 
 def test_microcontroller_reconnects_serial():
@@ -180,6 +182,7 @@ def test_microcontroller_reconnects_serial():
     micro.move_z_usteps(3 * some_pos)
     wait()
     assert_pos_almost_equal((some_pos, 2 * some_pos, 3 * some_pos, 0), micro.get_pos())
+    micro.close()
 
 
 def test_home_directions():
@@ -200,3 +203,5 @@ def test_home_directions():
             hm(homing_direction=d)
             wait()
             assert test_micro.last_command[3] == d.value
+
+    test_micro.close()

--- a/software/tests/control/test_microscope.py
+++ b/software/tests/control/test_microscope.py
@@ -8,3 +8,9 @@ from tests.control.test_microcontroller import get_test_micro
 def test_create_simulated_microscope():
     sim_scope = control.microscope.Microscope.build_from_global_config(True)
     sim_scope.close()
+
+def test_simulated_scope_basic_ops():
+    scope = control.microscope.Microscope.build_from_global_config(True)
+
+    scope.stage.home(x=True, y=True, z=True, blocking=True)
+    scope.stage.move_x_to(scope.con)

--- a/software/tests/control/test_microscope.py
+++ b/software/tests/control/test_microscope.py
@@ -9,8 +9,18 @@ def test_create_simulated_microscope():
     sim_scope = control.microscope.Microscope.build_from_global_config(True)
     sim_scope.close()
 
+
 def test_simulated_scope_basic_ops():
     scope = control.microscope.Microscope.build_from_global_config(True)
 
-    scope.stage.home(x=True, y=True, z=True, blocking=True)
-    scope.stage.move_x_to(scope.con)
+    scope.stage.home(x=True, y=True, z=True, theta=False, blocking=True)
+    scope.stage.move_x_to(scope.stage.get_config().X_AXIS.MAX_POSITION / 2)
+    scope.stage.move_y_to(scope.stage.get_config().Y_AXIS.MAX_POSITION / 2)
+    scope.stage.move_z_to(scope.stage.get_config().Z_AXIS.MAX_POSITION / 2)
+
+    scope.camera.start_streaming()
+    scope.illumination_controller.turn_on_illumination()
+    scope.camera.send_trigger()
+    scope.camera.read_frame()
+    scope.illumination_controller.turn_off_illumination()
+    scope.camera.stop_streaming()

--- a/software/tests/control/test_microscope.py
+++ b/software/tests/control/test_microscope.py
@@ -6,4 +6,5 @@ from tests.control.test_microcontroller import get_test_micro
 
 
 def test_create_simulated_microscope():
-    sim_scope = control.microscope.Microscope(is_simulation=True)
+    sim_scope = control.microscope.Microscope.build_from_global_config(True)
+    sim_scope.close()

--- a/software/tools/microscope_stress_test.py
+++ b/software/tools/microscope_stress_test.py
@@ -1,0 +1,101 @@
+import logging
+import time
+from collections import Counter
+
+import control.microscope
+import squid.logging
+from control.core.stream_handler import StreamHandlerFunctions
+
+log = squid.logging.get_logger("Microscope stress test")
+
+
+def main(args):
+    if args.verbose:
+        squid.logging.set_stdout_log_level(logging.DEBUG)
+
+    # NOTE(imo): This will be expanded as we expand upon `Microscope` functionality.  The expectation is that
+    # you can use this to test on real hardware (in addition to the existing unit tests)
+    scope: control.microscope.Microscope = control.microscope.Microscope.build_from_global_config(args.simulate)
+
+    # Do manual homing, and again using the scope helper
+    scope.stage.home(x=False, y=False, z=True, theta=False, blocking=True)
+    scope.stage.home(x=True, y=True, z=False, theta=False, blocking=True)
+
+    scope.home_xyz()
+
+    # Do some moves with stage directly, and the stage helpers
+    x_max = scope.stage.get_config().X_AXIS.MAX_POSITION
+    y_max = scope.stage.get_config().Y_AXIS.MAX_POSITION
+    z_max = scope.stage.get_config().Z_AXIS.MAX_POSITION
+    scope.stage.move_x_to(x_max / 2)
+    scope.stage.move_y_to(y_max / 2)
+    scope.stage.move_z_to(z_max / 5)
+
+    scope.move_to_position(x=x_max / 3, y=y_max / 3, z=z_max / 4)
+
+    scope.camera.start_streaming()
+    for config_name in scope.configuration_manager.channel_manager.get_configurations(scope.objective_store.current_objective):
+        scope.live_controller.set_microscope_mode(config_name)
+        scope.illumination_controller.turn_on_illumination()
+
+        if focus_cam := scope.addons.camera_focus:
+            try:
+                scope.low_level_drivers.microcontroller.turn_on_AF_laser()
+                scope.low_level_drivers.microcontroller.wait_till_operation_is_completed()
+                while not focus_cam.get_ready_for_trigger():
+                    time.sleep(0.001)
+                focus_cam.send_trigger()
+                focus_frame = focus_cam.read_frame()
+            finally:
+                scope.low_level_drivers.microcontroller.turn_off_AF_laser()
+                scope.low_level_drivers.microcontroller.wait_till_operation_is_completed()
+
+        while not scope.camera.get_ready_for_trigger():
+            time.sleep(0.001)
+        scope.camera.send_trigger()
+        frame = scope.camera.read_frame()
+
+    scope.camera.stop_streaming()
+
+    counts = {
+        "image_to_display": 0,
+        "packet_image_to_write": 0,
+        "signal_new_frame_received": 0
+    }
+
+    stream_handlers = StreamHandlerFunctions(
+        image_to_display=lambda a: counts["image_to_display"] += 1,
+        packet_image_to_write=lambda a,i,f: counts.update(["packet_image_to_write"]),
+        signal_new_frame_received=lambda: counts.update(["signal_new_frame_received"]),
+        accept_new_frame=lambda: True
+    )
+    trigger_fps = 2
+    desired_frames = 6
+    scope.update_camera_functions(stream_handlers)
+    scope.live_controller.set_trigger_fps(trigger_fps)
+    scope.start_live()
+    time.sleep(desired_frames / trigger_fps)
+    scope.stop_live()
+
+    for label, count in counts:
+        if desired_frames != count:
+            log.warning(f"Counter with {label=} saw {counts} counts instead of expected {desired_frames}")
+        else:
+            log.info(f"Counter with {label=} has correct count. {counts} == {desired_frames}")
+
+    scope.close()
+
+
+if __name__ == "__main__":
+    import argparse
+    import sys
+
+    ap = argparse.ArgumentParser(description="Create a Microscope object, then run it through its paces")
+
+    ap.add_argument("--runtime", type=float, help="Time, in s, to run the test for.", default=60)
+    ap.add_argument("--verbose", action="store_true", help="Turn on debug logging")
+    ap.add_argument("--simulate", action="store_true", help="Run with a simulated microscope")
+
+    args = ap.parse_args()
+
+    sys.exit(main(args))


### PR DESCRIPTION
This is step 1 in creating our fully-headless `Microscope` object.  By this, we mean that Qt is never imported and no ui library is needed.

Tested By:
  1. Local sim testing
  2. Testing on a toupcam system with no laser AF
  3. Testing on a toupcam system with laser AF
  4. grepping for `liveController.*` uses, and checking they migrated properly
  5. `pytest -m tests`
  6. For laser AF: click all laser AF buttons
  7. For cameras: Try adjusting camera settings
  8. For live + acquisitions: acquisitions with laser af, contrast af, no af, mutli channel.  I verified I can abort aquisitions still, and that all images are saved as expected.