### PR TITLE
bug fix: illumination always turns on when software starts

### DIFF
--- a/software/control/core/live_controller.py
+++ b/software/control/core/live_controller.py
@@ -298,7 +298,8 @@ class LiveController:
         self._log.debug(f"Setting {fps_trigger=}")
         self.fps_trigger = fps_trigger
         self.timer_trigger_interval = (1 / self.fps_trigger) * 1000
-        self._start_new_timer()
+        if self.is_live:
+            self._start_new_timer()
 
     def _stop_triggerred_acquisition(self):
         self._stop_existing_timer()


### PR DESCRIPTION
We were calling `_start_new_timer()` unconditionally in LiveController when we set trigger fps. On start this was called and turned on illumination. Added `if self.is_live:` to start timer only when live is on.