### PR TITLE
bug fix: wellplate calibration widget

### DIFF
--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -8973,9 +8973,6 @@ class CalibrationLiveViewer(QWidget):
         # Set fixed size for the viewer
         self.setFixedSize(500, 500)
 
-        # Initialize with a blank image
-        self.display_image(np.zeros((xmax, ymax)))
-
     def setCrosshairPosition(self):
         center = self.viewbox.viewRect().center()
         self.crosshair_h.setPos(center.y())


### PR DESCRIPTION
Tested with hardware.

This pull request refactors and re-enables the "click-to-move" functionality in the `software/control/widgets.py` file and introduces UI improvements for the viewer. The changes include fixing broken functionality, adding calculations for stage movement, and enhancing the user interface by disabling unnecessary interactions.

### Functional Improvements:

* **Re-enabled "click-to-move" functionality**: The `toggleClickToMove` method now connects or disconnects the `signal_calibration_viewer_click` signal based on the checkbox state, and the `viewerClicked` method calculates stage movement using pixel size and direction. This restores previously broken functionality.

### UI Enhancements:

* **Disabled panning and context menu in the viewer**: The `initUI` method now disables mouse panning and the context menu for the viewer to streamline user interaction.
* **Removed initialization with a blank image**: The `initUI` method no longer initializes the viewer with a blank image, simplifying the setup process.