### PR TITLE
fix: fall back to per-iris defaults when channel has no confocal_hardware_settings

### DIFF
--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -3231,23 +3231,25 @@ class SpinningDiskConfocalWidget(QWidget):
         hw_settings = getattr(configuration, "confocal_hardware_settings", None)
         self.block_iris_control_signals(True)
         try:
-            for has_iris, iris_val, slider, spinbox in (
+            for has_iris, iris_val, default, slider, spinbox in (
                 (
                     self.xlight.has_illumination_iris_diaphragm,
                     getattr(hw_settings, "illumination_iris", None) if hw_settings else None,
+                    XLIGHT_ILLUMINATION_IRIS_DEFAULT,
                     self.slider_illumination_iris,
                     self.spinbox_illumination_iris,
                 ),
                 (
                     self.xlight.has_emission_iris_diaphragm,
                     getattr(hw_settings, "emission_iris", None) if hw_settings else None,
+                    XLIGHT_EMISSION_IRIS_DEFAULT,
                     self.slider_emission_iris,
                     self.spinbox_emission_iris,
                 ),
             ):
                 if not has_iris:
                     continue
-                value = int(iris_val) if iris_val is not None else slider.minimum()
+                value = int(iris_val) if iris_val is not None else int(default)
                 self._set_iris_ui(slider, spinbox, value)
         finally:
             self.block_iris_control_signals(False)


### PR DESCRIPTION
## Summary
- `SpinningDiskConfocalWidget.update_iris_from_config` used `slider.minimum()` (i.e. `0`) as the fallback when a channel's `confocal_hardware_settings.illumination_iris` / `emission_iris` was `None`, causing the iris UI to read `0` whenever the field was unset.
- Switch the fallback to `XLIGHT_ILLUMINATION_IRIS_DEFAULT` / `XLIGHT_EMISSION_IRIS_DEFAULT` (both `100`) so the UI matches the default that `default_config_generator.build_confocal_settings_from_config` already writes for fresh profiles.

## Why this matters
The fresh-config path in `default_config_generator.py` already populates iris fields with `100` when `confocal_config.yaml` is missing. But channels whose `confocal_hardware_settings` ends up `None` (legacy/migrated configs, profiles generated with `include_confocal=False`, etc.) hit this UI fallback and showed `0` — even though hardware defaults to fully open. This made it look like the iris was always defaulting to `0` on systems without a confocal config file.

## Test plan
- [ ] Launch GUI with a profile whose channel YAMLs have `confocal_hardware_settings: null` and verify the iris sliders read `100` (not `0`) on channel selection.
- [ ] Launch GUI with a profile whose channel YAMLs have explicit `illumination_iris` / `emission_iris` values and confirm those values still display correctly (no regression).
- [ ] `black --config pyproject.toml --check .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)