### PR TITLE
bug fix: buttons for coordinates are not disabled properly after acquisition is finished

### DIFF
--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -4702,6 +4702,7 @@ class WellplateMultiPointWidget(QFrame):
             self.focusMapWidget.update_focus_point_display()
             self.focusMapWidget.enable_updating_focus_points_on_signal()
         self.setEnabled_all(True)
+        self.toggle_coordinate_controls(self.has_loaded_coordinates)
 
     def setEnabled_all(self, enabled):
         for widget in self.findChildren(QWidget):


### PR DESCRIPTION
This pull request makes a small update to the `acquisition_is_finished` method in `software/control/widgets.py`, ensuring that coordinate controls are toggled based on whether coordinates have been loaded when an acquisition is finished.