### PR TITLE
bug fix: laser af using other spots in averaging

### DIFF
--- a/software/control/core/laser_auto_focus_controller.py
+++ b/software/control/core/laser_auto_focus_controller.py
@@ -574,7 +574,7 @@ class LaserAutofocusController(QObject):
                     > self.laser_af_properties.laser_af_range
                 ):
                     self._log.warning(
-                        f"Spot detected at ({x:.1f}, {y:.1f}) is out of range ({self.laser_af_properties.laser_af_range:.1f} μm)"
+                        f"Spot detected at ({x:.1f}, {y:.1f}) is out of range ({self.laser_af_properties.laser_af_range:.1f} μm), skipping it."
                     )
                     continue
 

--- a/software/control/core/laser_auto_focus_controller.py
+++ b/software/control/core/laser_auto_focus_controller.py
@@ -643,9 +643,3 @@ class LaserAutofocusController(QObject):
                 self.microcontroller.wait_till_operation_is_completed()
             except TimeoutError:
                 self._log.exception("Failed to turn off AF laser after get_image!")
-
-    def clear_reference(self):
-        """Clear reference position"""
-        self.has_reference = False
-        self.reference_crop = None
-        self._log.info("Reference spot position cleared")

--- a/software/control/core/laser_auto_focus_controller.py
+++ b/software/control/core/laser_auto_focus_controller.py
@@ -568,6 +568,16 @@ class LaserAutofocusController(QObject):
                 else:
                     x, y = result
 
+                if (
+                    self.laser_af_properties.has_reference
+                    and abs(x - self.laser_af_properties.x_reference) * self.laser_af_properties.pixel_to_um
+                    > self.laser_af_properties.laser_af_range
+                ):
+                    self._log.warning(
+                        f"Spot detected at ({x:.1f}, {y:.1f}) is out of range ({self.laser_af_properties.laser_af_range:.1f} μm)"
+                    )
+                    continue
+
                 tmp_x += x
                 tmp_y += y
                 successful_detections += 1


### PR DESCRIPTION
This pull request introduces an important improvement to the laser auto-focus controller's spot detection logic and removes an unused method related to clearing the reference position. The main change adds a check to ensure that detected laser spots are within the allowed range, improving reliability and safety.

Laser spot detection enhancements:
* Added a validation step in `_get_laser_spot_centroid` to skip and warn if the detected spot is outside the allowed range from the reference position, based on `laser_af_range` and pixel-to-micron conversion.

Code cleanup:
* Removed the `clear_reference` method from the controller, which is not being used anywhere.