### PR TITLE
feat: enforce single Squid GUI instance via QLockFile

### DIFF
--- a/software/control/single_instance.py
+++ b/software/control/single_instance.py
@@ -1,0 +1,61 @@
+"""Per-user single-instance enforcement for the Squid GUI.
+
+Acquires an exclusive lock file at startup so a second launch by the same
+user on the same machine can detect and refuse to run. Backed by Qt's
+QLockFile, which embeds the holding process's PID and hostname and reclaims
+the lock automatically if the recorded PID is no longer alive (stale-lock
+recovery).
+"""
+
+import os
+
+# Pin the Qt binding before importing qtpy, matching the convention used by
+# every other Qt-using module in this codebase.
+os.environ["QT_API"] = "pyqt5"
+
+import getpass
+from typing import NamedTuple, Optional
+
+from qtpy.QtCore import QDir, QLockFile
+
+
+class LockAcquireResult(NamedTuple):
+    """Result of acquire_single_instance_lock().
+
+    `lock` is the held QLockFile on success, otherwise None. `path` is the
+    lock file path, returned in both outcomes so callers can show it in an
+    error dialog. `busy` is True when failure was specifically "another
+    instance owns the lock" — distinguishing it from permission/path errors,
+    which deserve a different message.
+    """
+
+    lock: Optional[QLockFile]
+    path: str
+    busy: bool
+
+
+def _default_lock_path() -> str:
+    return os.path.join(QDir.tempPath(), f"squid-{getpass.getuser()}.lock")
+
+
+def acquire_single_instance_lock(lock_path: Optional[str] = None) -> LockAcquireResult:
+    """Try to acquire the Squid single-instance lock.
+
+    The caller MUST keep the returned QLockFile alive for the app's lifetime;
+    QLockFile releases the lock when its destructor runs.
+
+    `lock_path` is for tests; production code calls this with no arguments.
+    """
+    if lock_path is None:
+        lock_path = _default_lock_path()
+
+    lock = QLockFile(lock_path)
+    # 0 disables time-based staleness; rely only on PID liveness, so a slow
+    # but alive instance is never reclaimed by a wall-clock heuristic.
+    lock.setStaleLockTime(0)
+
+    if lock.tryLock(0):
+        return LockAcquireResult(lock=lock, path=lock_path, busy=False)
+
+    busy = lock.error() == QLockFile.LockFailedError
+    return LockAcquireResult(lock=None, path=lock_path, busy=busy)

--- a/software/main_hcs.py
+++ b/software/main_hcs.py
@@ -21,6 +21,7 @@ from control._def import USE_TERMINAL_CONSOLE, ENABLE_MCP_SERVER_SUPPORT, CONTRO
 import control._def
 import control.utils
 import control.microscope
+from control.single_instance import acquire_single_instance_lock
 
 # Import auto-migration function
 from tools.migrate_acquisition_configs import run_auto_migration
@@ -53,6 +54,38 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
+    # Construct QApplication first so the single-instance check can show a
+    # QMessageBox before any other startup side effects (logging, migration).
+    app = QApplication(["Squid"])
+    app.setStyle("Fusion")
+    app.setWindowIcon(QIcon("icon/cephla_logo.ico"))
+
+    # Single-instance check before file logging or migration so a losing
+    # second instance does not interleave log output or race the migration.
+    lock_result = acquire_single_instance_lock()
+    if lock_result.lock is None:
+        if lock_result.busy:
+            QMessageBox.critical(
+                None,
+                "Squid Already Running",
+                "Another instance of Squid is already running on this computer.\n\n"
+                "Please close the existing Squid window before starting a new one.\n\n"
+                f"If you believe this is an error, you can delete the lock file at:\n{lock_result.path}",
+            )
+        else:
+            QMessageBox.critical(
+                None,
+                "Could Not Start Squid",
+                f"Failed to create the lock file at:\n{lock_result.path}\n\n"
+                "Check that the temp directory is writable.",
+            )
+        sys.exit(1)
+    instance_lock = lock_result.lock
+    # main_hcs.py exits via os._exit(), which skips destructors. aboutToQuit
+    # fires before app.exec_() returns, so unlock() runs and the lock file is
+    # removed on a normal exit.
+    app.aboutToQuit.connect(instance_lock.unlock)
+
     log = squid.logging.get_logger("main_hcs")
 
     if args.verbose:
@@ -68,9 +101,6 @@ if __name__ == "__main__":
     # Auto-migrate legacy acquisition configurations if present
     run_auto_migration()
 
-    app = QApplication(["Squid"])
-    app.setStyle("Fusion")
-    app.setWindowIcon(QIcon("icon/cephla_logo.ico"))
     # This allows shutdown via ctrl+C even after the gui has popped up.
     signal.signal(signal.SIGINT, signal.SIG_DFL)
 

--- a/software/tests/control/test_single_instance.py
+++ b/software/tests/control/test_single_instance.py
@@ -1,0 +1,92 @@
+"""Tests for the Squid single-instance lock helper."""
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+from control.single_instance import acquire_single_instance_lock
+
+
+def test_acquire_returns_lock_and_path(tmp_path):
+    lock_path = str(tmp_path / "squid-test.lock")
+
+    result = acquire_single_instance_lock(lock_path=lock_path)
+
+    assert result.lock is not None
+    assert result.path == lock_path
+    assert result.busy is False
+    assert Path(lock_path).exists()
+
+    result.lock.unlock()
+
+
+def test_second_acquire_in_same_process_is_busy(tmp_path):
+    lock_path = str(tmp_path / "squid-test.lock")
+
+    first = acquire_single_instance_lock(lock_path=lock_path)
+    second = acquire_single_instance_lock(lock_path=lock_path)
+
+    assert first.lock is not None
+    assert second.lock is None
+    assert second.busy is True
+    assert second.path == lock_path
+
+    first.lock.unlock()
+
+
+def test_release_allows_subsequent_acquire(tmp_path):
+    lock_path = str(tmp_path / "squid-test.lock")
+
+    first = acquire_single_instance_lock(lock_path=lock_path)
+    assert first.lock is not None
+    first.lock.unlock()
+
+    second = acquire_single_instance_lock(lock_path=lock_path)
+    assert second.lock is not None
+
+    second.lock.unlock()
+
+
+def test_stale_lock_from_dead_process_is_reclaimed(tmp_path):
+    lock_path = str(tmp_path / "squid-test.lock")
+
+    # Child acquires the lock, prints a marker, then dies without releasing.
+    # os._exit() skips Python and Qt destructors, leaving the lock file on
+    # disk holding a PID that is no longer alive.
+    child_script = textwrap.dedent(
+        f"""
+        import os, sys
+        from qtpy.QtCore import QLockFile
+
+        lock = QLockFile({lock_path!r})
+        lock.setStaleLockTime(0)
+        if not lock.tryLock(0):
+            sys.exit(2)
+        print("acquired", flush=True)
+        os._exit(0)
+        """
+    )
+
+    # Pin QT_API so qtpy in the child selects the same binding as the parent
+    # regardless of what other Qt bindings are installed in the environment.
+    child_env = {**os.environ, "QT_API": "pyqt5"}
+    result = subprocess.run(
+        [sys.executable, "-c", child_script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=child_env,
+    )
+    assert (
+        result.returncode == 0
+    ), f"child exited {result.returncode}; stdout={result.stdout!r} stderr={result.stderr!r}"
+    assert "acquired" in result.stdout
+
+    # The lock file is on disk with a dead PID. Acquiring should succeed via
+    # QLockFile's PID-based stale-lock recovery.
+    acquired = acquire_single_instance_lock(lock_path=lock_path)
+    assert acquired.lock is not None
+
+    acquired.lock.unlock()


### PR DESCRIPTION
## Summary

- Block a second `main_hcs.py` launch on the same machine with a clear warning dialog and a clean `sys.exit(1)`, before any hardware is initialized.
- Backed by `QLockFile`, which embeds the holding process's PID and hostname and auto-recovers if a previous Squid crashed without releasing the lock.
- Lock file lives at `<QDir.tempPath()>/squid-<username>.lock`. The dialog tells the user the path so they can delete it manually as a last resort.
- Behavior is identical in `--simulation` mode and against real hardware. The headless microscope API (#524) is a separate entry point and is not covered.

## Test plan

- [x] Unit tests added in `tests/control/test_single_instance.py` (4 tests, all pass):
  - acquire returns lock + path
  - second acquire in same process returns `None`
  - releasing lets a subsequent acquire succeed
  - stale lock from a dead-process PID is reclaimed (subprocess uses `os._exit(0)` to skip cleanup)
- [x] `black --config pyproject.toml --check .` clean
- [ ] Manual smoke test: run `python3 main_hcs.py --simulation` in two terminals; second process shows the "Squid Already Running" dialog and exits with status 1, with no hardware initialization in its log.
- [ ] Manual smoke test: kill the first GUI with `kill -9 <pid>`, then relaunch — should succeed via stale-lock recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)