### PR TITLE
feat: use software crop in AbstractCamera

### DIFF
--- a/software/squid/abc.py
+++ b/software/squid/abc.py
@@ -571,7 +571,7 @@ class AbstractCamera(metaclass=abc.ABCMeta):
         crop_height = int(crop_height * self._software_crop_height_ratio)
         return crop_width, crop_height
 
-    def set_crop_size_ratio(self, width_ratio: float, height_ratio: float):
+    def set_software_crop_ratio(self, width_ratio: float, height_ratio: float):
         """
         Set the software crop size ratio.
         """


### PR DESCRIPTION
This change has not been reflected in GUI yet, but it's been tested on a customer's system with some customized code.

This pull request introduces support for software-based cropping in the `software/squid/abc.py` camera module, allowing for more flexible image processing after hardware cropping. The changes add new attributes for crop ratios, update crop size calculations, and provide a method to set the software crop ratios.

**Software crop support:**

* Added `self._software_crop_width_ratio` and `self._software_crop_height_ratio` attributes to the class, initialized to `1.0` (no crop by default), along with documentation describing their use after hardware cropping.
* Updated the `get_crop_size` method to apply the software crop ratios to the calculated crop width and height, so the returned size reflects both hardware and software cropping.
* Added the `set_software_crop_ratio` method to allow setting the software crop width and height ratios dynamically.