### PR TITLE
bug fix: select camera port for changing filter wheel position

### DIFF
--- a/software/control/core/core.py
+++ b/software/control/core/core.py
@@ -517,7 +517,9 @@ class LiveController(QObject):
 
         if USE_DRAGONFLY:
             try:
-                self.microscope.dragonfly.set_emission_filter(self.currentConfiguration.emission_filter_position)
+                self.microscope.dragonfly.set_emission_filter(
+                    self.microscope.dragonfly.get_camera_port(), self.currentConfiguration.emission_filter_position
+                )
             except Exception as e:
                 print("not setting emission filter position due to " + str(e))
 

--- a/software/control/serial_peripherals.py
+++ b/software/control/serial_peripherals.py
@@ -505,14 +505,14 @@ class Dragonfly:
         response = self._send_command(command)
         return position if response else None
 
-    def get_emission_filter(self, port: int) -> int | None:
+    def get_emission_filter(self, port: int) -> int:
         """Get current emission filter wheel position
 
         Args:
             port: Filter wheel port number (typically 1)
 
         Returns:
-            Current position or None if error
+            Current position
         """
         response = self._send_command(f"AT_FW_POS,{port},?")
         if response and response.isdigit():
@@ -530,11 +530,11 @@ class Dragonfly:
         response = self._send_command(command)
         return position if response else None
 
-    def get_port_selection_dichroic(self) -> int | None:
+    def get_port_selection_dichroic(self) -> int:
         """Get current port selection dichroic position
 
         Returns:
-            Current position or None if error
+            Current position
         """
         response = self._send_command("AT_PS_POS,1,?")
         if response and response.isdigit():

--- a/software/control/serial_peripherals.py
+++ b/software/control/serial_peripherals.py
@@ -549,7 +549,7 @@ class Dragonfly:
         Returns:
             Current camera port (1 or 2)
         """
-        if not self.ps_info or len(self.ps_info) < self.current_port_selection_dichroic:
+        if not self.ps_info or not (1 <= self.current_port_selection_dichroic <= len(self.ps_info)):
             raise ValueError(f"Port selection dichroic info does not match current position: {self.ps_info}")
 
         if self.ps_info[self.current_port_selection_dichroic - 1].endswith("100% Pass"):

--- a/software/control/serial_peripherals.py
+++ b/software/control/serial_peripherals.py
@@ -515,7 +515,10 @@ class Dragonfly:
             Current position or None if error
         """
         response = self._send_command(f"AT_FW_POS,{port},?")
-        return int(response) if response and response.isdigit() else None
+        if response and response.isdigit():
+            return int(response)
+        else:
+            raise ValueError(f"Unknown emission filter position: {response}")
 
     def set_port_selection_dichroic(self, position: int) -> int | None:
         """Set port selection dichroic position
@@ -534,8 +537,11 @@ class Dragonfly:
             Current position or None if error
         """
         response = self._send_command("AT_PS_POS,1,?")
-        self.current_port_selection_dichroic = int(response) if response and response.isdigit() else None
-        return self.current_port_selection_dichroic
+        if response and response.isdigit():
+            self.current_port_selection_dichroic = int(response)
+            return self.current_port_selection_dichroic
+        else:
+            raise ValueError(f"Unknown port selection dichroic position: {response}")
 
     def get_camera_port(self) -> int:
         """Get current camera port
@@ -543,6 +549,9 @@ class Dragonfly:
         Returns:
             Current camera port (1 or 2)
         """
+        if not self.ps_info or len(self.ps_info) < self.current_port_selection_dichroic:
+            raise ValueError(f"Port selection dichroic info does not match current position: {self.ps_info}")
+
         if self.ps_info[self.current_port_selection_dichroic - 1].endswith("100% Pass"):
             return 1
         elif self.ps_info[self.current_port_selection_dichroic - 1].endswith("100% Reflect"):

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -962,13 +962,9 @@ class DragonflyConfocalWidget(QWidget):
             if current_port2_filter is not None:
                 self.dropdown_port2_emission_filter.setCurrentText(str(current_port2_filter))
 
-            current_port1_aperture = self.dragonfly.get_field_aperture_wheel_position(1)
-            if current_port1_aperture is not None:
-                self.dropdown_port1_field_aperture.setCurrentText(str(current_port1_aperture))
-
-            current_port2_aperture = self.dragonfly.get_field_aperture_wheel_position(2)
-            if current_port2_aperture is not None:
-                self.dropdown_port2_field_aperture.setCurrentText(str(current_port2_aperture))
+            current_field_aperture = self.dragonfly.get_field_aperture_wheel_position()
+            if current_field_aperture is not None:
+                self.dropdown_field_aperture.setCurrentText(str(current_field_aperture))
 
             motor_state = self.dragonfly.get_disk_motor_state()
             if motor_state is not None:


### PR DESCRIPTION
This pull request introduces updates to the microscope control system, focusing on improving the handling of camera ports, dichroic positions, and emission filters. Key changes include enhancing the logic for determining the camera port, updating emission filter handling, and simplifying field aperture selection in the user interface.

### Enhancements to camera port and dichroic position handling:
* [`software/control/serial_peripherals.py`](diffhunk://#diff-44ed897ed53a1d092c75d43a3ab81a26266124c1d153a2f223dda9552f8347d7L535-R551): Added `get_camera_port` to determine the current camera port based on dichroic position and its associated information. This method raises an error if the port cannot be determined.  
* [`software/control/serial_peripherals.py`](diffhunk://#diff-44ed897ed53a1d092c75d43a3ab81a26266124c1d153a2f223dda9552f8347d7L535-R551): Modified `get_port_selection_dichroic` to store the current dichroic position in `current_port_selection_dichroic` for easier access.  
* [`software/control/serial_peripherals.py`](diffhunk://#diff-44ed897ed53a1d092c75d43a3ab81a26266124c1d153a2f223dda9552f8347d7R739-R745): Added an alternative implementation of `get_camera_port` using a simpler dichroic position check.  

### Improvements to emission filter handling:
* [`software/control/core/core.py`](diffhunk://#diff-2fc90167f3cd3e8a6b36bdd78086c6ae5811054d9f87239fa2fe2b3a8858d691L520-R522): Updated `update_illumination` to use the new `get_camera_port` method when setting the emission filter, ensuring the correct camera port is used.  

### Simplification of field aperture selection in the UI:
* [`software/control/widgets.py`](diffhunk://#diff-26413fa85447f35aa4077535ae2d5f6f1905d5de96d6b303d426f9d039ddde2bL965-R967): Replaced separate handling of field aperture positions for two ports with a unified approach using `get_field_aperture_wheel_position`, simplifying the dropdown logic.