### PR TITLE
bug fix: Run Spot Detection

### DIFF
--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -719,7 +719,7 @@ class LaserAutofocusSettingWidget(QWidget):
         self.liveController.trigger_acquisition()
 
         try:
-            frame = self.liveController.microscope.camera.read_frame()
+            frame = self.liveController.camera.read_frame()
         finally:
             self.liveController.microscope.low_level_drivers.microcontroller.turn_off_AF_laser()
             self.liveController.microscope.low_level_drivers.microcontroller.wait_till_operation_is_completed()


### PR DESCRIPTION
Customer reported Run Spot Detection in laser af widget is broken. The reason is we were triggering laser af camera but trying to read image from main camera. This PR fixes it. Tested with hardware.
This pull request includes a small change to the camera frame acquisition logic in the `illuminate_and_get_frame` method. The change updates the method to read the frame directly from `self.liveController.camera` instead of accessing it through `self.liveController.microscope.camera`.