### PR TITLE
fix: align zarr writer test helper with current acquisition schema

### DIFF
--- a/software/tests/control/core/test_zarr_writer.py
+++ b/software/tests/control/core/test_zarr_writer.py
@@ -45,16 +45,13 @@ def make_test_capture_info(
         configuration=AcquisitionChannel(
             name="BF LED matrix full",
             illumination_settings=IlluminationSettings(
-                illumination_channels=["LED"],
-                intensity={"LED": 50.0},
-                z_offset_um=0.0,
+                illumination_channel="LED",
+                intensity=50.0,
             ),
-            camera_settings={
-                "main": CameraSettings(
-                    exposure_time_ms=10.0,
-                    gain_mode=1.0,
-                )
-            },
+            camera_settings=CameraSettings(
+                exposure_time_ms=10.0,
+                gain_mode=1.0,
+            ),
         ),
         save_directory="/tmp/test",
         file_id=f"test_{fov}_{z_index}",


### PR DESCRIPTION
## Summary
- `make_test_capture_info` in `tests/control/core/test_zarr_writer.py` constructed `IlluminationSettings` and `AcquisitionChannel.camera_settings` against the pre-v1.0 schema, causing 11 `ValidationError`s in `test_zarr_writer.py`.
- Updated to the current shape: `intensity` is a float, `illumination_channel` is singular, `z_offset_um` now lives on `AcquisitionChannel` (omitted, default 0.0), and `camera_settings` is a single `CameraSettings` (not `{"main": ...}`).

## Test plan
- [x] `python3 -m pytest tests/control/core/test_zarr_writer.py` — 79 passed (was 11 failed / 68 passed)
- [x] `python3 -m pytest --ignore=tests/control/test_HighContentScreeningGui.py` — 1258 passed, 5 skipped, 1 xfailed (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)