### PR TITLE
contrast autofocus: pull QT out of the base contrast and remove qt from related tests

### DIFF
--- a/software/control/core/auto_focus_controller.py
+++ b/software/control/core/auto_focus_controller.py
@@ -101,6 +101,7 @@ class AutoFocusController:
                 self._finished_fn()
                 raise RuntimeError("Previous focus thread failed to join")
 
+        self._keep_running.set()
         self._autofocus_worker = AutofocusWorker(
             self, self._on_autofocus_completed, self._image_to_display_fn, self._keep_running
         )

--- a/software/control/core/auto_focus_controller.py
+++ b/software/control/core/auto_focus_controller.py
@@ -1,12 +1,11 @@
+import threading
 import time
-from typing import Optional
-
-from PyQt5.QtCore import QObject, QThread
-from PyQt5.QtWidgets import QApplication
-from qtpy.QtCore import Signal
+from threading import Thread
+from typing import Optional, Callable
 
 import numpy as np
 
+import squid.logging
 from control import utils
 import control._def
 from control.core.auto_focus_worker import AutofocusWorker
@@ -16,24 +15,27 @@ from control.microscope import NL5
 from squid.abc import AbstractCamera, AbstractStage
 
 
-class AutoFocusController(QObject):
-    z_pos = Signal(float)
-    autofocusFinished = Signal()
-    image_to_display = Signal(np.ndarray)
-
+class AutoFocusController:
     def __init__(
         self,
         camera: AbstractCamera,
         stage: AbstractStage,
         liveController: LiveController,
         microcontroller: Microcontroller,
+        finished_fn: Callable[[], None],
+        image_to_display_fn: Callable[[np.ndarray], None],
         nl5: Optional[NL5],
     ):
-        QObject.__init__(self)
+        self._log = squid.logging.get_logger(self.__class__.__name__)
+        self._autofocus_worker: Optional[AutofocusWorker] = None
+        self._focus_thread: Optional[Thread] = None
+        self._keep_running = threading.Event()
         self.camera: AbstractCamera = camera
         self.stage: AbstractStage = stage
         self.microcontroller: Microcontroller = microcontroller
         self.liveController: LiveController = liveController
+        self._finished_fn = finished_fn
+        self._image_to_display_fn = image_to_display_fn
         self.nl5: Optional[NL5] = nl5
 
         # Start with "Reasonable" defaults.
@@ -56,7 +58,6 @@ class AutoFocusController(QObject):
         self.crop_height = crop_height
 
     def autofocus(self, focus_map_override=False):
-        # TODO(imo): We used to have the joystick button wired up to autofocus, but took it out in a refactor.  It needs to be restored.
         if self.use_focus_map and (not focus_map_override):
             self.autofocus_in_progress = True
 
@@ -65,10 +66,10 @@ class AutoFocusController(QObject):
 
             # z here is in mm because that's how the navigation controller stores it
             target_z = utils.interpolate_plane(*self.focus_map_coords[:3], (pos.x_mm, pos.y_mm))
-            print(f"Interpolated target z as {target_z} mm from focus map, moving there.")
+            self._log.info(f"Interpolated target z as {target_z} mm from focus map, moving there.")
             self.stage.move_z_to(target_z)
             self.autofocus_in_progress = False
-            self.autofocusFinished.emit()
+            self._finished_fn()
             return
         # stop live
         if self.liveController.is_live:
@@ -87,28 +88,24 @@ class AutoFocusController(QObject):
         self.autofocus_in_progress = True
 
         # create a QThread object
-        try:
-            if self.thread.isRunning():
-                print("*** autofocus thread is still running ***")
-                self.thread.terminate()
-                self.thread.wait()
-                print("*** autofocus threaded manually stopped ***")
-        except:
-            pass
-        self.thread = QThread(parent=self)
-        # create a worker object
-        self.autofocusWorker = AutofocusWorker(self)
-        # move the worker to the thread
-        self.autofocusWorker.moveToThread(self.thread)
-        # connect signals and slots
-        self.thread.started.connect(self.autofocusWorker.run)
-        self.autofocusWorker.finished.connect(self._on_autofocus_completed)
-        self.autofocusWorker.finished.connect(self.autofocusWorker.deleteLater)
-        self.autofocusWorker.finished.connect(self.thread.quit)
-        self.autofocusWorker.image_to_display.connect(self.slot_image_to_display)
-        self.thread.finished.connect(self.thread.quit)
-        # start the thread
-        self.thread.start()
+        if self._focus_thread and self._focus_thread.is_alive():
+            self._keep_running.clear()
+            try:
+                self._focus_thread.join(1.0)
+            except RuntimeError as e:
+                self._log.exception("Critical error joining previous autofocus thread.")
+                self._finished_fn()
+                raise e
+            if self._focus_thread.is_alive():
+                self._log.error("Previous focus thread failed to join!")
+                self._finished_fn()
+                raise RuntimeError("Previous focus thread failed to join")
+
+        self._autofocus_worker = AutofocusWorker(
+            self, self._on_autofocus_completed, self._image_to_display_fn, self._keep_running
+        )
+        self._focus_thread = Thread(target=self._autofocus_worker.run, daemon=True)
+        self._focus_thread.start()
 
     def _on_autofocus_completed(self):
         # re-enable callback
@@ -120,29 +117,24 @@ class AutoFocusController(QObject):
             self.liveController.start_live()
 
         # emit the autofocus finished signal to enable the UI
-        self.autofocusFinished.emit()
-        QApplication.processEvents()
-        print("autofocus finished")
+        self._finished_fn()
+        self._log.info("autofocus finished")
 
         # update the state
         self.autofocus_in_progress = False
 
-    def slot_image_to_display(self, image):
-        self.image_to_display.emit(image)
-
     def wait_till_autofocus_has_completed(self):
         while self.autofocus_in_progress:
-            QApplication.processEvents()
             time.sleep(0.005)
-        print("autofocus wait has completed, exit wait")
+        self._log.info("autofocus wait has completed, exit wait")
 
     def set_focus_map_use(self, enable):
         if not enable:
-            print("Disabling focus map.")
+            self._log.info("Disabling focus map.")
             self.use_focus_map = False
             return
         if len(self.focus_map_coords) < 3:
-            print("Not enough coordinates (less than 3) for focus map generation, disabling focus map.")
+            self._log.error("Not enough coordinates (less than 3) for focus map generation, disabling focus map.")
             self.use_focus_map = False
             return
         x1, y1, _ = self.focus_map_coords[0]
@@ -151,12 +143,12 @@ class AutoFocusController(QObject):
 
         detT = (y2 - y3) * (x1 - x3) + (x3 - x2) * (y1 - y3)
         if detT == 0:
-            print("Your 3 x-y coordinates are linear, cannot use to interpolate, disabling focus map.")
+            self._log.error("Your 3 x-y coordinates are linear, cannot use to interpolate, disabling focus map.")
             self.use_focus_map = False
             return
 
         if enable:
-            print("Enabling focus map.")
+            self._log.info("Enabling focus map.")
             self.use_focus_map = True
 
     def clear_focus_map(self):
@@ -180,25 +172,25 @@ class AutoFocusController(QObject):
         self.focus_map_coords = []
 
         for coord in [coord1, coord2, coord3]:
-            print(f"Navigating to coordinates ({coord[0]},{coord[1]}) to sample for focus map")
+            self._log.info(f"Navigating to coordinates ({coord[0]},{coord[1]}) to sample for focus map")
             self.stage.move_x_to(coord[0])
             self.stage.move_y_to(coord[1])
 
-            print("Autofocusing")
+            self._log.info("Autofocusing")
             self.autofocus(True)
             self.wait_till_autofocus_has_completed()
             pos = self.stage.get_pos()
 
-            print(f"Adding coordinates ({pos.x_mm},{pos.y_mm},{pos.z_mm}) to focus map")
+            self._log.info(f"Adding coordinates ({pos.x_mm},{pos.y_mm},{pos.z_mm}) to focus map")
             self.focus_map_coords.append((pos.x_mm, pos.y_mm, pos.z_mm))
 
-        print("Generated focus map.")
+        self._log.info("Generated focus map.")
 
     def add_current_coords_to_focus_map(self):
         if len(self.focus_map_coords) >= 3:
-            print("Replacing last coordinate on focus map.")
+            self._log.info("Replacing last coordinate on focus map.")
         self.stage.wait_for_idle(timeout_s=0.5)
-        print("Autofocusing")
+        self._log.info("Autofocusing")
         self.autofocus(True)
         self.wait_till_autofocus_has_completed()
         pos = self.stage.get_pos()
@@ -219,4 +211,4 @@ class AutoFocusController(QObject):
         if len(self.focus_map_coords) >= 3:
             self.focus_map_coords.pop()
         self.focus_map_coords.append((x, y, z))
-        print(f"Added triple ({x},{y},{z}) to focus map")
+        self._log.info(f"Added triple ({x},{y},{z}) to focus map")

--- a/software/control/core/auto_focus_worker.py
+++ b/software/control/core/auto_focus_worker.py
@@ -65,6 +65,7 @@ class AutofocusWorker:
         image = None
         for i in range(self.N):
             if not self._keep_running.is_set():
+                self._log.warning("Signal to abort autofocus received, aborting!")
                 # This aborts and then we report our best focus so far
                 break
             self.stage.move_z(self.deltaZ)

--- a/software/control/core/auto_focus_worker.py
+++ b/software/control/core/auto_focus_worker.py
@@ -1,12 +1,10 @@
-from typing import Optional, TypeVar
+import threading
+from typing import Callable, Optional, TypeVar
 
-from PyQt5.QtCore import QObject
-from PyQt5.QtWidgets import QApplication
-from qtpy.QtCore import Signal
 import time
-
 import numpy as np
 
+import squid.logging
 from control import utils
 import control._def
 from control.core.live_controller import LiveController
@@ -17,13 +15,19 @@ from squid.abc import AbstractCamera, AbstractStage
 AutoFocusController = TypeVar("AutoFocusController")
 
 
-class AutofocusWorker(QObject):
-    finished = Signal()
-    image_to_display = Signal(np.ndarray)
-
-    def __init__(self, autofocusController):
-        QObject.__init__(self)
+class AutofocusWorker:
+    def __init__(
+        self,
+        autofocusController,
+        finished_fn: Callable[[], None],
+        image_to_display_fn: Callable[[np.ndarray], None],
+        keep_running: threading.Event,
+    ):
         self.autofocusController: AutoFocusController = autofocusController
+        self._finished_fn = finished_fn
+        self._image_to_display_fn = image_to_display_fn
+        self._keep_running: threading.Event = keep_running
+        self._log = squid.logging.get_logger(self.__class__.__name__)
 
         self.camera: AbstractCamera = self.autofocusController.camera
         self.microcontroller: Microcontroller = self.autofocusController.microcontroller
@@ -38,8 +42,10 @@ class AutofocusWorker(QObject):
         self.crop_height = self.autofocusController.crop_height
 
     def run(self):
-        self.run_autofocus()
-        self.finished.emit()
+        try:
+            self.run_autofocus()
+        finally:
+            self._finished_fn()
 
     def wait_till_operation_is_completed(self):
         while self.microcontroller.is_busy():
@@ -58,6 +64,9 @@ class AutofocusWorker(QObject):
         steps_moved = 0
         image = None
         for i in range(self.N):
+            if not self._keep_running.is_set():
+                # This aborts and then we report our best focus so far
+                break
             self.stage.move_z(self.deltaZ)
             steps_moved = steps_moved + 1
             # trigger acquisition (including turning on the illumination) and read frame
@@ -88,20 +97,17 @@ class AutofocusWorker(QObject):
                 self.liveController.turn_off_illumination()
 
             image = utils.crop_image(image, self.crop_width, self.crop_height)
-            self.image_to_display.emit(image)
+            self._image_to_display_fn(image)
 
-            QApplication.processEvents()
             timestamp_0 = time.time()
             focus_measure = utils.calculate_focus_measure(image, control._def.FOCUS_MEASURE_OPERATOR)
             timestamp_1 = time.time()
-            print("             calculating focus measure took " + str(timestamp_1 - timestamp_0) + " second")
+            self._log.info("             calculating focus measure took " + str(timestamp_1 - timestamp_0) + " second")
             focus_measure_vs_z[i] = focus_measure
-            print(i, focus_measure)
+            self._log.debug(f"{i} {focus_measure}")
             focus_measure_max = max(focus_measure, focus_measure_max)
             if focus_measure < focus_measure_max * control._def.AF.STOP_THRESHOLD:
                 break
-
-        QApplication.processEvents()
 
         # maneuver for achiving uniform step size and repeatability when using open-loop control
         self.stage.move_z(-steps_moved * self.deltaZ)
@@ -109,10 +115,8 @@ class AutofocusWorker(QObject):
         idx_in_focus = focus_measure_vs_z.index(max(focus_measure_vs_z))
         self.stage.move_z((idx_in_focus + 1) * self.deltaZ)
 
-        QApplication.processEvents()
-
         # move to the calculated in-focus position
         if idx_in_focus == 0:
-            print("moved to the bottom end of the AF range")
+            self._log.info("moved to the bottom end of the AF range")
         if idx_in_focus == self.N - 1:
-            print("moved to the top end of the AF range")
+            self._log.info("moved to the top end of the AF range")

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -147,7 +147,7 @@ class MovementUpdater(QObject):
 
 
 class QtAutoFocusController(AutoFocusController, QObject):
-    finished = Signal()
+    autofocusFinished = Signal()
     image_to_display = Signal(np.ndarray)
 
     def __init__(
@@ -165,7 +165,7 @@ class QtAutoFocusController(AutoFocusController, QObject):
             stage,
             liveController,
             microcontroller,
-            lambda: self.finished.emit(),
+            lambda: self.autofocusFinished.emit(),
             lambda image: self.image_to_display.emit(image),
             nl5,
         )

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -146,6 +146,31 @@ class MovementUpdater(QObject):
         self.previous_pos = pos
 
 
+class QtAutoFocusController(AutoFocusController, QObject):
+    finished = Signal()
+    image_to_display = Signal(np.ndarray)
+
+    def __init__(
+        self,
+        camera: AbstractCamera,
+        stage: AbstractStage,
+        liveController: LiveController,
+        microcontroller: Microcontroller,
+        nl5: Optional[control.microscope.NL5],
+    ):
+        QObject.__init__(self)
+        AutoFocusController.__init__(
+            self,
+            camera,
+            stage,
+            liveController,
+            microcontroller,
+            lambda: self.finished.emit(),
+            lambda image: self.image_to_display.emit(image),
+            nl5,
+        )
+
+
 class QtMultiPointController(MultiPointController, QObject):
     acquisition_finished = Signal()
     signal_acquisition_start = Signal()
@@ -403,7 +428,7 @@ class HighContentScreeningGui(QMainWindow):
         self.slidePositionController = core.SlidePositionController(
             self.stage, self.liveController, is_for_wellplate=True
         )
-        self.autofocusController = AutoFocusController(
+        self.autofocusController = QtAutoFocusController(
             self.camera, self.stage, self.liveController, self.microcontroller, self.nl5
         )
         if ENABLE_TRACKING:

--- a/software/tests/control/gui_test_stubs.py
+++ b/software/tests/control/gui_test_stubs.py
@@ -4,32 +4,15 @@ import control.microscope
 import control.core.objective_store
 import control.microcontroller
 import control.lighting
-import squid.abc
 
-from control._def import OBJECTIVES, DEFAULT_OBJECTIVE
-
-from control.core.auto_focus_controller import AutoFocusController
 from control.core.channel_configuration_mananger import ChannelConfigurationManager
 from control.core.configuration_mananger import ConfigurationManager
 from control.core.core import NavigationViewer
 from control.core.laser_af_settings_manager import LaserAFSettingManager
-from control.core.laser_auto_focus_controller import LaserAutofocusController
-from control.core.live_controller import LiveController
-from control.core.multi_point_controller import MultiPointController, NoOpCallbacks
-from control.core.multi_point_utils import MultiPointControllerFunctions
-from control.core.scan_coordinates import ScanCoordinates
 from control.gui_hcs import QtMultiPointController
 from control.microscope import Microscope
 from tests.tools import get_repo_root
-
-
-def get_test_live_controller(microscope: control.microscope.Microscope, starting_objective) -> LiveController:
-    controller = LiveController(microscope=microscope, camera=microscope.camera)
-
-    controller.set_microscope_mode(
-        microscope.configuration_manager.channel_manager.get_configurations(objective=starting_objective)[0]
-    )
-    return controller
+import tests.control.test_stubs as ts
 
 
 def get_test_configuration_manager_path() -> pathlib.Path:
@@ -56,91 +39,28 @@ def get_test_illumination_controller(
     )
 
 
-def get_test_autofocus_controller(
-    camera,
-    stage: squid.abc.AbstractStage,
-    live_controller: LiveController,
-    microcontroller: control.microcontroller.Microcontroller,
-):
-    return AutoFocusController(
-        camera=camera, stage=stage, liveController=live_controller, microcontroller=microcontroller, nl5=None
-    )
-
-
-def get_test_laser_autofocus_controller(microscope: Microscope):
-    return LaserAutofocusController(
-        microcontroller=microscope.low_level_drivers.microcontroller,
-        camera=microscope.addons.camera_focus,
-        liveController=LiveController(microscope=microscope, camera=microscope.addons.camera_focus),
-        stage=microscope.stage,
-        piezo=microscope.addons.piezo_stage,
-        objectiveStore=microscope.objective_store,
-        laserAFSettingManager=microscope.laser_af_settings_manager,
-    )
-
-
-def get_test_scan_coordinates(
-    objective_store: control.core.objective_store.ObjectiveStore,
-    stage: squid.abc.AbstractStage,
-    camera: squid.abc.AbstractCamera,
-):
-    return ScanCoordinates(objectiveStore=objective_store, stage=stage, camera=camera)
-
-
-def get_test_objective_store():
-    return control.core.objective_store.ObjectiveStore(objectives_dict=OBJECTIVES, default_objective=DEFAULT_OBJECTIVE)
-
-
 def get_test_navigation_viewer(objective_store: control.core.objective_store.ObjectiveStore, camera_pixel_size: float):
     return NavigationViewer(objective_store, camera_pixel_size)
 
 
 def get_test_qt_multi_point_controller(microscope: Microscope) -> QtMultiPointController:
-    live_controller = get_test_live_controller(
+    live_controller = ts.get_test_live_controller(
         microscope=microscope, starting_objective=microscope.objective_store.default_objective
     )
 
     multi_point_controller = QtMultiPointController(
         microscope=microscope,
         live_controller=live_controller,
-        autofocus_controller=get_test_autofocus_controller(
+        autofocus_controller=ts.get_test_autofocus_controller(
             microscope.camera, microscope.stage, live_controller, microscope.low_level_drivers.microcontroller
         ),
         channel_configuration_manager=microscope.channel_configuration_manager,
-        scan_coordinates=get_test_scan_coordinates(microscope.objective_store, microscope.stage, microscope.camera),
+        scan_coordinates=ts.get_test_scan_coordinates(microscope.objective_store, microscope.stage, microscope.camera),
         objective_store=microscope.objective_store,
-        laser_autofocus_controller=get_test_laser_autofocus_controller(microscope),
+        laser_autofocus_controller=ts.get_test_laser_autofocus_controller(microscope),
     )
 
     multi_point_controller.set_base_path("/tmp/")
     multi_point_controller.start_new_experiment("unit test experiment (qt)")
-
-    return multi_point_controller
-
-
-def get_test_multi_point_controller(
-    microscope: Microscope, callbacks: MultiPointControllerFunctions = NoOpCallbacks
-) -> MultiPointController:
-    live_controller = get_test_live_controller(
-        microscope=microscope, starting_objective=microscope.objective_store.default_objective
-    )
-
-    multi_point_controller = MultiPointController(
-        microscope=microscope,
-        live_controller=live_controller,
-        autofocus_controller=get_test_autofocus_controller(
-            microscope.camera, microscope.stage, live_controller, microscope.low_level_drivers.microcontroller
-        ),
-        channel_configuration_manager=microscope.channel_configuration_manager,
-        scan_coordinates=get_test_scan_coordinates(
-            objective_store=microscope.objective_store, stage=microscope.stage, camera=microscope.camera
-        ),
-        callbacks=callbacks,
-        objective_store=microscope.objective_store,
-        laser_autofocus_controller=get_test_laser_autofocus_controller(microscope),
-    )
-
-    multi_point_controller.set_base_path("/tmp/")
-    multi_point_controller.start_new_experiment("unit test experiment")
 
     return multi_point_controller

--- a/software/tests/control/test_MultiPointController.py
+++ b/software/tests/control/test_MultiPointController.py
@@ -1,16 +1,16 @@
-import pytest
 import threading
 
-import tests.control.gui_test_stubs as gts
 import control._def
 import control.microscope
 from control.core.multi_point_controller import MultiPointController
 from control.core.multi_point_utils import MultiPointControllerFunctions, AcquisitionParameters
 
+import tests.control.test_stubs as ts
 
-def test_multi_point_controller_image_count_calculation(qtbot):
+
+def test_multi_point_controller_image_count_calculation():
     scope = control.microscope.Microscope.build_from_global_config(True)
-    mpc = gts.get_test_qt_multi_point_controller(microscope=scope)
+    mpc = ts.get_test_multi_point_controller(microscope=scope)
 
     control._def.MERGE_CHANNELS = False
     all_configuration_names = [
@@ -61,9 +61,9 @@ def test_multi_point_controller_image_count_calculation(qtbot):
     assert mpc.get_acquisition_image_count() == final_number_of_fov * (all_config_count + 1)
 
 
-def test_multi_point_controller_disk_space_estimate(qtbot):
+def test_multi_point_controller_disk_space_estimate():
     scope = control.microscope.Microscope.build_from_global_config(True)
-    mpc = gts.get_test_qt_multi_point_controller(microscope=scope)
+    mpc = ts.get_test_multi_point_controller(microscope=scope)
 
     control._def.MERGE_CHANNELS = False
     all_configuration_names = [
@@ -176,11 +176,11 @@ def select_some_configs(mpc: MultiPointController, objective: str):
     mpc.set_selected_configurations(selected_configurations_name=first_two_config_names)
 
 
-def test_multi_point_controller_basic_acquisition(qtbot):
+def test_multi_point_controller_basic_acquisition():
     control._def.MERGE_CHANNELS = False
     scope = control.microscope.Microscope.build_from_global_config(True)
     tt = TestAcquisitionTracker()
-    mpc = gts.get_test_multi_point_controller(microscope=scope, callbacks=tt.get_callbacks())
+    mpc = ts.get_test_multi_point_controller(microscope=scope, callbacks=tt.get_callbacks())
 
     add_some_coordinates(mpc)
     select_some_configs(mpc, scope.objective_store.current_objective)
@@ -205,7 +205,7 @@ def test_multi_point_with_laser_af():
     scope = control.microscope.Microscope.build_from_global_config(True)
     tt = TestAcquisitionTracker()
 
-    mpc = gts.get_test_multi_point_controller(microscope=scope, callbacks=tt.get_callbacks())
+    mpc = ts.get_test_multi_point_controller(microscope=scope, callbacks=tt.get_callbacks())
 
     add_some_coordinates(mpc)
     select_some_configs(mpc, scope.objective_store.current_objective)
@@ -229,14 +229,13 @@ def test_multi_point_with_laser_af():
     assert tt.config_change_count > 0
 
 
-@pytest.mark.skip(reason="We still need to pull QT usage out of AutofocusController and AutofocusWorker.")
 def test_multi_point_with_contrast_af():
     control._def.MERGE_CHANNELS = False
 
     scope = control.microscope.Microscope.build_from_global_config(True)
     tt = TestAcquisitionTracker()
 
-    mpc = gts.get_test_multi_point_controller(microscope=scope, callbacks=tt.get_callbacks())
+    mpc = ts.get_test_multi_point_controller(microscope=scope, callbacks=tt.get_callbacks())
 
     add_some_coordinates(mpc)
     select_some_configs(mpc, scope.objective_store.current_objective)

--- a/software/tests/control/test_ObjectiveStore.py
+++ b/software/tests/control/test_ObjectiveStore.py
@@ -1,10 +1,9 @@
-import tests.control.gui_test_stubs as gts
-import pytest
+import tests.control.test_stubs as ts
 import control._def
 
 
 def test_objective_store():
-    objective_store = gts.get_test_objective_store()
+    objective_store = ts.get_test_objective_store()
     objective1 = {
         "name": "10x",
         "magnification": 10,

--- a/software/tests/control/test_stubs.py
+++ b/software/tests/control/test_stubs.py
@@ -1,0 +1,93 @@
+from control._def import OBJECTIVES, DEFAULT_OBJECTIVE
+from control.core.auto_focus_controller import AutoFocusController
+from control.core.laser_auto_focus_controller import LaserAutofocusController
+from control.core.live_controller import LiveController
+from control.core.multi_point_controller import NoOpCallbacks, MultiPointController
+from control.core.multi_point_utils import MultiPointControllerFunctions
+from control.core.objective_store import ObjectiveStore
+from control.core.scan_coordinates import ScanCoordinates
+from control.microcontroller import Microcontroller
+from control.microscope import Microscope
+from squid.abc import AbstractStage, AbstractCamera
+
+
+def get_test_live_controller(microscope: Microscope, starting_objective) -> LiveController:
+    controller = LiveController(microscope=microscope, camera=microscope.camera)
+
+    controller.set_microscope_mode(
+        microscope.configuration_manager.channel_manager.get_configurations(objective=starting_objective)[0]
+    )
+    return controller
+
+
+def get_test_autofocus_controller(
+    camera,
+    stage: AbstractStage,
+    live_controller: LiveController,
+    microcontroller: Microcontroller,
+):
+    return AutoFocusController(
+        camera=camera,
+        stage=stage,
+        liveController=live_controller,
+        microcontroller=microcontroller,
+        nl5=None,
+        finished_fn=lambda: None,
+        image_to_display_fn=lambda image: None,
+    )
+
+
+def get_test_scan_coordinates(
+    objective_store: ObjectiveStore,
+    stage: AbstractStage,
+    camera: AbstractCamera,
+):
+    return ScanCoordinates(objectiveStore=objective_store, stage=stage, camera=camera)
+
+
+def get_test_objective_store():
+    return ObjectiveStore(objectives_dict=OBJECTIVES, default_objective=DEFAULT_OBJECTIVE)
+
+
+def get_test_laser_autofocus_controller(microscope: Microscope):
+    return LaserAutofocusController(
+        microcontroller=microscope.low_level_drivers.microcontroller,
+        camera=microscope.addons.camera_focus,
+        liveController=LiveController(microscope=microscope, camera=microscope.addons.camera_focus),
+        stage=microscope.stage,
+        piezo=microscope.addons.piezo_stage,
+        objectiveStore=microscope.objective_store,
+        laserAFSettingManager=microscope.laser_af_settings_manager,
+    )
+
+
+def get_test_multi_point_controller(
+    microscope: Microscope,
+    callbacks: MultiPointControllerFunctions = NoOpCallbacks,
+) -> MultiPointController:
+    live_controller = get_test_live_controller(
+        microscope=microscope, starting_objective=microscope.objective_store.default_objective
+    )
+
+    multi_point_controller = MultiPointController(
+        microscope=microscope,
+        live_controller=live_controller,
+        autofocus_controller=get_test_autofocus_controller(
+            microscope.camera,
+            microscope.stage,
+            live_controller,
+            microscope.low_level_drivers.microcontroller,
+        ),
+        channel_configuration_manager=microscope.channel_configuration_manager,
+        scan_coordinates=get_test_scan_coordinates(
+            objective_store=microscope.objective_store, stage=microscope.stage, camera=microscope.camera
+        ),
+        callbacks=callbacks,
+        objective_store=microscope.objective_store,
+        laser_autofocus_controller=get_test_laser_autofocus_controller(microscope),
+    )
+
+    multi_point_controller.set_base_path("/tmp/")
+    multi_point_controller.start_new_experiment("unit test experiment")
+
+    return multi_point_controller


### PR DESCRIPTION
I narrowed down our occasionally segfaulting tests to the QT usage in the contrast autofocus code.  We needed to remove the qt usage here anyway, so this does that and simultaneously fixes the segfaulting test setup (by separating stubs that no longer need qt, and those that do, and removing qt usage in tests where not needed).

I think as long as we're using QT without understanding the core problem that's leading to these segfaults, we're liable to have this return.  But for now, this fixes it.

Tested By: Running on a cephla stage + toupcam system, and making sure manual contrast autofocus works.  Then running an acquisition with contrast autofocus, and one without, and making sure both work.  Unit tests also now pass without a segfault.