### PR TITLE
bug: toupcam: do not double up on cam exposure time

### DIFF
--- a/software/control/camera_toupcam.py
+++ b/software/control/camera_toupcam.py
@@ -359,7 +359,7 @@ class ToupcamCamera(AbstractCamera):
             self._hw_set_strobe_delay_ms_fn(self.get_strobe_time())
 
         if send_exposure:
-            self._calculate_and_set_camera_exposure_time(camera_exposure_time_ms)
+            self._calculate_and_set_camera_exposure_time(image_exposure_time_ms)
 
         self._log.debug(
             f"image size: {width=} x {height=}, {buffer_size=}, strobe_time={self.get_strobe_time()} [ms], exposure_time={self.get_exposure_time()} [ms], full frame time={self.get_total_frame_time()} [ms], {send_exposure=}"


### PR DESCRIPTION
We were doubling up the camera strobe + trig delay compensation.  This meant that for longer exposure times, we'd think the camera was ready for another trigger earlier than it actually was. As a result, we'd get lost frames (because a trigger too early would be ignored - the camera was still exposing with the doubled up exposure, but the camera driver in our code was using the correct frame length).

Tested by: Running an acquisition with >200ms exposure times, and 1x1 binning so that the strobe calc was really long (~147ms).  This resulted in ~500 ms exposures sent to the camera before this fix, but now results in the correct ~350 ms.