### PR TITLE
use emission filter wheel in live controller

### DIFF
--- a/software/control/core/core.py
+++ b/software/control/core/core.py
@@ -505,13 +505,19 @@ class LiveController(QObject):
                     self.microscope.cellx.set_laser_power(NL5_WAVENLENGTH_MAP[wavelength], int(intensity))
 
         # set emission filter position
-        if ENABLE_SPINNING_DISK_CONFOCAL:
+        if ENABLE_SPINNING_DISK_CONFOCAL and not USE_DRAGONFLY:
             try:
                 self.microscope.xlight.set_emission_filter(
                     XLIGHT_EMISSION_FILTER_MAPPING[illumination_source],
                     extraction=False,
                     validate=XLIGHT_VALIDATE_WHEEL_POS,
                 )
+            except Exception as e:
+                print("not setting emission filter position due to " + str(e))
+
+        if USE_DRAGONFLY:
+            try:
+                self.microscope.dragonfly.set_emission_filter(self.currentConfiguration.emission_filter_position)
             except Exception as e:
                 print("not setting emission filter position due to " + str(e))
 


### PR DESCRIPTION
This is a temporary solution. We'll use one interface for all filter wheel soon.

This pull request introduces updates to the `update_illumination` method in the `core.py` file to enhance compatibility with the Dragonfly microscope system while maintaining support for existing configurations. The most important changes involve conditional logic adjustments and the addition of new functionality for setting the emission filter position when using Dragonfly.

### Compatibility updates for Dragonfly system:

* Updated the conditional check for spinning disk confocal systems to exclude Dragonfly by adding `and not USE_DRAGONFLY` to the condition. This ensures the correct emission filter logic is applied based on the hardware in use. (`[software/control/core/core.pyL508-R508](diffhunk://#diff-2fc90167f3cd3e8a6b36bdd78086c6ae5811054d9f87239fa2fe2b3a8858d691L508-R508)`)
* Added a new block to handle emission filter positioning specifically for the Dragonfly system. This includes a try-except block to call `self.microscope.dragonfly.set_emission_filter` with the appropriate configuration and handle potential exceptions gracefully. (`[software/control/core/core.pyR518-R523](diffhunk://#diff-2fc90167f3cd3e8a6b36bdd78086c6ae5811054d9f87239fa2fe2b3a8858d691R518-R523)`)