### PR TITLE
fix: detect JobRunner subprocess death and stop memory-profiler ESRCH spam

### DIFF
--- a/software/control/core/job_processing.py
+++ b/software/control/core/job_processing.py
@@ -1066,11 +1066,12 @@ class JobRunner(multiprocessing.Process):
         self._bp_pending_bytes = bp_pending_bytes
         self._bp_capacity_event = bp_capacity_event
 
-        # Watchdog for detecting unexpected subprocess death (segfault, OOM kill, etc.).
-        # Without this, a dead JobRunner silently rots the acquisition: the parent keeps
-        # queuing save jobs that no one consumes.
         self._on_unexpected_exit: Optional[Callable[[Optional[int]], None]] = None
         self._watchdog: Optional[threading.Thread] = None
+        # Set by kill()/terminate()/shutdown() so the watchdog can distinguish
+        # intentional exit from segfault/OOM. Separate from _shutdown_event, which
+        # is a multiprocessing primitive that shutdown() nulls during cleanup.
+        self._intentional_exit = False
 
         # Clean up stale metadata files from previous crashed acquisitions
         # Only run when explicitly requested (i.e., when OME-TIFF saving is being used)
@@ -1089,7 +1090,6 @@ class JobRunner(multiprocessing.Process):
 
     def start(self):
         super().start()
-        # Watchdog must start after super().start() so self.pid and self.sentinel are set.
         self._watchdog = threading.Thread(
             target=self._watch_subprocess,
             daemon=True,
@@ -1098,29 +1098,23 @@ class JobRunner(multiprocessing.Process):
         self._watchdog.start()
 
     def kill(self):
-        # Mark as expected so the watchdog treats the exit as intentional.
-        if self._shutdown_event is not None:
-            self._shutdown_event.set()
+        self._intentional_exit = True
         super().kill()
 
     def terminate(self):
-        # Mark as expected so the watchdog treats the exit as intentional.
-        if self._shutdown_event is not None:
-            self._shutdown_event.set()
+        self._intentional_exit = True
         super().terminate()
 
     def _watch_subprocess(self) -> None:
         """Block until the subprocess exits, then distinguish expected vs. unexpected death."""
-        # Capture references; shutdown() clears self._shutdown_event after join().
-        shutdown_event = self._shutdown_event
         pid = self.pid
         multiprocessing.connection.wait([self.sentinel])
         exitcode = self.exitcode
-        if shutdown_event is not None and shutdown_event.is_set():
+        if self._intentional_exit:
             self._log.info(f"JobRunner PID={pid} exited cleanly (exitcode={exitcode})")
             return
         self._log.error(
-            f"JobRunner PID={pid} died UNEXPECTEDLY (exitcode={exitcode}). " f"Pending save jobs will not complete."
+            f"JobRunner PID={pid} died UNEXPECTEDLY (exitcode={exitcode}). Pending save jobs will not complete."
         )
         handler = self._on_unexpected_exit
         if handler is not None:
@@ -1232,6 +1226,7 @@ class JobRunner(multiprocessing.Process):
         # Guard against double shutdown
         if self._shutdown_event is None:
             return
+        self._intentional_exit = True
         self._shutdown_event.set()
         # Send sentinel to wake up worker blocked on queue.get()
         try:

--- a/software/control/core/job_processing.py
+++ b/software/control/core/job_processing.py
@@ -1103,6 +1103,12 @@ class JobRunner(multiprocessing.Process):
             self._shutdown_event.set()
         super().kill()
 
+    def terminate(self):
+        # Mark as expected so the watchdog treats the exit as intentional.
+        if self._shutdown_event is not None:
+            self._shutdown_event.set()
+        super().terminate()
+
     def _watch_subprocess(self) -> None:
         """Block until the subprocess exits, then distinguish expected vs. unexpected death."""
         # Capture references; shutdown() clears self._shutdown_event after join().

--- a/software/control/core/job_processing.py
+++ b/software/control/core/job_processing.py
@@ -1,12 +1,14 @@
 import abc
 import multiprocessing
+import multiprocessing.connection
 import queue
 import os
+import threading
 import time
 import json
 from datetime import datetime
 from contextlib import contextmanager
-from typing import ClassVar, Dict, Generic, List, Optional, Set, Tuple, TypeVar, Union
+from typing import Callable, ClassVar, Dict, Generic, List, Optional, Set, Tuple, TypeVar, Union
 from uuid import uuid4
 
 from dataclasses import dataclass, field
@@ -1064,12 +1066,63 @@ class JobRunner(multiprocessing.Process):
         self._bp_pending_bytes = bp_pending_bytes
         self._bp_capacity_event = bp_capacity_event
 
+        # Watchdog for detecting unexpected subprocess death (segfault, OOM kill, etc.).
+        # Without this, a dead JobRunner silently rots the acquisition: the parent keeps
+        # queuing save jobs that no one consumes.
+        self._on_unexpected_exit: Optional[Callable[[Optional[int]], None]] = None
+        self._watchdog: Optional[threading.Thread] = None
+
         # Clean up stale metadata files from previous crashed acquisitions
         # Only run when explicitly requested (i.e., when OME-TIFF saving is being used)
         if cleanup_stale_ome_files:
             removed = ome_tiff_writer.cleanup_stale_metadata_files()
             if removed:
                 self._log.info(f"Cleaned up {len(removed)} stale OME-TIFF metadata files")
+
+    def set_unexpected_exit_handler(self, handler: Optional[Callable[[Optional[int]], None]]) -> None:
+        """Register a callback to invoke if the subprocess dies without a clean shutdown.
+
+        The handler is called from the watchdog thread with the subprocess exitcode
+        (which may be None, a positive int, or a negative signal number on POSIX).
+        """
+        self._on_unexpected_exit = handler
+
+    def start(self):
+        super().start()
+        # Watchdog must start after super().start() so self.pid and self.sentinel are set.
+        self._watchdog = threading.Thread(
+            target=self._watch_subprocess,
+            daemon=True,
+            name=f"JobRunner-watchdog[{self.pid}]",
+        )
+        self._watchdog.start()
+
+    def kill(self):
+        # Mark as expected so the watchdog treats the exit as intentional.
+        if self._shutdown_event is not None:
+            self._shutdown_event.set()
+        super().kill()
+
+    def _watch_subprocess(self) -> None:
+        """Block until the subprocess exits, then distinguish expected vs. unexpected death."""
+        # Capture references; shutdown() clears self._shutdown_event after join().
+        shutdown_event = self._shutdown_event
+        pid = self.pid
+        multiprocessing.connection.wait([self.sentinel])
+        exitcode = self.exitcode
+        if shutdown_event is not None and shutdown_event.is_set():
+            self._log.info(f"JobRunner PID={pid} exited cleanly (exitcode={exitcode})")
+            return
+        self._log.error(
+            f"JobRunner PID={pid} died UNEXPECTEDLY (exitcode={exitcode}). "
+            f"Pending save jobs will not complete."
+        )
+        handler = self._on_unexpected_exit
+        if handler is not None:
+            try:
+                handler(exitcode)
+            except Exception:
+                self._log.exception("JobRunner unexpected-exit handler raised")
 
     def dispatch(self, job: Job):
         # Inject acquisition_info into SaveOMETiffJob instances before serialization.

--- a/software/control/core/job_processing.py
+++ b/software/control/core/job_processing.py
@@ -1114,8 +1114,7 @@ class JobRunner(multiprocessing.Process):
             self._log.info(f"JobRunner PID={pid} exited cleanly (exitcode={exitcode})")
             return
         self._log.error(
-            f"JobRunner PID={pid} died UNEXPECTEDLY (exitcode={exitcode}). "
-            f"Pending save jobs will not complete."
+            f"JobRunner PID={pid} died UNEXPECTEDLY (exitcode={exitcode}). " f"Pending save jobs will not complete."
         )
         handler = self._on_unexpected_exit
         if handler is not None:

--- a/software/control/core/memory_profiler.py
+++ b/software/control/core/memory_profiler.py
@@ -259,7 +259,9 @@ def _get_linux_pss_mb(pid: int) -> float:
                     pss_total_kb += int(parts[1])
 
         return pss_total_kb / 1024
-    except (FileNotFoundError, PermissionError, ValueError):
+    except (FileNotFoundError, PermissionError, ValueError, ProcessLookupError):
+        # ProcessLookupError (errno ESRCH) can occur when the process exited between
+        # PID enumeration and the smaps_rollup read, or when the PID is a zombie.
         pass
     return 0.0
 

--- a/software/control/core/multi_point_worker.py
+++ b/software/control/core/multi_point_worker.py
@@ -335,6 +335,11 @@ class MultiPointWorker:
                     if prewarmed_job_runner.is_ready():
                         self._log.info(f"Using pre-warmed job runner for {job_class.__name__} jobs")
                         job_runner = prewarmed_job_runner
+                        # Register abort handler as early as possible on adoption. The
+                        # window between controller-side start() and this point remains
+                        # uncovered for pre-warmed runners, but beyond here any
+                        # unexpected death triggers an abort.
+                        job_runner.set_unexpected_exit_handler(self._on_job_runner_died)
                         # Configure it with current acquisition settings
                         job_runner.set_acquisition_info(self.acquisition_info)
                         if zarr_writer_info:
@@ -366,12 +371,13 @@ class MultiPointWorker:
                         # Pass zarr writer info for ZARR_V3 format
                         zarr_writer_info=zarr_writer_info,
                     )
+                    # Register abort handler before start() so the watchdog always has
+                    # a handler available, even if the subprocess dies during warmup.
+                    job_runner.set_unexpected_exit_handler(self._on_job_runner_died)
                     job_runner.start()
                     # Subprocess starts warming up in background - don't block here
 
             self._job_runners.append((job_class, job_runner))
-            if job_runner is not None:
-                job_runner.set_unexpected_exit_handler(self._on_job_runner_died)
         self._abort_on_failed_job = abort_on_failed_jobs
         self._first_job_dispatched = False  # Track if we've waited for subprocess warmup
 

--- a/software/control/core/multi_point_worker.py
+++ b/software/control/core/multi_point_worker.py
@@ -377,9 +377,7 @@ class MultiPointWorker:
 
     def _on_job_runner_died(self, exitcode: Optional[int]) -> None:
         """Invoked by JobRunner's watchdog when a subprocess dies unexpectedly."""
-        self._log.error(
-            f"JobRunner subprocess died unexpectedly (exitcode={exitcode}); aborting acquisition."
-        )
+        self._log.error(f"JobRunner subprocess died unexpectedly (exitcode={exitcode}); aborting acquisition.")
         self._acquisition_error_count += 1
         self.request_abort_fn()
 

--- a/software/control/core/multi_point_worker.py
+++ b/software/control/core/multi_point_worker.py
@@ -335,10 +335,8 @@ class MultiPointWorker:
                     if prewarmed_job_runner.is_ready():
                         self._log.info(f"Using pre-warmed job runner for {job_class.__name__} jobs")
                         job_runner = prewarmed_job_runner
-                        # Register abort handler as early as possible on adoption. The
-                        # window between controller-side start() and this point remains
-                        # uncovered for pre-warmed runners, but beyond here any
-                        # unexpected death triggers an abort.
+                        # Pre-warmed runners were started by the controller without a
+                        # handler; the pre-handoff window stays uncovered by design.
                         job_runner.set_unexpected_exit_handler(self._on_job_runner_died)
                         # Configure it with current acquisition settings
                         job_runner.set_acquisition_info(self.acquisition_info)
@@ -371,8 +369,7 @@ class MultiPointWorker:
                         # Pass zarr writer info for ZARR_V3 format
                         zarr_writer_info=zarr_writer_info,
                     )
-                    # Register abort handler before start() so the watchdog always has
-                    # a handler available, even if the subprocess dies during warmup.
+                    # Must precede start() so the watchdog covers warmup-time deaths.
                     job_runner.set_unexpected_exit_handler(self._on_job_runner_died)
                     job_runner.start()
                     # Subprocess starts warming up in background - don't block here

--- a/software/control/core/multi_point_worker.py
+++ b/software/control/core/multi_point_worker.py
@@ -332,27 +332,26 @@ class MultiPointWorker:
             if Acquisition.USE_MULTIPROCESSING:
                 # Try to use pre-warmed runner for the first job class
                 if can_use_prewarmed and not used_prewarmed:
-                    if prewarmed_job_runner.is_ready():
+                    # is_alive() must be checked alongside is_ready(): the subprocess sets
+                    # _ready_event early in run() and the Event survives in shared memory
+                    # after death, so is_ready() alone can't detect a corpse.
+                    if prewarmed_job_runner.is_alive() and prewarmed_job_runner.is_ready():
                         self._log.info(f"Using pre-warmed job runner for {job_class.__name__} jobs")
                         job_runner = prewarmed_job_runner
-                        # Pre-warmed runners were started by the controller without a
-                        # handler; the pre-handoff window stays uncovered by design.
                         job_runner.set_unexpected_exit_handler(self._on_job_runner_died)
-                        # Configure it with current acquisition settings
                         job_runner.set_acquisition_info(self.acquisition_info)
                         if zarr_writer_info:
                             job_runner.set_zarr_writer_info(zarr_writer_info)
                         used_prewarmed = True
                     else:
                         self._log.warning(
-                            f"Pre-warmed job runner not ready (possibly hung during warmup), "
+                            f"Pre-warmed job runner unavailable (died or hung during warmup); "
                             f"shutting it down and creating new one for {job_class.__name__}"
                         )
-                        # Shutdown the hung pre-warmed runner to avoid resource leak
                         try:
                             prewarmed_job_runner.shutdown(timeout_s=1.0)
                         except Exception as e:
-                            self._log.error(f"Error shutting down hung pre-warmed runner: {e}")
+                            self._log.error(f"Error shutting down unusable pre-warmed runner: {e}")
                         # Don't try to use pre-warmed runner again for subsequent job classes
                         can_use_prewarmed = False
 

--- a/software/control/core/multi_point_worker.py
+++ b/software/control/core/multi_point_worker.py
@@ -370,8 +370,18 @@ class MultiPointWorker:
                     # Subprocess starts warming up in background - don't block here
 
             self._job_runners.append((job_class, job_runner))
+            if job_runner is not None:
+                job_runner.set_unexpected_exit_handler(self._on_job_runner_died)
         self._abort_on_failed_job = abort_on_failed_jobs
         self._first_job_dispatched = False  # Track if we've waited for subprocess warmup
+
+    def _on_job_runner_died(self, exitcode: Optional[int]) -> None:
+        """Invoked by JobRunner's watchdog when a subprocess dies unexpectedly."""
+        self._log.error(
+            f"JobRunner subprocess died unexpectedly (exitcode={exitcode}); aborting acquisition."
+        )
+        self._acquisition_error_count += 1
+        self.request_abort_fn()
 
     def update_use_piezo(self, value):
         self.use_piezo = value

--- a/software/tests/control/core/test_job_runner_watchdog.py
+++ b/software/tests/control/core/test_job_runner_watchdog.py
@@ -1,0 +1,147 @@
+"""Tests for JobRunner watchdog (unexpected subprocess death detection).
+
+These tests cover the watchdog thread that distinguishes intentional shutdown
+from unexpected subprocess death (segfault, SIGKILL, OOM kill) and invokes a
+registered handler so an acquisition can abort instead of silently rotting.
+"""
+
+import os
+import signal
+import threading
+import time
+
+import pytest
+
+from control.core.job_processing import JobRunner
+
+
+@pytest.fixture
+def runner():
+    """Provide an unstarted JobRunner; ensure cleanup even if the test crashes mid-run."""
+    r = JobRunner()
+    r.daemon = True
+    yield r
+    if r.is_alive():
+        try:
+            r.kill()
+            r.join(timeout=2.0)
+        except Exception:
+            pass
+
+
+# Watchdog runs in a daemon thread; allow it to finish after the sentinel fires.
+_WATCHDOG_GRACE_S = 0.3
+
+
+class TestWatchdogUnexpectedDeath:
+    """Verify the watchdog detects unexpected subprocess death and invokes the handler."""
+
+    def test_sigkill_fires_handler_with_negative_exitcode(self, runner):
+        handler_fired = threading.Event()
+        received_exitcode = []
+
+        def handler(exitcode):
+            received_exitcode.append(exitcode)
+            handler_fired.set()
+
+        runner.set_unexpected_exit_handler(handler)
+        runner.start()
+        assert runner.wait_ready(timeout_s=5.0)
+
+        os.kill(runner.pid, signal.SIGKILL)
+
+        assert handler_fired.wait(timeout=5.0), "Watchdog handler did not fire after SIGKILL"
+        assert received_exitcode == [-signal.SIGKILL]
+
+
+class TestWatchdogIntentionalExit:
+    """Verify intentional stop paths (kill/terminate/shutdown) do NOT fire the handler."""
+
+    def test_kill_does_not_fire_handler(self, runner):
+        handler_fired = threading.Event()
+        runner.set_unexpected_exit_handler(lambda ec: handler_fired.set())
+        runner.start()
+        assert runner.wait_ready(timeout_s=5.0)
+
+        runner.kill()
+        runner.join(timeout=2.0)
+        time.sleep(_WATCHDOG_GRACE_S)
+
+        assert not handler_fired.is_set(), "Handler fired despite intentional kill()"
+
+    def test_terminate_does_not_fire_handler(self, runner):
+        handler_fired = threading.Event()
+        runner.set_unexpected_exit_handler(lambda ec: handler_fired.set())
+        runner.start()
+        assert runner.wait_ready(timeout_s=5.0)
+
+        runner.terminate()
+        runner.join(timeout=2.0)
+        time.sleep(_WATCHDOG_GRACE_S)
+
+        assert not handler_fired.is_set(), "Handler fired despite intentional terminate()"
+
+    def test_shutdown_does_not_fire_handler(self, runner):
+        handler_fired = threading.Event()
+        runner.set_unexpected_exit_handler(lambda ec: handler_fired.set())
+        runner.start()
+        assert runner.wait_ready(timeout_s=5.0)
+
+        runner.shutdown(timeout_s=2.0)
+        time.sleep(_WATCHDOG_GRACE_S)
+
+        assert not handler_fired.is_set(), "Handler fired despite intentional shutdown()"
+
+
+class TestWatchdogResilience:
+    """Verify the watchdog is robust to handler misbehavior and shutdown ordering."""
+
+    def test_handler_exception_does_not_propagate(self, runner):
+        # The watchdog daemon thread must catch handler exceptions (it logs them).
+        # If propagation happened, the test process would not reach the post-join asserts.
+        runner.set_unexpected_exit_handler(lambda ec: (_ for _ in ()).throw(RuntimeError("boom")))
+        runner.start()
+        assert runner.wait_ready(timeout_s=5.0)
+
+        os.kill(runner.pid, signal.SIGKILL)
+        runner.join(timeout=5.0)
+        time.sleep(_WATCHDOG_GRACE_S)
+
+        assert not runner.is_alive()
+
+    def test_intentional_exit_survives_shutdown_cleanup(self, runner):
+        """Regression: shutdown() nulls _shutdown_event during cleanup. The intent flag
+        must be a separate attribute that survives that nullification, or the watchdog
+        could read None and misclassify intentional shutdown as unexpected death.
+        """
+        handler_fired = threading.Event()
+        runner.set_unexpected_exit_handler(lambda ec: handler_fired.set())
+        runner.start()
+        assert runner.wait_ready(timeout_s=5.0)
+
+        runner.shutdown(timeout_s=2.0)
+
+        assert runner._intentional_exit is True
+        assert runner._shutdown_event is None
+
+        time.sleep(_WATCHDOG_GRACE_S)
+        assert not handler_fired.is_set()
+
+
+class TestPreWarmedAdoption:
+    """Document the load-bearing assumption behind the is_alive() check at adoption."""
+
+    def test_is_ready_returns_true_for_dead_subprocess(self, runner):
+        """is_ready() reads a multiprocessing.Event the subprocess sets early in run().
+        After SIGKILL the Event remains set in shared memory, so is_ready() alone cannot
+        distinguish a live runner from a corpse. is_alive() must also be checked before
+        adopting a pre-warmed runner.
+        """
+        runner.start()
+        assert runner.wait_ready(timeout_s=5.0)
+
+        os.kill(runner.pid, signal.SIGKILL)
+        runner.join(timeout=5.0)
+
+        assert runner.is_ready() is True, "is_ready() should still report True even after death"
+        assert runner.is_alive() is False, "is_alive() should report False after death"


### PR DESCRIPTION
## Summary

- Add a watchdog thread to `JobRunner` that detects unexpected subprocess death (segfault, SIGKILL, OOM) via `Process.sentinel` and invokes a handler. `MultiPointWorker` wires this to `request_abort_fn()` so the acquisition stops within one timepoint check instead of silently queuing saves into a dead worker for hours.
- Catch `ProcessLookupError` in `_get_linux_pss_mb` alongside `FileNotFoundError`/`PermissionError`/`ValueError`, so reading `/proc/<zombie>/smaps_rollup` no longer produces a WARNING + traceback on every sample.

## Background

On a 48-hour run, the `JobRunner` subprocess segfaulted ~9 hours in inside `libnvidia-glcore.so` (inherited via `fork()` from the Qt/OpenGL parent — NVIDIA's userspace driver is famously not `fork()`-safe). The parent never noticed: `/proc/<pid>` was enumerated as a zombie, 465 subsequent timepoint save jobs queued into a `multiprocessing.Queue` nothing was consuming, and the UI reported normal completion. The only log signal was ~6,900 memory-profiler ESRCH tracebacks plus 466 `Backpressure reset() called with 1 jobs pending` warnings.

These fixes do not address the root cause (fork-unsafety — that is a separate follow-up to switch `JobRunner` to `spawn` after a payload-picklability audit). They turn a silent multi-hour data-loss failure into a loud, actionable error on the next timepoint check.

## Test plan

- [x] `pytest tests/control/core/test_job_runner_shutdown.py tests/control/core/test_job_runner_pending.py tests/control/core/test_backpressure.py` — 63 passed
- [x] `pytest tests/control/core/test_job_processing_downsampled.py tests/control/core/test_drain_all_issue.py` — 13 passed
- [x] `pytest tests/control/core/test_memory_profiler.py` — 56 passed (1 skipped, platform-specific)
- [x] Manual smoke test: `os.kill(runner.pid, SIGKILL)` on a live JobRunner → watchdog fires within milliseconds, handler receives `exitcode=-9` (`-SIGKILL`), ERROR log identifies PID and "died UNEXPECTEDLY"
- [x] `pre-commit run` (Black) passes
- [ ] Full acquisition smoke test on hardware (kill runner mid-run in simulation, confirm acquisition aborts cleanly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)