### PR TITLE
bug fix: qt widget layout error

### DIFF
--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -991,9 +991,9 @@ class DragonflyConfocalWidget(QWidget):
         self.signal_toggle_confocal_widefield.emit(self.confocal_mode)
 
     def init_ui(self):
-        main_layout = QVBoxLayout(self)
+        main_layout = QVBoxLayout()
 
-        layout_confocal = QHBoxLayout(self)
+        layout_confocal = QHBoxLayout()
         # Row 1: Switch to Confocal button, Disk Motor button, Dichroic dropdown
         self.btn_toggle_confocal = QPushButton("Switch to Confocal")
         self.btn_disk_motor = QPushButton("Disk Motor On")
@@ -1009,7 +1009,7 @@ class DragonflyConfocalWidget(QWidget):
         layout_confocal.addWidget(dichroic_label)
         layout_confocal.addWidget(self.dropdown_dichroic)
 
-        layout_wheels = QGridLayout(self)
+        layout_wheels = QGridLayout()
         # Row 2: Camera Port 1 Emission Filter and Field Aperture
         port1_emission_label = QLabel("Port 1 Emission Filter")
         self.dropdown_port1_emission_filter = QComboBox(self)


### PR DESCRIPTION
This pull request makes minor adjustments to the initialization of UI layouts in the `widgets.py` file to improve consistency and avoid passing the parent widget unnecessarily. These changes simplify the layout creation process.

### UI Layout Initialization Improvements:
* [`software/control/widgets.py`](diffhunk://#diff-26413fa85447f35aa4077535ae2d5f6f1905d5de96d6b303d426f9d039ddde2bL994-R996): Removed the parent widget argument (`self`) when initializing `QVBoxLayout`, `QHBoxLayout`, and `QGridLayout` in the `init_ui` method. This ensures a cleaner and more consistent approach to layout initialization. [[1]](diffhunk://#diff-26413fa85447f35aa4077535ae2d5f6f1905d5de96d6b303d426f9d039ddde2bL994-R996) [[2]](diffhunk://#diff-26413fa85447f35aa4077535ae2d5f6f1905d5de96d6b303d426f9d039ddde2bL1012-R1012)