### PR TITLE
feat: set laser af reference when setting z min in z range

### DIFF
--- a/software/control/core/laser_auto_focus_controller.py
+++ b/software/control/core/laser_auto_focus_controller.py
@@ -366,6 +366,10 @@ class LaserAutofocusController(QObject):
         Returns:
             bool: True if reference was set successfully, False if spot detection failed
         """
+        if not self.is_initialized:
+            self._log.exception("Laser autofocus is not initialized, cannot set reference")
+            return False
+
         # turn on the laser
         try:
             self.microcontroller.turn_on_AF_laser()

--- a/software/control/core/laser_auto_focus_controller.py
+++ b/software/control/core/laser_auto_focus_controller.py
@@ -367,7 +367,7 @@ class LaserAutofocusController(QObject):
             bool: True if reference was set successfully, False if spot detection failed
         """
         if not self.is_initialized:
-            self._log.exception("Laser autofocus is not initialized, cannot set reference")
+            self._log.error("Laser autofocus is not initialized, cannot set reference")
             return False
 
         # turn on the laser

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -3219,8 +3219,19 @@ class FlexibleMultiPointWidget(QFrame):
             if widget is not None:
                 widget.setVisible(is_visible)
 
+        # Disable reflection autofocus checkbox if Z-range is visible
+        self.checkbox_withReflectionAutofocus.setEnabled(not is_visible)
         # Enable/disable NZ entry based on the inverse of is_visible
         self.entry_NZ.setEnabled(not is_visible)
+        current_z = self.stage.get_pos().z_mm * 1000
+        self.entry_minZ.setValue(current_z)
+        if (
+            is_visible
+            and self.checkbox_withReflectionAutofocus.isChecked()
+            and not self.multipointController.laserAutoFocusController.set_reference()
+        ):
+            error_dialog("Failed to set reference for reflection autofocus. Is the laser autofocus initialized?")
+        self.entry_maxZ.setValue(current_z)
 
         if not is_visible:
             try:
@@ -3267,6 +3278,11 @@ class FlexibleMultiPointWidget(QFrame):
     def set_z_min(self):
         z_value = self.stage.get_pos().z_mm * 1000  # Convert to μm
         self.entry_minZ.setValue(z_value)
+        if (
+            self.checkbox_withReflectionAutofocus.isChecked()
+            and not self.multipointController.laserAutoFocusController.set_reference()
+        ):
+            error_dialog("Failed to set reference for reflection autofocus. Is the laser autofocus initialized?")
 
     def set_z_max(self):
         z_value = self.stage.get_pos().z_mm * 1000  # Convert to μm
@@ -3275,6 +3291,11 @@ class FlexibleMultiPointWidget(QFrame):
     def update_z_min(self, z_pos_um):
         if z_pos_um < self.entry_minZ.value():
             self.entry_minZ.setValue(z_pos_um)
+            if (
+                self.checkbox_withReflectionAutofocus.isChecked()
+                and not self.multipointController.laserAutoFocusController.set_reference()
+            ):
+                error_dialog("Failed to set reference for reflection autofocus. Is the laser autofocus initialized?")
 
     def update_z_max(self, z_pos_um):
         if z_pos_um > self.entry_maxZ.value():
@@ -4418,10 +4439,18 @@ class WellplateMultiPointWidget(QFrame):
                 if widget:
                     widget.setVisible(is_visible)
 
+        # Disable reflection autofocus checkbox if Z-range is visible
+        self.checkbox_withReflectionAutofocus.setEnabled(not is_visible)
         # Enable/disable NZ entry based on the inverse of is_visible
         self.entry_NZ.setEnabled(not is_visible)
         current_z = self.stage.get_pos().z_mm * 1000
         self.entry_minZ.setValue(current_z)
+        if (
+            is_visible
+            and self.checkbox_withReflectionAutofocus.isChecked()
+            and not self.multipointController.laserAutoFocusController.set_reference()
+        ):
+            error_dialog("Failed to set reference for reflection autofocus. Is the laser autofocus initialized?")
         self.entry_maxZ.setValue(current_z)
 
         # Safely connect or disconnect signals
@@ -4550,6 +4579,11 @@ class WellplateMultiPointWidget(QFrame):
     def set_z_min(self):
         z_value = self.stage.get_pos().z_mm * 1000  # Convert to μm
         self.entry_minZ.setValue(z_value)
+        if (
+            self.checkbox_withReflectionAutofocus.isChecked()
+            and not self.multipointController.laserAutoFocusController.set_reference()
+        ):
+            error_dialog("Failed to set reference for reflection autofocus. Is the laser autofocus initialized?")
 
     def set_z_max(self):
         z_value = self.stage.get_pos().z_mm * 1000  # Convert to μm
@@ -4558,6 +4592,11 @@ class WellplateMultiPointWidget(QFrame):
     def update_z_min(self, z_pos_um):
         if z_pos_um < self.entry_minZ.value():
             self.entry_minZ.setValue(z_pos_um)
+            if (
+                self.checkbox_withReflectionAutofocus.isChecked()
+                and not self.multipointController.laserAutoFocusController.set_reference()
+            ):
+                error_dialog("Failed to set reference for reflection autofocus. Is the laser autofocus initialized?")
 
     def update_z_max(self, z_pos_um):
         if z_pos_um > self.entry_maxZ.value():

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -3225,12 +3225,8 @@ class FlexibleMultiPointWidget(QFrame):
         self.entry_NZ.setEnabled(not is_visible)
         current_z = self.stage.get_pos().z_mm * 1000
         self.entry_minZ.setValue(current_z)
-        if (
-            is_visible
-            and self.checkbox_withReflectionAutofocus.isChecked()
-            and not self.multipointController.laserAutoFocusController.set_reference()
-        ):
-            error_dialog("Failed to set reference for reflection autofocus. Is the laser autofocus initialized?")
+        if is_visible:
+            self._reset_reflection_af_reference()
         self.entry_maxZ.setValue(current_z)
 
         if not is_visible:
@@ -3278,11 +3274,7 @@ class FlexibleMultiPointWidget(QFrame):
     def set_z_min(self):
         z_value = self.stage.get_pos().z_mm * 1000  # Convert to μm
         self.entry_minZ.setValue(z_value)
-        if (
-            self.checkbox_withReflectionAutofocus.isChecked()
-            and not self.multipointController.laserAutoFocusController.set_reference()
-        ):
-            error_dialog("Failed to set reference for reflection autofocus. Is the laser autofocus initialized?")
+        self._reset_reflection_af_reference()
 
     def set_z_max(self):
         z_value = self.stage.get_pos().z_mm * 1000  # Convert to μm
@@ -3291,15 +3283,18 @@ class FlexibleMultiPointWidget(QFrame):
     def update_z_min(self, z_pos_um):
         if z_pos_um < self.entry_minZ.value():
             self.entry_minZ.setValue(z_pos_um)
-            if (
-                self.checkbox_withReflectionAutofocus.isChecked()
-                and not self.multipointController.laserAutoFocusController.set_reference()
-            ):
-                error_dialog("Failed to set reference for reflection autofocus. Is the laser autofocus initialized?")
+            self._reset_reflection_af_reference()
 
     def update_z_max(self, z_pos_um):
         if z_pos_um > self.entry_maxZ.value():
             self.entry_maxZ.setValue(z_pos_um)
+
+    def _reset_reflection_af_reference(self):
+        if (
+            self.checkbox_withReflectionAutofocus.isChecked()
+            and not self.multipointController.laserAutoFocusController.set_reference()
+        ):
+            error_dialog("Failed to set reference for reflection autofocus. Is the laser autofocus initialized?")
 
     def update_z(self):
         z_mm = self.stage.get_pos().z_mm
@@ -4445,12 +4440,8 @@ class WellplateMultiPointWidget(QFrame):
         self.entry_NZ.setEnabled(not is_visible)
         current_z = self.stage.get_pos().z_mm * 1000
         self.entry_minZ.setValue(current_z)
-        if (
-            is_visible
-            and self.checkbox_withReflectionAutofocus.isChecked()
-            and not self.multipointController.laserAutoFocusController.set_reference()
-        ):
-            error_dialog("Failed to set reference for reflection autofocus. Is the laser autofocus initialized?")
+        if is_visible:
+            self._reset_reflection_af_reference()
         self.entry_maxZ.setValue(current_z)
 
         # Safely connect or disconnect signals
@@ -4579,11 +4570,7 @@ class WellplateMultiPointWidget(QFrame):
     def set_z_min(self):
         z_value = self.stage.get_pos().z_mm * 1000  # Convert to μm
         self.entry_minZ.setValue(z_value)
-        if (
-            self.checkbox_withReflectionAutofocus.isChecked()
-            and not self.multipointController.laserAutoFocusController.set_reference()
-        ):
-            error_dialog("Failed to set reference for reflection autofocus. Is the laser autofocus initialized?")
+        self._reset_reflection_af_reference()
 
     def set_z_max(self):
         z_value = self.stage.get_pos().z_mm * 1000  # Convert to μm
@@ -4592,15 +4579,18 @@ class WellplateMultiPointWidget(QFrame):
     def update_z_min(self, z_pos_um):
         if z_pos_um < self.entry_minZ.value():
             self.entry_minZ.setValue(z_pos_um)
-            if (
-                self.checkbox_withReflectionAutofocus.isChecked()
-                and not self.multipointController.laserAutoFocusController.set_reference()
-            ):
-                error_dialog("Failed to set reference for reflection autofocus. Is the laser autofocus initialized?")
+            self._reset_reflection_af_reference()
 
     def update_z_max(self, z_pos_um):
         if z_pos_um > self.entry_maxZ.value():
             self.entry_maxZ.setValue(z_pos_um)
+
+    def _reset_reflection_af_reference(self):
+        if (
+            self.checkbox_withReflectionAutofocus.isChecked()
+            and not self.multipointController.laserAutoFocusController.set_reference()
+        ):
+            error_dialog("Failed to set reference for reflection autofocus. Is the laser autofocus initialized?")
 
     def init_z(self, z_pos_mm=None):
         # sets initial z range form the current z position used after startup of the GUI


### PR DESCRIPTION
Tested in simulation mode.

This pull request improves the robustness and user feedback of the laser autofocus and Z-range controls in the application. The main changes add checks to ensure the laser autofocus system is initialized before attempting to set a reference, and provide clear error messages to the user if initialization has not occurred. Additionally, the user interface now disables the reflection autofocus checkbox when Z-range controls are visible to prevent conflicting operations.

**Laser Autofocus Initialization Checks and Error Handling:**

* Added a check in `LaserAutoFocusController.set_reference` to ensure the controller is initialized before proceeding. If not initialized, an error is logged and the method returns `False`.
* In multiple places in `widgets.py` (e.g., `toggle_z_range_controls`, `set_z_min`, `set_z_max`, `update_z_min`), added logic to check if reflection autofocus is enabled and, if so, attempt to set the laser autofocus reference. If this fails, an error dialog is displayed to inform the user. [[1]](diffhunk://#diff-26413fa85447f35aa4077535ae2d5f6f1905d5de96d6b303d426f9d039ddde2bR3222-R3234) [[2]](diffhunk://#diff-26413fa85447f35aa4077535ae2d5f6f1905d5de96d6b303d426f9d039ddde2bR3281-R3285) [[3]](diffhunk://#diff-26413fa85447f35aa4077535ae2d5f6f1905d5de96d6b303d426f9d039ddde2bR3294-R3298) [[4]](diffhunk://#diff-26413fa85447f35aa4077535ae2d5f6f1905d5de96d6b303d426f9d039ddde2bR4582-R4586) [[5]](diffhunk://#diff-26413fa85447f35aa4077535ae2d5f6f1905d5de96d6b303d426f9d039ddde2bR4595-R4599)

**User Interface Improvements:**

* The reflection autofocus checkbox (`checkbox_withReflectionAutofocus`) is now disabled whenever Z-range controls are visible, preventing users from enabling it in an invalid state. [[1]](diffhunk://#diff-26413fa85447f35aa4077535ae2d5f6f1905d5de96d6b303d426f9d039ddde2bR3222-R3234) [[2]](diffhunk://#diff-26413fa85447f35aa4077535ae2d5f6f1905d5de96d6b303d426f9d039ddde2bR4442-R4453)