### PR TITLE
microcontroller: force int as a bandaid, check for integral input

### DIFF
--- a/software/control/microcontroller.py
+++ b/software/control/microcontroller.py
@@ -814,8 +814,8 @@ class Microcontroller:
         self.send_command(cmd)
 
     def configure_stage_pid(self, axis, transitions_per_revolution, flip_direction=False):
-        if not isinstance(transitions_per_revolution, int) or transitions_per_revolution <= 0:
-            raise ValueError(f"transitions_per_revolution must be a > 0 integer, but is: {transitions_per_revolution}")
+        if not isinstance(transitions_per_revolution, int):
+            raise ValueError(f"transitions_per_revolution must be an integer, but is: {transitions_per_revolution}")
 
         cmd = bytearray(self.tx_buffer_length)
         cmd[1] = CMD_SET.CONFIGURE_STAGE_PID

--- a/software/control/microcontroller.py
+++ b/software/control/microcontroller.py
@@ -814,6 +814,9 @@ class Microcontroller:
         self.send_command(cmd)
 
     def configure_stage_pid(self, axis, transitions_per_revolution, flip_direction=False):
+        if not isinstance(transitions_per_revolution, int) or transitions_per_revolution <= 0:
+            raise ValueError(f"transitions_per_revolution must be a > 0 integer, but is: {transitions_per_revolution}")
+
         cmd = bytearray(self.tx_buffer_length)
         cmd[1] = CMD_SET.CONFIGURE_STAGE_PID
         cmd[2] = axis
@@ -1218,21 +1221,22 @@ class Microcontroller:
                 raise self.last_command_aborted_error
 
     @staticmethod
-    def _int_to_payload(signed_int, number_of_bytes):
-        if signed_int >= 0:
-            payload = signed_int
+    def _int_to_payload(signed_int, number_of_bytes) -> int:
+        actually_signed_int = int(round(signed_int))
+        if actually_signed_int >= 0:
+            payload = actually_signed_int
         else:
-            payload = 2 ** (8 * number_of_bytes) + signed_int  # find two's completement
-        return payload
+            payload = 2 ** (8 * number_of_bytes) + actually_signed_int  # find two's complement
+        return int(payload)
 
     @staticmethod
-    def _payload_to_int(payload, number_of_bytes):
+    def _payload_to_int(payload, number_of_bytes) -> int:
         signed = 0
         for i in range(number_of_bytes):
             signed = signed + int(payload[i]) * (256 ** (number_of_bytes - 1 - i))
         if signed >= 256**number_of_bytes / 2:
             signed = signed - 256**number_of_bytes
-        return signed
+        return int(signed)
 
     def set_dac80508_scaling_factor_for_illumination(self, illumination_intensity_factor):
         if illumination_intensity_factor > 1:


### PR DESCRIPTION
This does 2 things.  First, it puts a bandaid on our int<->payload helpers to make sure they always return an int (since it is assumed they do in code).  Second, for one specific case, it does the correct fix and validates that the user input is integral.  This is better because we don't just round/truncate and move on.  If the user is giving us a fractional `transitions_per_revolution`, something is wrong (since a fractional value does not make sense there - we can only send integers to the micro!).

Tested by: Unit tests still pass.  If we want to proceed with this I will add a failing test case for the float input case.