### PR TITLE
fix: align liveController.trigger_mode with hardware setup for Tucsen level trigger

### DIFF
--- a/software/control/camera_tucsen.py
+++ b/software/control/camera_tucsen.py
@@ -715,6 +715,7 @@ class TucsenCamera(AbstractCamera):
             elif acquisition_mode == CameraAcquisitionMode.HARDWARE_TRIGGER:
                 if self._model_properties.is_genicam:
                     self._set_genicam_parameter("TriggerMode", 1, TUELEM_TYPE.TU_ElemEnumeration.value)
+                    self._set_genicam_parameter("TriggerExposureType", 1, TUELEM_TYPE.TU_ElemEnumeration.value)
                 else:
                     self._trigger_attr.nTgrMode = TUCAM_CAPTURE_MODES.TUCCM_TRIGGER_STANDARD.value
             else:

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -436,8 +436,10 @@ class Microscope:
             self._log.info("Setting acquisition mode to HARDWARE_TRIGGER")
             self.camera.set_acquisition_mode(CameraAcquisitionMode.HARDWARE_TRIGGER)
             self.low_level_drivers.microcontroller.set_trigger_mode(control._def.HARDWARE_TRIGGER_MODE)
+            self.live_controller.trigger_mode = control._def.TriggerMode.HARDWARE
         else:
             self.camera.set_acquisition_mode(CameraAcquisitionMode.SOFTWARE_TRIGGER)
+            self.live_controller.trigger_mode = control._def.TriggerMode.SOFTWARE
 
         if self.addons.camera_focus:
             self.addons.camera_focus.set_pixel_format(squid.config.CameraPixelFormat.from_string("MONO8"))


### PR DESCRIPTION
## Summary

- Tucsen Aries acquisition with `HARDWARE_TRIGGER_MODE = Level` produced wrong trigger timing: a fixed-width camera trigger pulse narrower than the illumination pulse, unaffected by exposure-time changes. Live mode looked fine.
- Root cause: `Microscope._prepare_for_use()` configured the camera (`HARDWARE_TRIGGER`) and the MCU (`set_trigger_mode(LEVEL)`) when `DEFAULT_TRIGGER_MODE=Hardware`, but left `LiveController.trigger_mode` at its `SOFTWARE` default. `multi_point_worker.acquire_camera_image()` branches on `liveController.trigger_mode` and passes `illumination_time=None` down the SOFTWARE path. `Camera.send_trigger(None)` still routes to `_hw_trigger_fn(None)` for a `HARDWARE_TRIGGER`-mode camera, but `acquisition_camera_hw_trigger_fn` translates `None` to `illumination_on_time_us=0`. The firmware level-trigger pulse width is `strobe_delay + illumination_on_time`, so it collapsed to just `strobe_delay` — fixed, independent of exposure — while software took over illumination. Live worked because its `trigger_acquisition()` always passes `camera.get_exposure_time()` regardless of `liveController.trigger_mode`.
- Fix: in `microscope.py:_prepare_for_use`, after configuring the camera and MCU, explicitly align `live_controller.trigger_mode`. Direct attribute assignment is used because `LiveController.set_trigger_mode()` would call `set_exposure_time(currentConfiguration.exposure_time)` and `currentConfiguration` is still `None` this early.
- Also: set `TriggerExposureType=1` (Width) on Tucsen GenICam cameras when entering `HARDWARE_TRIGGER`, so the Aries follows the trigger pulse width instead of its programmed `ExposureTime` — required for level-trigger acquisition.

## Test plan

- [ ] On a machine configured with `DEFAULT_TRIGGER_MODE = Hardware Trigger` and `HARDWARE_TRIGGER_MODE = Level`, restart the GUI and run a single-FOV acquisition without touching the trigger-mode dropdown.
- [ ] On the scope, verify the camera-trigger pulse fully contains the illumination pulse (level-mode shape) and that pulse width tracks the channel's exposure-time setting.
- [ ] Confirm live mode still behaves correctly (no regression).
- [ ] Run `python3 -m pytest --ignore=tests/control/test_HighContentScreeningGui.py` to ensure no test regressions.
- [ ] Verify edge-trigger setups (`HARDWARE_TRIGGER_MODE = Edge`) still work — the only behavioral change there is `liveController.trigger_mode` matching the camera/MCU at startup, which is what other code paths already assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)