### PR TITLE
fix: upgrade pip and drop napari[all] to unblock CI

### DIFF
--- a/software/setup_22.04.sh
+++ b/software/setup_22.04.sh
@@ -53,7 +53,12 @@ fi
 cd "$SQUID_SOFTWARE_ROOT"
 mkdir -p "$SQUID_SOFTWARE_ROOT/cache"
 
-# install libraries 
+# Ubuntu 22.04 ships pip 22.0.2, whose resolver can't handle the napari
+# dependency graph on current PyPI (hits ResolutionTooDeep after hours of
+# backtracking). Upgrade pip before installing libraries.
+python3 -m pip install --upgrade pip
+
+# install libraries
 pip3 install qtpy pyserial pandas imageio crc==1.3.0 lxml "numpy<2" tifffile scipy pyreadline3
 pip3 install opencv-python-headless opencv-contrib-python-headless
 pip3 install napari==0.5.4 scikit-image dask_image ome_zarr aicsimageio basicpy pytest pytest-qt pytest-xvfb gitpython matplotlib pydantic_xml pyvisa hidapi filelock lxml_html_clean psutil mcp ndv

--- a/software/setup_22.04.sh
+++ b/software/setup_22.04.sh
@@ -56,7 +56,7 @@ mkdir -p "$SQUID_SOFTWARE_ROOT/cache"
 # install libraries 
 pip3 install qtpy pyserial pandas imageio crc==1.3.0 lxml "numpy<2" tifffile scipy pyreadline3
 pip3 install opencv-python-headless opencv-contrib-python-headless
-pip3 install napari[all]==0.5.4 scikit-image dask_image ome_zarr aicsimageio basicpy pytest pytest-qt pytest-xvfb gitpython matplotlib pydantic_xml pyvisa hidapi filelock lxml_html_clean psutil mcp ndv
+pip3 install napari==0.5.4 scikit-image dask_image ome_zarr aicsimageio basicpy pytest pytest-qt pytest-xvfb gitpython matplotlib pydantic_xml pyvisa hidapi filelock lxml_html_clean psutil mcp ndv
 
 # install camera drivers
 cd "$DAHENG_CAMERA_DRIVER_ROOT"

--- a/software/setup_22.04.sh
+++ b/software/setup_22.04.sh
@@ -53,9 +53,9 @@ fi
 cd "$SQUID_SOFTWARE_ROOT"
 mkdir -p "$SQUID_SOFTWARE_ROOT/cache"
 
-# Ubuntu 22.04 ships pip 22.0.2, whose resolver can't handle the napari
-# dependency graph on current PyPI (hits ResolutionTooDeep after hours of
-# backtracking). Upgrade pip before installing libraries.
+# Ubuntu 22.04 ships pip 22.0.2, whose resolver can't handle the
+# napari==0.5.4 dependency graph on current PyPI (hits ResolutionTooDeep
+# after hours of backtracking). Upgrade pip before installing libraries.
 python3 -m pip install --upgrade pip
 
 # install libraries


### PR DESCRIPTION
## Summary

CI's `install-and-test` has been failing on every PR since April 14 with `pip._vendor.resolvelib.resolvers.ResolutionTooDeep: 2000000`. Last green master run was April 3 (#524). No commits to setup files in that window — the regression is purely from new releases on PyPI dragging Ubuntu's pip 22.0.2 into unbounded backtracking.

**Root cause:** Ubuntu 22.04 ships pip 22.0.2, whose resolver cannot handle the napari dependency graph against current PyPI. Verified by reproducing the same backtracking pattern locally with `pip==22.0.2` (got stuck on `napari-svg`, `magicgui`, `npe2`, etc. — exact same packages CI bounces on). Modern pip (23+) resolves the same dependency set in seconds.

## Changes

1. **Upgrade pip** before installing libraries in `setup_22.04.sh`. This is the actual fix.
2. **Drop the `[all]` extra** from `napari==0.5.4`. The codebase only imports `napari.Viewer` and `napari.utils.colormaps`; PyQt5 is already installed via apt on line 28. The `[all]` extra additionally pulls in `napari-plugin-manager` and a redundant Qt backend, neither of which Squid uses. Reduces conflict surface as a secondary cleanup.

## Test plan

- [ ] CI `install-and-test` job completes in roughly the same ~14 min as it did pre-regression
- [ ] `python3 main_hcs.py --simulation` launches and the live / multi-channel / mosaic napari widgets work — sanity check that no plugin we silently relied on was in `[all]`

## Notes

The previous run on this branch (24947389105, with only `[all]` removed) was still hanging in setup at 60+ min when I cancelled it — that confirmed dropping `[all]` alone wasn't enough, since `magicgui` / `npe2` / `napari-svg` / `napari-console` / `napari-plugin-engine` are *core* napari deps, not extras. The pip upgrade is what actually unblocks resolution.

Long-term follow-up worth considering: commit a frozen `requirements.txt` so the project is immune to transitive PyPI releases breaking installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)