### PR TITLE
feat: headless microscope API — hardware init, single-FOV acquisition, laser AF, profiles (temporary)

### DIFF
--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -621,7 +621,7 @@ class HighContentScreeningGui(QMainWindow):
         load_slack_settings_from_cache()
 
         self.load_objects(is_simulation=is_simulation)
-        self.setup_hardware(skip_init=self._skip_init)
+        self.setup_hardware()
 
         self.setup_movement_updater()
 
@@ -813,67 +813,14 @@ class HighContentScreeningGui(QMainWindow):
             fluidics=self.fluidics,
         )
 
-    def setup_hardware(self, skip_init: bool = False):
-        # Setup hardware components
-        if not self.microcontroller:
-            raise ValueError("Microcontroller must be none-None for hardware setup.")
-
-        try:
-            x_config = self.stage.get_config().X_AXIS
-            y_config = self.stage.get_config().Y_AXIS
-            z_config = self.stage.get_config().Z_AXIS
-
-            if skip_init:
-                self.log.info("Skipping hardware initialization (--skip-init flag set)")
-            else:
-                self.log.info(
-                    f"Setting stage limits to:"
-                    f" x=[{x_config.MIN_POSITION},{x_config.MAX_POSITION}],"
-                    f" y=[{y_config.MIN_POSITION},{y_config.MAX_POSITION}],"
-                    f" z=[{z_config.MIN_POSITION},{z_config.MAX_POSITION}]"
-                )
-
-                self.stage.set_limits(
-                    x_pos_mm=x_config.MAX_POSITION,
-                    x_neg_mm=x_config.MIN_POSITION,
-                    y_pos_mm=y_config.MAX_POSITION,
-                    y_neg_mm=y_config.MIN_POSITION,
-                    z_pos_mm=z_config.MAX_POSITION,
-                    z_neg_mm=z_config.MIN_POSITION,
-                )
-
-                self.microscope.home_xyz()
-
-        except TimeoutError as e:
-            # If we can't recover from a timeout, at least do our best to make sure the system is left in a safe
-            # and restartable state.
-            self.log.error("Setup timed out, resetting microcontroller before failing gui setup")
-            self.microcontroller.reset()
-            raise e
-        if DEFAULT_TRIGGER_MODE == TriggerMode.HARDWARE:
-            print("Setting acquisition mode to HARDWARE_TRIGGER")
-            self.camera.set_acquisition_mode(squid.abc.CameraAcquisitionMode.HARDWARE_TRIGGER)
-            self.microcontroller.set_trigger_mode(HARDWARE_TRIGGER_MODE)
-        else:
-            self.camera.set_acquisition_mode(squid.abc.CameraAcquisitionMode.SOFTWARE_TRIGGER)
+    def setup_hardware(self):
         self.camera.add_frame_callback(self.streamHandler.get_frame_callback())
         self.camera.enable_callbacks(enabled=True)
 
         if self.camera_focus:
-            self.camera_focus.set_acquisition_mode(
-                squid.abc.CameraAcquisitionMode.SOFTWARE_TRIGGER
-            )  # self.camera.set_continuous_acquisition()
             self.camera_focus.add_frame_callback(self.streamHandler_focus_camera.get_frame_callback())
             self.camera_focus.enable_callbacks(enabled=True)
             self.camera_focus.start_streaming()
-
-        if self.objective_changer:
-            self.objective_changer.home()
-            self.objective_changer.setSpeed(XERYON_SPEED)
-            if DEFAULT_OBJECTIVE in XERYON_OBJECTIVE_SWITCHER_POS_1:
-                self.objective_changer.moveToPosition1(move_z=False)
-            elif DEFAULT_OBJECTIVE in XERYON_OBJECTIVE_SWITCHER_POS_2:
-                self.objective_changer.moveToPosition2(move_z=False)
 
     def waitForMicrocontroller(self, timeout=5.0, error_message=None):
         try:

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -1,5 +1,7 @@
+import os
+import time
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 import imageio
 import numpy as np
@@ -638,6 +640,78 @@ class Microscope:
         imageio.imwrite(str(p), image)
         self._log.info(f"Image saved to {p}")
         return str(p)
+
+    def acquire_single_fov(
+        self,
+        channel_names: List[str],
+        save_path: str,
+        NZ: int = 1,
+        deltaZ_mm: float = 0.0,
+        z_stacking_config: str = "FROM BOTTOM",
+    ) -> List[str]:
+        """Acquire a C+Z stack at the current position.
+
+        Iterates over z-planes and channels, saving each image to save_path.
+        File naming follows the acquisition pipeline convention:
+        ``0_000000_{z}_{channel_name}.{ext}``
+
+        Args:
+            channel_names: List of illumination channel names to acquire.
+            save_path: Directory to save images into (created if needed).
+            NZ: Number of z-planes.
+            deltaZ_mm: Z step size in mm (positive = upward).
+            z_stacking_config: "FROM BOTTOM", "FROM CENTER", or "FROM TOP".
+
+        Returns:
+            List of saved file paths.
+        """
+        objective = self.objective_store.current_objective
+        configs = []
+        for name in channel_names:
+            config = self.live_controller.get_channel_by_name(objective, name)
+            if config is None:
+                available = [ch.name for ch in self.live_controller.get_channels(objective)]
+                raise ValueError(f"Channel '{name}' not found. Available: {available}")
+            configs.append(config)
+
+        os.makedirs(save_path, exist_ok=True)
+
+        deltaZ = deltaZ_mm
+        if z_stacking_config == "FROM TOP":
+            deltaZ = -abs(deltaZ_mm)
+
+        # Move to start of z-stack
+        if NZ > 1 and z_stacking_config == "FROM CENTER":
+            self.stage.move_z(-deltaZ * round((NZ - 1) / 2.0))
+            time.sleep(control._def.SCAN_STABILIZATION_TIME_MS_Z / 1000)
+
+        saved_paths = []
+        for z_level in range(NZ):
+            for config in configs:
+                self.live_controller.set_microscope_mode(config)
+                self._wait_for_microcontroller()
+
+                image = self.acquire_image()
+
+                channel_name_safe = config.name.replace(" ", "_")
+                file_id = f"0_000000_{z_level}_{channel_name_safe}"
+                saved = self.save_image(image, os.path.join(save_path, file_id))
+                saved_paths.append(saved)
+
+            if z_level < NZ - 1:
+                self.stage.move_z(deltaZ)
+                time.sleep(control._def.SCAN_STABILIZATION_TIME_MS_Z / 1000)
+
+        # Move z back to starting position
+        if NZ > 1:
+            if z_stacking_config == "FROM CENTER":
+                rel_z = -deltaZ * (NZ - 1) + deltaZ * round((NZ - 1) / 2)
+            else:
+                rel_z = -deltaZ * (NZ - 1)
+            self.stage.move_z(rel_z)
+
+        self._log.info(f"Acquired {len(saved_paths)} images ({len(configs)} channels x {NZ} z-planes)")
+        return saved_paths
 
     def home_xyz(self) -> None:
         """Home the X, Y, and Z axes based on configuration settings.

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Optional
 
+import imageio
 import numpy as np
 
 import control._def
@@ -427,11 +428,50 @@ class Microscope:
         self.camera.set_pixel_format(
             squid.config.CameraPixelFormat.from_string(control._def.CAMERA_CONFIG.PIXEL_FORMAT_DEFAULT)
         )
-        self.camera.set_acquisition_mode(CameraAcquisitionMode.SOFTWARE_TRIGGER)
+        if control._def.DEFAULT_TRIGGER_MODE == control._def.TriggerMode.HARDWARE:
+            self._log.info("Setting acquisition mode to HARDWARE_TRIGGER")
+            self.camera.set_acquisition_mode(CameraAcquisitionMode.HARDWARE_TRIGGER)
+            self.low_level_drivers.microcontroller.set_trigger_mode(control._def.HARDWARE_TRIGGER_MODE)
+        else:
+            self.camera.set_acquisition_mode(CameraAcquisitionMode.SOFTWARE_TRIGGER)
 
         if self.addons.camera_focus:
             self.addons.camera_focus.set_pixel_format(squid.config.CameraPixelFormat.from_string("MONO8"))
             self.addons.camera_focus.set_acquisition_mode(CameraAcquisitionMode.SOFTWARE_TRIGGER)
+
+        if not skip_init:
+            try:
+                stage_config = self.stage.get_config()
+                x_config = stage_config.X_AXIS
+                y_config = stage_config.Y_AXIS
+                z_config = stage_config.Z_AXIS
+                self._log.info(
+                    f"Setting stage limits: x=[{x_config.MIN_POSITION},{x_config.MAX_POSITION}], "
+                    f"y=[{y_config.MIN_POSITION},{y_config.MAX_POSITION}], "
+                    f"z=[{z_config.MIN_POSITION},{z_config.MAX_POSITION}]"
+                )
+                self.stage.set_limits(
+                    x_pos_mm=x_config.MAX_POSITION,
+                    x_neg_mm=x_config.MIN_POSITION,
+                    y_pos_mm=y_config.MAX_POSITION,
+                    y_neg_mm=y_config.MIN_POSITION,
+                    z_pos_mm=z_config.MAX_POSITION,
+                    z_neg_mm=z_config.MIN_POSITION,
+                )
+                self.home_xyz()
+            except TimeoutError:
+                self._log.error("Hardware setup timed out, resetting microcontroller")
+                if self.low_level_drivers.microcontroller:
+                    self.low_level_drivers.microcontroller.reset()
+                raise
+
+        if self.addons.objective_changer:
+            self.addons.objective_changer.home()
+            self.addons.objective_changer.setSpeed(control._def.XERYON_SPEED)
+            if control._def.DEFAULT_OBJECTIVE in control._def.XERYON_OBJECTIVE_SWITCHER_POS_1:
+                self.addons.objective_changer.moveToPosition1(move_z=False)
+            elif control._def.DEFAULT_OBJECTIVE in control._def.XERYON_OBJECTIVE_SWITCHER_POS_2:
+                self.addons.objective_changer.moveToPosition2(move_z=False)
 
     def _sync_confocal_mode_from_hardware(self) -> bool:
         """Sync confocal mode state from spinning disk hardware.
@@ -577,6 +617,27 @@ class Microscope:
             # always turn off illumination when using software trigger
             if using_software_trigger:
                 self.live_controller.turn_off_illumination()
+
+    def save_image(self, image: np.ndarray, path: str) -> str:
+        """Save an image using the configured image format.
+
+        Uses tiff for uint16 images, otherwise Acquisition.IMAGE_FORMAT.
+        If path has no extension, the appropriate one is appended.
+
+        Args:
+            image: Image array to save.
+            path: Output file path (with or without extension).
+
+        Returns:
+            The actual path the image was saved to.
+        """
+        extension = "tiff" if image.dtype == np.uint16 else control._def.Acquisition.IMAGE_FORMAT
+        p = Path(path)
+        if not p.suffix:
+            p = p.with_suffix(f".{extension}")
+        imageio.imwrite(str(p), image)
+        self._log.info(f"Image saved to {p}")
+        return str(p)
 
     def home_xyz(self) -> None:
         """Home the X, Y, and Z axes based on configuration settings.

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -729,7 +729,9 @@ class Microscope:
 
         VALID_Z_STACKING_CONFIGS = {"FROM BOTTOM", "FROM CENTER", "FROM TOP"}
         if z_stacking_config not in VALID_Z_STACKING_CONFIGS:
-            raise ValueError(f"Invalid z_stacking_config '{z_stacking_config}'. Must be one of: {VALID_Z_STACKING_CONFIGS}")
+            raise ValueError(
+                f"Invalid z_stacking_config '{z_stacking_config}'. Must be one of: {VALID_Z_STACKING_CONFIGS}"
+            )
 
         Path(save_path).mkdir(parents=True, exist_ok=True)
 

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -682,7 +682,7 @@ class Microscope:
         if not self._laser_af_controller.is_initialized:
             raise RuntimeError(
                 "Laser autofocus is not initialized. "
-                "Call set_reference() first or ensure a cached configuration exists."
+                "Call initialize_auto() and set_reference() first, or ensure a cached configuration exists."
             )
         success = self._laser_af_controller.move_to_target(target_um)
         if success:
@@ -726,11 +726,17 @@ class Microscope:
                 raise ValueError(f"Channel '{name}' not found. Available: {available}")
             configs.append(config)
 
+        VALID_Z_STACKING_CONFIGS = {"FROM BOTTOM", "FROM CENTER", "FROM TOP"}
+        if z_stacking_config not in VALID_Z_STACKING_CONFIGS:
+            raise ValueError(f"Invalid z_stacking_config '{z_stacking_config}'. Must be one of: {VALID_Z_STACKING_CONFIGS}")
+
         os.makedirs(save_path, exist_ok=True)
 
         deltaZ = deltaZ_mm
         if z_stacking_config == "FROM TOP":
             deltaZ = -abs(deltaZ_mm)
+
+        z_start = self.stage.get_pos().z_mm
 
         # Move to start of z-stack
         if NZ > 1 and z_stacking_config == "FROM CENTER":
@@ -738,29 +744,28 @@ class Microscope:
             time.sleep(control._def.SCAN_STABILIZATION_TIME_MS_Z / 1000)
 
         saved_paths = []
-        for z_level in range(NZ):
-            for config in configs:
-                self.live_controller.set_microscope_mode(config)
-                self._wait_for_microcontroller()
+        try:
+            for z_level in range(NZ):
+                for config in configs:
+                    self.live_controller.set_microscope_mode(config)
+                    self._wait_for_microcontroller()
 
-                image = self.acquire_image()
+                    image = self.acquire_image()
 
-                channel_name_safe = config.name.replace(" ", "_")
-                file_id = f"0_0_{z_level}_{channel_name_safe}"
-                saved = self.save_image(image, os.path.join(save_path, file_id))
-                saved_paths.append(saved)
+                    channel_name_safe = config.name.replace(" ", "_")
+                    file_id = f"0_0_{z_level}_{channel_name_safe}"
+                    saved = self.save_image(image, os.path.join(save_path, file_id))
+                    saved_paths.append(saved)
 
-            if z_level < NZ - 1:
-                self.stage.move_z(deltaZ)
-                time.sleep(control._def.SCAN_STABILIZATION_TIME_MS_Z / 1000)
-
-        # Move z back to starting position
-        if NZ > 1:
-            if z_stacking_config == "FROM CENTER":
-                rel_z = -deltaZ * (NZ - 1) + deltaZ * round((NZ - 1) / 2)
-            else:
-                rel_z = -deltaZ * (NZ - 1)
-            self.stage.move_z(rel_z)
+                if z_level < NZ - 1:
+                    self.stage.move_z(deltaZ)
+                    time.sleep(control._def.SCAN_STABILIZATION_TIME_MS_Z / 1000)
+        finally:
+            # Always return Z to starting position
+            try:
+                self.stage.move_z_to(z_start)
+            except Exception as e:
+                self._log.error(f"Failed to return Z to start position {z_start} mm: {e}")
 
         self._log.info(f"Acquired {len(saved_paths)} images ({len(configs)} channels x {NZ} z-planes)")
         return saved_paths
@@ -982,9 +987,11 @@ class Microscope:
         if objective is None:
             objective = self.objective_store.current_objective
         channel_config = self.live_controller.get_channel_by_name(objective, channel)
-        if channel_config:
-            channel_config.illumination_intensity = intensity
-            self.live_controller.set_microscope_mode(channel_config)
+        if channel_config is None:
+            available = [ch.name for ch in self.live_controller.get_channels(objective)]
+            raise ValueError(f"Channel '{channel}' not found for objective '{objective}'. Available: {available}")
+        channel_config.illumination_intensity = intensity
+        self.live_controller.set_microscope_mode(channel_config)
 
     def set_exposure_time(self, channel: str, exposure_time: float, objective: Optional[str] = None) -> None:
         """Set the exposure time for a channel.
@@ -997,6 +1004,8 @@ class Microscope:
         if objective is None:
             objective = self.objective_store.current_objective
         channel_config = self.live_controller.get_channel_by_name(objective, channel)
-        if channel_config:
-            channel_config.exposure_time = exposure_time
-            self.live_controller.set_microscope_mode(channel_config)
+        if channel_config is None:
+            available = [ch.name for ch in self.live_controller.get_channels(objective)]
+            raise ValueError(f"Channel '{channel}' not found for objective '{objective}'. Available: {available}")
+        channel_config.exposure_time = exposure_time
+        self.live_controller.set_microscope_mode(channel_config)

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -637,6 +637,7 @@ class Microscope:
         p = Path(path)
         if not p.suffix:
             p = p.with_suffix(f".{extension}")
+        p.parent.mkdir(parents=True, exist_ok=True)
         imageio.imwrite(str(p), image)
         self._log.info(f"Image saved to {p}")
         return str(p)
@@ -690,6 +691,8 @@ class Microscope:
             self._log.warning(f"Laser AF failed (target={target_um} µm)")
         return success
 
+    # TODO: Move to MultiPointController in the future.
+
     def acquire_single_fov(
         self,
         channel_names: List[str],
@@ -702,7 +705,7 @@ class Microscope:
 
         Iterates over z-planes and channels, saving each image to save_path.
         File naming follows the acquisition pipeline convention:
-        ``0_000000_{z}_{channel_name}.{ext}``
+        ``0_0_{z}_{channel_name}.{ext}``
 
         Args:
             channel_names: List of illumination channel names to acquire.
@@ -743,7 +746,7 @@ class Microscope:
                 image = self.acquire_image()
 
                 channel_name_safe = config.name.replace(" ", "_")
-                file_id = f"0_000000_{z_level}_{channel_name_safe}"
+                file_id = f"0_0_{z_level}_{channel_name_safe}"
                 saved = self.save_image(image, os.path.join(save_path, file_id))
                 saved_paths.append(saved)
 

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -641,6 +641,55 @@ class Microscope:
         self._log.info(f"Image saved to {p}")
         return str(p)
 
+    # TODO: LaserAutofocusController is a higher-level controller that orchestrates
+    # hardware primitives. It should not live on Microscope long-term. It's here
+    # temporarily so headless scripts get laser AF without manually wiring up the
+    # controller and handling objective-change reloads. Once we have a proper
+    # acquisition API layer, move this there.
+
+    def _ensure_laser_af_controller(self):
+        if not hasattr(self, "_laser_af_controller") or self._laser_af_controller is None:
+            if not control._def.SUPPORT_LASER_AUTOFOCUS:
+                raise RuntimeError("Laser autofocus is not enabled (SUPPORT_LASER_AUTOFOCUS=False)")
+            if not self.addons.camera_focus:
+                raise RuntimeError("No focus camera available for laser autofocus")
+            from control.core.laser_auto_focus_controller import LaserAutofocusController
+
+            self._laser_af_controller = LaserAutofocusController(
+                microcontroller=self.low_level_drivers.microcontroller,
+                camera=self.addons.camera_focus,
+                liveController=self.live_controller_focus,
+                stage=self.stage,
+                piezo=self.addons.piezo_stage,
+                objectiveStore=self.objective_store,
+            )
+
+    def perform_laser_af(self, target_um: float = 0.0) -> bool:
+        """Perform laser autofocus at the current position.
+
+        Args:
+            target_um: Target displacement from reference in micrometers.
+                0.0 means move to the reference focal plane.
+
+        Returns:
+            True if autofocus succeeded, False otherwise.
+
+        Raises:
+            RuntimeError: If laser autofocus is not configured or not initialized.
+        """
+        self._ensure_laser_af_controller()
+        if not self._laser_af_controller.is_initialized:
+            raise RuntimeError(
+                "Laser autofocus is not initialized. "
+                "Call set_reference() first or ensure a cached configuration exists."
+            )
+        success = self._laser_af_controller.move_to_target(target_um)
+        if success:
+            self._log.info(f"Laser AF succeeded (target={target_um} µm)")
+        else:
+            self._log.warning(f"Laser AF failed (target={target_um} µm)")
+        return success
+
     def acquire_single_fov(
         self,
         channel_names: List[str],
@@ -888,6 +937,9 @@ class Microscope:
             objective: Name of the objective to set as current.
         """
         self.objective_store.set_current_objective(objective)
+        # Reload laser AF config for the new objective
+        if hasattr(self, "_laser_af_controller") and self._laser_af_controller is not None:
+            self._laser_af_controller.on_settings_changed()
 
     def set_illumination_intensity(self, channel: str, intensity: float, objective: Optional[str] = None) -> None:
         """Set the illumination intensity for a channel.

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -1,4 +1,3 @@
-import os
 import time
 from pathlib import Path
 from typing import List, Optional
@@ -367,6 +366,7 @@ class Microscope:
         self._simulated = simulated
 
         self.objective_store: ObjectiveStore = ObjectiveStore()
+        self._laser_af_controller = None
 
         # Centralized config management
         self.config_repo: ConfigRepository = ConfigRepository()
@@ -620,6 +620,13 @@ class Microscope:
             if using_software_trigger:
                 self.live_controller.turn_off_illumination()
 
+    def _get_channel_or_raise(self, objective: str, channel_name: str):
+        config = self.live_controller.get_channel_by_name(objective, channel_name)
+        if config is None:
+            available = [ch.name for ch in self.live_controller.get_channels(objective)]
+            raise ValueError(f"Channel '{channel_name}' not found for objective '{objective}'. Available: {available}")
+        return config
+
     def save_image(self, image: np.ndarray, path: str) -> str:
         """Save an image using the configured image format.
 
@@ -649,7 +656,7 @@ class Microscope:
     # acquisition API layer, move this there.
 
     def _ensure_laser_af_controller(self):
-        if not hasattr(self, "_laser_af_controller") or self._laser_af_controller is None:
+        if self._laser_af_controller is None:
             if not control._def.SUPPORT_LASER_AUTOFOCUS:
                 raise RuntimeError("Laser autofocus is not enabled (SUPPORT_LASER_AUTOFOCUS=False)")
             if not self.addons.camera_focus:
@@ -718,19 +725,13 @@ class Microscope:
             List of saved file paths.
         """
         objective = self.objective_store.current_objective
-        configs = []
-        for name in channel_names:
-            config = self.live_controller.get_channel_by_name(objective, name)
-            if config is None:
-                available = [ch.name for ch in self.live_controller.get_channels(objective)]
-                raise ValueError(f"Channel '{name}' not found. Available: {available}")
-            configs.append(config)
+        configs = [self._get_channel_or_raise(objective, name) for name in channel_names]
 
         VALID_Z_STACKING_CONFIGS = {"FROM BOTTOM", "FROM CENTER", "FROM TOP"}
         if z_stacking_config not in VALID_Z_STACKING_CONFIGS:
             raise ValueError(f"Invalid z_stacking_config '{z_stacking_config}'. Must be one of: {VALID_Z_STACKING_CONFIGS}")
 
-        os.makedirs(save_path, exist_ok=True)
+        Path(save_path).mkdir(parents=True, exist_ok=True)
 
         deltaZ = deltaZ_mm
         if z_stacking_config == "FROM TOP":
@@ -754,7 +755,7 @@ class Microscope:
 
                     channel_name_safe = config.name.replace(" ", "_")
                     file_id = f"0_0_{z_level}_{channel_name_safe}"
-                    saved = self.save_image(image, os.path.join(save_path, file_id))
+                    saved = self.save_image(image, str(Path(save_path) / file_id))
                     saved_paths.append(saved)
 
                 if z_level < NZ - 1:
@@ -958,7 +959,7 @@ class Microscope:
         self.config_repo.load_profile(profile)
         self._log.info(f"Loaded user profile '{profile}'")
         # Reload laser AF config for the new profile
-        if hasattr(self, "_laser_af_controller") and self._laser_af_controller is not None:
+        if self._laser_af_controller is not None:
             self._laser_af_controller.on_settings_changed()
 
     def get_available_profiles(self) -> List[str]:
@@ -973,7 +974,7 @@ class Microscope:
         """
         self.objective_store.set_current_objective(objective)
         # Reload laser AF config for the new objective
-        if hasattr(self, "_laser_af_controller") and self._laser_af_controller is not None:
+        if self._laser_af_controller is not None:
             self._laser_af_controller.on_settings_changed()
 
     def set_illumination_intensity(self, channel: str, intensity: float, objective: Optional[str] = None) -> None:
@@ -986,10 +987,7 @@ class Microscope:
         """
         if objective is None:
             objective = self.objective_store.current_objective
-        channel_config = self.live_controller.get_channel_by_name(objective, channel)
-        if channel_config is None:
-            available = [ch.name for ch in self.live_controller.get_channels(objective)]
-            raise ValueError(f"Channel '{channel}' not found for objective '{objective}'. Available: {available}")
+        channel_config = self._get_channel_or_raise(objective, channel)
         channel_config.illumination_intensity = intensity
         self.live_controller.set_microscope_mode(channel_config)
 
@@ -1003,9 +1001,6 @@ class Microscope:
         """
         if objective is None:
             objective = self.objective_store.current_objective
-        channel_config = self.live_controller.get_channel_by_name(objective, channel)
-        if channel_config is None:
-            available = [ch.name for ch in self.live_controller.get_channels(objective)]
-            raise ValueError(f"Channel '{channel}' not found for objective '{objective}'. Available: {available}")
+        channel_config = self._get_channel_or_raise(objective, channel)
         channel_config.exposure_time = exposure_time
         self.live_controller.set_microscope_mode(channel_config)

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -930,6 +930,33 @@ class Microscope:
         self.move_y_to(y)
         self.move_z_to(z)
 
+    # TODO: Profile management is application-level config I/O, not hardware control.
+    # It lives here temporarily because ConfigRepository was inherited from the legacy
+    # ConfigurationManager/ChannelConfigurationManager that were on Microscope from the
+    # start. Move to a proper application layer when one exists.
+
+    def load_user_profile(self, profile: str) -> None:
+        """Load a user profile, switching channel configs and laser AF configs.
+
+        Args:
+            profile: Profile name (must exist under user_profiles/).
+
+        Raises:
+            ValueError: If profile doesn't exist.
+        """
+        available = self.config_repo.get_available_profiles()
+        if profile not in available:
+            raise ValueError(f"Profile '{profile}' not found. Available: {available}")
+        self.config_repo.load_profile(profile)
+        self._log.info(f"Loaded user profile '{profile}'")
+        # Reload laser AF config for the new profile
+        if hasattr(self, "_laser_af_controller") and self._laser_af_controller is not None:
+            self._laser_af_controller.on_settings_changed()
+
+    def get_available_profiles(self) -> List[str]:
+        """Get list of available user profiles."""
+        return self.config_repo.get_available_profiles()
+
     def set_objective(self, objective: str) -> None:
         """Set the current objective lens.
 

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -431,6 +431,8 @@ class Microscope:
             squid.config.CameraPixelFormat.from_string(control._def.CAMERA_CONFIG.PIXEL_FORMAT_DEFAULT)
         )
         if control._def.DEFAULT_TRIGGER_MODE == control._def.TriggerMode.HARDWARE:
+            if not self.low_level_drivers.microcontroller:
+                raise RuntimeError("Hardware trigger mode requires a microcontroller, but none is configured.")
             self._log.info("Setting acquisition mode to HARDWARE_TRIGGER")
             self.camera.set_acquisition_mode(CameraAcquisitionMode.HARDWARE_TRIGGER)
             self.low_level_drivers.microcontroller.set_trigger_mode(control._def.HARDWARE_TRIGGER_MODE)
@@ -628,22 +630,20 @@ class Microscope:
         return config
 
     def save_image(self, image: np.ndarray, path: str) -> str:
-        """Save an image using the configured image format.
+        """Save an image to the given path.
 
-        Uses tiff for uint16 images, otherwise Acquisition.IMAGE_FORMAT.
-        If path has no extension, the appropriate one is appended.
+        Extension is determined by dtype: tiff for uint16, otherwise
+        Acquisition.IMAGE_FORMAT. Any existing extension in path is replaced.
 
         Args:
             image: Image array to save.
-            path: Output file path (with or without extension).
+            path: Output file path (extension is overridden).
 
         Returns:
             The actual path the image was saved to.
         """
         extension = "tiff" if image.dtype == np.uint16 else control._def.Acquisition.IMAGE_FORMAT
-        p = Path(path)
-        if not p.suffix:
-            p = p.with_suffix(f".{extension}")
+        p = Path(path).with_suffix(f".{extension}")
         p.parent.mkdir(parents=True, exist_ok=True)
         imageio.imwrite(str(p), image)
         self._log.info(f"Image saved to {p}")

--- a/software/tests/control/core/test_scan_coordinates.py
+++ b/software/tests/control/core/test_scan_coordinates.py
@@ -33,9 +33,9 @@ def test_scan_coordinates_basic_operation():
 
     scan_coordinates = ScanCoordinates(scope.objective_store, scope.stage, scope.camera, update_callback=test_callback)
 
-    single_fov_center = (6.0, 7.0, 3.0)
-    flexible_center = (8.0, 9.0, 0.5)
-    well_center = (6.5, 8.5, scope.stage.get_pos().z_mm)
+    single_fov_center = (20.0, 20.0, 3.0)
+    flexible_center = (30.0, 30.0, 0.5)
+    well_center = (25.0, 25.0, scope.stage.get_pos().z_mm)
     scan_coordinates.add_single_fov_region("single_fov", *single_fov_center)
     scan_coordinates.add_flexible_region("flexible_region", *flexible_center, 2, 2, 10)
     scan_coordinates.add_region("well_region", well_center[0], well_center[1], 4, 10, "Circle")


### PR DESCRIPTION
## Summary
- Consolidate hardware init from GUI into `Microscope._prepare_for_use()` so headless scripts get the same initialization (stage limits, homing, trigger mode, objective changer) without duplicating code
- Add headless acquisition methods: `acquire_single_fov()` (C+Z stack), `save_image()`, `perform_laser_af()`, `load_user_profile()`, `set_objective()` with laser AF reload
- GUI `setup_hardware()` reduced to camera callback registration only
- Channel validation: `set_illumination_intensity` / `set_exposure_time` now raise `ValueError` on unknown channel names instead of silently doing nothing

## New Microscope API

```python
# Setup
scope = Microscope.build_from_global_config(simulated=True)
scope.load_user_profile("default")
scope.set_objective("20x")

# Single image
scope.move_to_position(x, y, z)
scope.set_exposure_time("BF LED matrix full", 50.0)
scope.set_illumination_intensity("BF LED matrix full", 20.0)
image = scope.acquire_image()
scope.save_image(image, "output/image")

# Multi-location with laser AF and C+Z stacks
for loc in locations:
    scope.move_to_position(*loc)
    scope.perform_laser_af()
    scope.acquire_single_fov(channels, save_path, NZ=5, deltaZ_mm=0.001)

scope.close()
```

## Changes
- **`control/microscope.py`**: `_prepare_for_use` now handles stage limits, homing, trigger mode (respects `DEFAULT_TRIGGER_MODE`), objective changer. New methods: `save_image`, `acquire_single_fov`, `perform_laser_af`, `load_user_profile`, `get_available_profiles`, `_get_channel_or_raise`. Laser AF controller lazily created, reloaded on objective/profile change.
- **`control/gui_hcs.py`**: `setup_hardware` reduced to camera callback registration only.
- **`tests/control/core/test_scan_coordinates.py`**: Updated test coordinates to be within stage limits.

## Test plan
- [x] All directly affected tests pass (test_microscope, test_scan_coordinates, test_MultiPointController, test_MultiPointWorker)
- [x] Headless demo script runs in simulation (single image + multi-location C+Z stacks)
- [ ] GUI startup with `--simulation` flag
- [ ] GUI startup with `--skip-init` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)