### PR TITLE
move microcontroller initialization code out of gui

### DIFF
--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -482,12 +482,6 @@ class HighContentScreeningGui(QMainWindow):
             if USE_ZABER_EMISSION_FILTER_WHEEL:
                 self.emission_filter_wheel.wait_for_homing_complete()
 
-            if HAS_OBJECTIVE_PIEZO:
-                OUTPUT_GAINS.CHANNEL7_GAIN = OBJECTIVE_PIEZO_CONTROL_VOLTAGE_RANGE == 5
-            div = 1 if OUTPUT_GAINS.REFDIV else 0
-            gains = sum(getattr(OUTPUT_GAINS, f"CHANNEL{i}_GAIN") << i for i in range(8))
-            self.microcontroller.configure_dac80508_refdiv_and_gain(div, gains)
-            self.microcontroller.set_dac80508_scaling_factor_for_illumination(ILLUMINATION_INTENSITY_FACTOR)
         except TimeoutError as e:
             # If we can't recover from a timeout, at least do our best to make sure the system is left in a safe
             # and restartable state.

--- a/software/control/microcontroller.py
+++ b/software/control/microcontroller.py
@@ -514,6 +514,7 @@ class Microcontroller:
             self.initialize_drivers()
             time.sleep(0.5)
             self.configure_actuators()
+            self.set_dac80508_scaling_factor_for_illumination(ILLUMINATION_INTENSITY_FACTOR)
             if USE_SQUID_FILTERWHEEL:
                 self.configure_squidfilter()
             time.sleep(0.5)

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -208,7 +208,12 @@ class LowLevelDrivers:
         self.microcontroller: Optional[Microcontroller] = microcontroller
 
     def prepare_for_use(self):
-        pass
+        if self.microcontroller and control._def.HAS_OBJECTIVE_PIEZO:
+            # Configure DAC gains for objective piezo
+            control._def.OUTPUT_GAINS.CHANNEL7_GAIN = control._def.OBJECTIVE_PIEZO_CONTROL_VOLTAGE_RANGE == 5
+            div = 1 if control._def.OUTPUT_GAINS.REFDIV else 0
+            gains = sum(getattr(control._def.OUTPUT_GAINS, f"CHANNEL{i}_GAIN") << i for i in range(8))
+            self.microcontroller.configure_dac80508_refdiv_and_gain(div, gains)
 
 
 class Microscope:


### PR DESCRIPTION
This pull request refactors how and where the DAC gain configuration for the objective piezo is handled, moving related logic from the GUI hardware setup to the microscope's preparation phase and ensuring DAC scaling for illumination is always set during microcontroller initialization. This makes hardware initialization more modular and robust.

Hardware initialization refactoring:

* Moved DAC gain configuration for the objective piezo out of `setup_hardware` in `gui_hcs.py` and into the `prepare_for_use` method of `Microscope`, ensuring it only runs when needed and making the code more modular. [[1]](diffhunk://#diff-b32c2c591f7e7074dc4393294e5993027fa1de4429b34dbf8e760d697b2c7219L485-L490) [[2]](diffhunk://#diff-0335b71615d885047310f61f8354ce70de2d0913b37a44489c8867df347677a8L211-R216)

Microcontroller setup improvement:

* Ensured that the DAC scaling factor for illumination (`set_dac80508_scaling_factor_for_illumination`) is always set during microcontroller initialization, regardless of where the hardware setup is triggered.