### PR TITLE
bug fix: Calibration Live Viewer cannot be opened from Sample Format dropdown

### DIFF
--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -8502,7 +8502,7 @@ class WellplateCalibration(QDialog):
         # Add left column to main layout
         layout.addLayout(left_layout)
 
-        self.live_viewer = CalibrationLiveViewer(parent=self)
+        self.live_viewer = CalibrationLiveViewer()
         self.streamHandler.image_to_display.connect(self.live_viewer.display_image)
 
         if not self.was_live:


### PR DESCRIPTION
This pull request makes a minor update to the initialization of the `CalibrationLiveViewer` widget in `software/control/widgets.py`, removing the `parent` argument. Tested with hardware