### PR TITLE
fix: firmware reports failed moves (CMD_EXECUTION_ERROR); filter wheel uses absolute MOVETO

### DIFF
--- a/firmware/controller/src/commands/commands.cpp
+++ b/firmware/controller/src/commands/commands.cpp
@@ -13,6 +13,7 @@ void init_callbacks()
     cmd_map[MOVETO_Y] = &callback_move_to_y;
     cmd_map[MOVETO_Z] = &callback_move_to_z;
     cmd_map[MOVETO_W] = &callback_move_to_w;
+    cmd_map[MOVETO_W2] = &callback_move_to_w2;
     cmd_map[SET_LIM] = &callback_set_lim;
     cmd_map[SET_LIM_SWITCH_POLARITY] = &callback_set_lim_switch_polarity;
     cmd_map[SET_HOME_SAFETY_MERGIN] = &callback_set_home_safety_margin;

--- a/firmware/controller/src/commands/stage_commands.cpp
+++ b/firmware/controller/src/commands/stage_commands.cpp
@@ -1,10 +1,21 @@
 #include "stage_commands.h"
 
-// Surface a failed move so the next position-update reports CMD_EXECUTION_ERROR.
+// Surface a failed move whose callback had already claimed
+// mcu_cmd_execution_in_progress = true. Unwinds the in_progress flag
+// so the host stops waiting for a completion that won't arrive.
 static inline void mark_move_failed()
 {
     mcu_cmd_execution_status = CMD_EXECUTION_ERROR;
     mcu_cmd_execution_in_progress = false;
+}
+
+// Surface a failed move from an early-return path that never claimed
+// mcu_cmd_execution_in_progress for this command. Leaves in_progress
+// untouched so an unrelated motion already in flight on another axis
+// keeps its "still working" state.
+static inline void report_move_error()
+{
+    mcu_cmd_execution_status = CMD_EXECUTION_ERROR;
 }
 
 void callback_move_x()
@@ -66,13 +77,15 @@ static inline long decode_payload_int32()
 }
 
 // Shared dispatch for filter-wheel moves (relative and absolute, W and W2).
-// Reject moves before INITFILTERWHEEL via mark_move_failed so the host can
-// re-home instead of trusting a silent ack.
+// Reject moves before INITFILTERWHEEL so the host can re-home instead of
+// trusting a silent ack.
 static void dispatch_filterwheel_move(uint8_t axis, bool enabled, long target, int* direction, long* target_position, bool* movement_in_progress)
 {
     if (!enabled)
     {
-        mark_move_failed();
+        // Don't touch in_progress: a motion on a different axis may be
+        // active and we mustn't unwind its "still working" state.
+        report_move_error();
         return;
     }
 

--- a/firmware/controller/src/commands/stage_commands.cpp
+++ b/firmware/controller/src/commands/stage_commands.cpp
@@ -1,15 +1,32 @@
 #include "stage_commands.h"
 
+// Mark the current command as failed so the next position-update packet
+// reports CMD_EXECUTION_ERROR. Used by every move callback when
+// tmc4361A_moveTo returns non-zero or a precondition check fails.
+// Without this the firmware would silently report COMPLETED_WITHOUT_ERRORS
+// for a move that never actually executed; the W axis (no encoder, no
+// position broadcast pre-fix) was the only place this manifested as a
+// persistent off-by-one position desync.
+static inline void mark_move_failed()
+{
+    mcu_cmd_execution_status = CMD_EXECUTION_ERROR;
+    mcu_cmd_execution_in_progress = false;
+}
+
 void callback_move_x()
 {
     long relative_position = int32_t(uint32_t(buffer_rx[2]) << 24 | uint32_t(buffer_rx[3]) << 16 | uint32_t(buffer_rx[4]) << 8 | uint32_t(buffer_rx[5]));
     long current_position = tmc4361A_currentPosition(&tmc4361[x]);
     X_direction = sgn(relative_position);
     X_commanded_target_position = ( relative_position > 0 ? min(current_position + relative_position, X_POS_LIMIT) : max(current_position + relative_position, X_NEG_LIMIT) );
+    mcu_cmd_execution_in_progress = true;
     if ( tmc4361A_moveTo(&tmc4361[x], X_commanded_target_position) == 0)
     {
         X_commanded_movement_in_progress = true;
-        mcu_cmd_execution_in_progress = true;
+    }
+    else
+    {
+        mark_move_failed();
     }
 }
 
@@ -19,10 +36,14 @@ void callback_move_y()
     long current_position = tmc4361A_currentPosition(&tmc4361[y]);
     Y_direction = sgn(relative_position);
     Y_commanded_target_position = ( relative_position > 0 ? min(current_position + relative_position, Y_POS_LIMIT) : max(current_position + relative_position, Y_NEG_LIMIT) );
+    mcu_cmd_execution_in_progress = true;
     if ( tmc4361A_moveTo(&tmc4361[y], Y_commanded_target_position) == 0)
     {
         Y_commanded_movement_in_progress = true;
-        mcu_cmd_execution_in_progress = true;
+    }
+    else
+    {
+        mark_move_failed();
     }
 }
 
@@ -33,26 +54,40 @@ void callback_move_z()
     Z_direction = sgn(relative_position);
     Z_commanded_target_position = ( relative_position > 0 ? min(current_position + relative_position, Z_POS_LIMIT) : max(current_position + relative_position, Z_NEG_LIMIT) );
     focusPosition = Z_commanded_target_position;
+    mcu_cmd_execution_in_progress = true;
     if ( tmc4361A_moveTo(&tmc4361[z], Z_commanded_target_position) == 0)
     {
         Z_commanded_movement_in_progress = true;
-        mcu_cmd_execution_in_progress = true;
+    }
+    else
+    {
+        mark_move_failed();
     }
 }
 
 // Helper function for filter wheel movement (shared by W and W2)
 static void move_filterwheel(uint8_t axis, bool enabled, int* direction, long* target_position, bool* movement_in_progress)
 {
-    if (!enabled) return;
+    if (!enabled)
+    {
+        // Move arrived before INITFILTERWHEEL — surface as an execution
+        // error so the host re-homes instead of trusting a silent ack.
+        mark_move_failed();
+        return;
+    }
 
     long relative_position = int32_t(uint32_t(buffer_rx[2]) << 24 | uint32_t(buffer_rx[3]) << 16 | uint32_t(buffer_rx[4]) << 8 | uint32_t(buffer_rx[5]));
     long current_position = tmc4361A_currentPosition(&tmc4361[axis]);
     *direction = sgn(relative_position);
     *target_position = current_position + relative_position;
+    mcu_cmd_execution_in_progress = true;
     if (tmc4361A_moveTo(&tmc4361[axis], *target_position) == 0)
     {
         *movement_in_progress = true;
-        mcu_cmd_execution_in_progress = true;
+    }
+    else
+    {
+        mark_move_failed();
     }
 }
 
@@ -71,10 +106,14 @@ void callback_move_to_x()
     long absolute_position = int32_t(uint32_t(buffer_rx[2]) << 24 | uint32_t(buffer_rx[3]) << 16 | uint32_t(buffer_rx[4]) << 8 | uint32_t(buffer_rx[5]));
     X_direction = sgn(absolute_position - tmc4361A_currentPosition(&tmc4361[x]));
     X_commanded_target_position = absolute_position;
+    mcu_cmd_execution_in_progress = true;
     if (tmc4361A_moveTo(&tmc4361[x], X_commanded_target_position) == 0)
     {
         X_commanded_movement_in_progress = true;
-        mcu_cmd_execution_in_progress = true;
+    }
+    else
+    {
+        mark_move_failed();
     }
 }
 
@@ -83,10 +122,14 @@ void callback_move_to_y()
     long absolute_position = int32_t(uint32_t(buffer_rx[2]) << 24 | uint32_t(buffer_rx[3]) << 16 | uint32_t(buffer_rx[4]) << 8 | uint32_t(buffer_rx[5]));
     Y_direction = sgn(absolute_position - tmc4361A_currentPosition(&tmc4361[y]));
     Y_commanded_target_position = absolute_position;
+    mcu_cmd_execution_in_progress = true;
     if (tmc4361A_moveTo(&tmc4361[y], Y_commanded_target_position) == 0)
     {
         Y_commanded_movement_in_progress = true;
-        mcu_cmd_execution_in_progress = true;
+    }
+    else
+    {
+        mark_move_failed();
     }
 }
 
@@ -95,26 +138,49 @@ void callback_move_to_z()
     long absolute_position = int32_t(uint32_t(buffer_rx[2]) << 24 | uint32_t(buffer_rx[3]) << 16 | uint32_t(buffer_rx[4]) << 8 | uint32_t(buffer_rx[5]));
     Z_direction = sgn(absolute_position - tmc4361A_currentPosition(&tmc4361[z]));
     Z_commanded_target_position = absolute_position;
+    mcu_cmd_execution_in_progress = true;
     if (tmc4361A_moveTo(&tmc4361[z], Z_commanded_target_position) == 0)
     {
         focusPosition = absolute_position;
         Z_commanded_movement_in_progress = true;
-        mcu_cmd_execution_in_progress = true;
+    }
+    else
+    {
+        mark_move_failed();
+    }
+}
+
+// Helper function for absolute filter wheel move (shared by W and W2)
+static void move_to_filterwheel(uint8_t axis, bool enabled, int* direction, long* target_position, bool* movement_in_progress)
+{
+    if (!enabled)
+    {
+        mark_move_failed();
+        return;
+    }
+
+    long absolute_position = int32_t(uint32_t(buffer_rx[2]) << 24 | uint32_t(buffer_rx[3]) << 16 | uint32_t(buffer_rx[4]) << 8 | uint32_t(buffer_rx[5]));
+    *direction = sgn(absolute_position - tmc4361A_currentPosition(&tmc4361[axis]));
+    *target_position = absolute_position;
+    mcu_cmd_execution_in_progress = true;
+    if (tmc4361A_moveTo(&tmc4361[axis], *target_position) == 0)
+    {
+        *movement_in_progress = true;
+    }
+    else
+    {
+        mark_move_failed();
     }
 }
 
 void callback_move_to_w()
 {
-    if (enable_filterwheel == true) {
-        long absolute_position = int32_t(uint32_t(buffer_rx[2]) << 24 | uint32_t(buffer_rx[3]) << 16 | uint32_t(buffer_rx[4]) << 8 | uint32_t(buffer_rx[5]));
-        W_direction = sgn(absolute_position - tmc4361A_currentPosition(&tmc4361[w]));
-        W_commanded_target_position = absolute_position;
-        if (tmc4361A_moveTo(&tmc4361[w], W_commanded_target_position) == 0)
-        {
-        W_commanded_movement_in_progress = true;
-        mcu_cmd_execution_in_progress = true;
-        }
-    }
+    move_to_filterwheel(w, enable_filterwheel, &W_direction, &W_commanded_target_position, &W_commanded_movement_in_progress);
+}
+
+void callback_move_to_w2()
+{
+    move_to_filterwheel(w2, enable_filterwheel_w2, &W2_direction, &W2_commanded_target_position, &W2_commanded_movement_in_progress);
 }
 
 void callback_set_lim()

--- a/firmware/controller/src/commands/stage_commands.cpp
+++ b/firmware/controller/src/commands/stage_commands.cpp
@@ -1,12 +1,6 @@
 #include "stage_commands.h"
 
-// Mark the current command as failed so the next position-update packet
-// reports CMD_EXECUTION_ERROR. Used by every move callback when
-// tmc4361A_moveTo returns non-zero or a precondition check fails.
-// Without this the firmware would silently report COMPLETED_WITHOUT_ERRORS
-// for a move that never actually executed; the W axis (no encoder, no
-// position broadcast pre-fix) was the only place this manifested as a
-// persistent off-by-one position desync.
+// Surface a failed move so the next position-update reports CMD_EXECUTION_ERROR.
 static inline void mark_move_failed()
 {
     mcu_cmd_execution_status = CMD_EXECUTION_ERROR;
@@ -65,23 +59,27 @@ void callback_move_z()
     }
 }
 
-// Helper function for filter wheel movement (shared by W and W2)
-static void move_filterwheel(uint8_t axis, bool enabled, int* direction, long* target_position, bool* movement_in_progress)
+// Decode a 32-bit signed payload from buffer_rx[2..5] (big-endian).
+static inline long decode_payload_int32()
+{
+    return int32_t(uint32_t(buffer_rx[2]) << 24 | uint32_t(buffer_rx[3]) << 16 | uint32_t(buffer_rx[4]) << 8 | uint32_t(buffer_rx[5]));
+}
+
+// Shared dispatch for filter-wheel moves (relative and absolute, W and W2).
+// Reject moves before INITFILTERWHEEL via mark_move_failed so the host can
+// re-home instead of trusting a silent ack.
+static void dispatch_filterwheel_move(uint8_t axis, bool enabled, long target, int* direction, long* target_position, bool* movement_in_progress)
 {
     if (!enabled)
     {
-        // Move arrived before INITFILTERWHEEL — surface as an execution
-        // error so the host re-homes instead of trusting a silent ack.
         mark_move_failed();
         return;
     }
 
-    long relative_position = int32_t(uint32_t(buffer_rx[2]) << 24 | uint32_t(buffer_rx[3]) << 16 | uint32_t(buffer_rx[4]) << 8 | uint32_t(buffer_rx[5]));
-    long current_position = tmc4361A_currentPosition(&tmc4361[axis]);
-    *direction = sgn(relative_position);
-    *target_position = current_position + relative_position;
+    *direction = sgn(target - tmc4361A_currentPosition(&tmc4361[axis]));
+    *target_position = target;
     mcu_cmd_execution_in_progress = true;
-    if (tmc4361A_moveTo(&tmc4361[axis], *target_position) == 0)
+    if (tmc4361A_moveTo(&tmc4361[axis], target) == 0)
     {
         *movement_in_progress = true;
     }
@@ -93,12 +91,14 @@ static void move_filterwheel(uint8_t axis, bool enabled, int* direction, long* t
 
 void callback_move_w()
 {
-    move_filterwheel(w, enable_filterwheel, &W_direction, &W_commanded_target_position, &W_commanded_movement_in_progress);
+    long target = tmc4361A_currentPosition(&tmc4361[w]) + decode_payload_int32();
+    dispatch_filterwheel_move(w, enable_filterwheel, target, &W_direction, &W_commanded_target_position, &W_commanded_movement_in_progress);
 }
 
 void callback_move_w2()
 {
-    move_filterwheel(w2, enable_filterwheel_w2, &W2_direction, &W2_commanded_target_position, &W2_commanded_movement_in_progress);
+    long target = tmc4361A_currentPosition(&tmc4361[w2]) + decode_payload_int32();
+    dispatch_filterwheel_move(w2, enable_filterwheel_w2, target, &W2_direction, &W2_commanded_target_position, &W2_commanded_movement_in_progress);
 }
 
 void callback_move_to_x()
@@ -150,37 +150,14 @@ void callback_move_to_z()
     }
 }
 
-// Helper function for absolute filter wheel move (shared by W and W2)
-static void move_to_filterwheel(uint8_t axis, bool enabled, int* direction, long* target_position, bool* movement_in_progress)
-{
-    if (!enabled)
-    {
-        mark_move_failed();
-        return;
-    }
-
-    long absolute_position = int32_t(uint32_t(buffer_rx[2]) << 24 | uint32_t(buffer_rx[3]) << 16 | uint32_t(buffer_rx[4]) << 8 | uint32_t(buffer_rx[5]));
-    *direction = sgn(absolute_position - tmc4361A_currentPosition(&tmc4361[axis]));
-    *target_position = absolute_position;
-    mcu_cmd_execution_in_progress = true;
-    if (tmc4361A_moveTo(&tmc4361[axis], *target_position) == 0)
-    {
-        *movement_in_progress = true;
-    }
-    else
-    {
-        mark_move_failed();
-    }
-}
-
 void callback_move_to_w()
 {
-    move_to_filterwheel(w, enable_filterwheel, &W_direction, &W_commanded_target_position, &W_commanded_movement_in_progress);
+    dispatch_filterwheel_move(w, enable_filterwheel, decode_payload_int32(), &W_direction, &W_commanded_target_position, &W_commanded_movement_in_progress);
 }
 
 void callback_move_to_w2()
 {
-    move_to_filterwheel(w2, enable_filterwheel_w2, &W2_direction, &W2_commanded_target_position, &W2_commanded_movement_in_progress);
+    dispatch_filterwheel_move(w2, enable_filterwheel_w2, decode_payload_int32(), &W2_direction, &W2_commanded_target_position, &W2_commanded_movement_in_progress);
 }
 
 void callback_set_lim()

--- a/firmware/controller/src/commands/stage_commands.h
+++ b/firmware/controller/src/commands/stage_commands.h
@@ -13,6 +13,7 @@ void callback_move_to_x();
 void callback_move_to_y();
 void callback_move_to_z();
 void callback_move_to_w();
+void callback_move_to_w2();
 void callback_set_lim();
 void callback_set_lim_switch_polarity();
 void callback_set_home_safety_margin();

--- a/firmware/controller/src/constants.h
+++ b/firmware/controller/src/constants.h
@@ -9,8 +9,9 @@
 // Version is sent in response byte 22 as nibble-encoded: high nibble = major, low nibble = minor
 // Version 1.0 = first version with multi-port illumination support
 // Version 1.1 = serial watchdog for illumination auto-shutoff
+// Version 1.2 = CMD_EXECUTION_ERROR reported on failed moves + MOVETO_W2 command
 #define FIRMWARE_VERSION_MAJOR 1
-#define FIRMWARE_VERSION_MINOR 1
+#define FIRMWARE_VERSION_MINOR 2
 
 #include "def/def_v1.h"
 

--- a/firmware/controller/src/constants_protocol.h
+++ b/firmware/controller/src/constants_protocol.h
@@ -74,6 +74,7 @@ static const int TURN_OFF_ALL_PORTS = 39;      // Turn off all illumination port
 static const int SET_WATCHDOG_TIMEOUT = 40;   // Set serial watchdog timeout and enable
 static const int SET_PIN_LEVEL = 41;
 static const int HEARTBEAT = 42;              // No-op keepalive for watchdog
+static const int MOVETO_W2 = 43;              // Absolute move on the W2 filter wheel
 static const int INITFILTERWHEEL_W2 = 252;
 static const int INITFILTERWHEEL = 253;
 static const int INITIALIZE = 254;

--- a/firmware/controller/src/globals.cpp
+++ b/firmware/controller/src/globals.cpp
@@ -33,10 +33,6 @@ uint16_t home_safety_margin[TOTAL_AXES] = {4, 4, 4, 4, 4};
 volatile int buffer_rx_ptr = 0;
 byte cmd_id = 0;
 bool mcu_cmd_execution_in_progress = false;
-// Status reported in the next position-update packet whenever
-// mcu_cmd_execution_in_progress is false. Reset to COMPLETED_WITHOUT_ERRORS
-// at the start of every received command; overwritten with
-// CMD_EXECUTION_ERROR by a callback that detects a failure.
 byte mcu_cmd_execution_status = COMPLETED_WITHOUT_ERRORS;
 bool checksum_error = false;
 

--- a/firmware/controller/src/globals.cpp
+++ b/firmware/controller/src/globals.cpp
@@ -33,6 +33,11 @@ uint16_t home_safety_margin[TOTAL_AXES] = {4, 4, 4, 4, 4};
 volatile int buffer_rx_ptr = 0;
 byte cmd_id = 0;
 bool mcu_cmd_execution_in_progress = false;
+// Status reported in the next position-update packet whenever
+// mcu_cmd_execution_in_progress is false. Reset to COMPLETED_WITHOUT_ERRORS
+// at the start of every received command; overwritten with
+// CMD_EXECUTION_ERROR by a callback that detects a failure.
+byte mcu_cmd_execution_status = COMPLETED_WITHOUT_ERRORS;
 bool checksum_error = false;
 
 // limit switch

--- a/firmware/controller/src/globals.h
+++ b/firmware/controller/src/globals.h
@@ -37,6 +37,7 @@ extern uint16_t home_safety_margin[TOTAL_AXES];
 extern volatile int buffer_rx_ptr;
 extern byte cmd_id;
 extern bool mcu_cmd_execution_in_progress;
+extern byte mcu_cmd_execution_status;
 extern bool checksum_error;
 
 // limit switch

--- a/firmware/controller/src/operations.cpp
+++ b/firmware/controller/src/operations.cpp
@@ -370,11 +370,7 @@ void finalize_homing_w()
   {
     if (enable_filterwheel == true) {
       // Anchor the driver coordinate to 0 at the home reference so the
-      // host can target absolute slot positions as
-      // `slot_index * usteps_per_slot + offset`. Without this the
-      // post-home X_ACTUAL is whatever value the limit switch latched
-      // (hardware-dependent), and absolute MOVETO_W targets would be
-      // off by that latch value.
+      // host can target absolute slot positions via MOVETO_W.
       tmc4361A_setCurrentPosition(&tmc4361[w], 0);
       tmc4361A_write_encoder(&tmc4361[w], 0);
       if (stage_PID_enabled[w])

--- a/firmware/controller/src/operations.cpp
+++ b/firmware/controller/src/operations.cpp
@@ -369,6 +369,13 @@ void finalize_homing_w()
   if (is_homing_W && home_W_found && ( tmc4361A_currentPosition(&tmc4361[w]) == tmc4361A_targetPosition(&tmc4361[w]) || us_since_w_home_found > 500 * 1000 ) )
   {
     if (enable_filterwheel == true) {
+      // Anchor the driver coordinate to 0 at the home reference so the
+      // host can target absolute slot positions as
+      // `slot_index * usteps_per_slot + offset`. Without this the
+      // post-home X_ACTUAL is whatever value the limit switch latched
+      // (hardware-dependent), and absolute MOVETO_W targets would be
+      // off by that latch value.
+      tmc4361A_setCurrentPosition(&tmc4361[w], 0);
       tmc4361A_write_encoder(&tmc4361[w], 0);
       if (stage_PID_enabled[w])
         tmc4361A_set_PID(&tmc4361[w], PID_BPG0);
@@ -386,6 +393,7 @@ void finalize_homing_w2()
   if (is_homing_W2 && home_W2_found && ( tmc4361A_currentPosition(&tmc4361[w2]) == tmc4361A_targetPosition(&tmc4361[w2]) || us_since_w2_home_found > 500 * 1000 ) )
   {
     if (enable_filterwheel_w2 == true) {
+      tmc4361A_setCurrentPosition(&tmc4361[w2], 0);
       tmc4361A_write_encoder(&tmc4361[w2], 0);
       if (stage_PID_enabled[w2])
         tmc4361A_set_PID(&tmc4361[w2], PID_BPG0);

--- a/firmware/controller/src/serial_communication.cpp
+++ b/firmware/controller/src/serial_communication.cpp
@@ -26,6 +26,13 @@ void process_serial_message()
       // Reset watchdog timer on every valid serial message
       last_serial_message_time = millis();
 
+      // Reset execution status for this new command; callbacks set it to
+      // CMD_EXECUTION_ERROR if they detect a failure (e.g. tmc4361A_moveTo
+      // returning non-zero, or a filter-wheel move arriving before
+      // INITFILTERWHEEL) so the host can distinguish a real success from
+      // a silently dropped move.
+      mcu_cmd_execution_status = COMPLETED_WITHOUT_ERRORS;
+
       CommandCallback p_callback = cmd_map[buffer_rx[1]];
       if (!p_callback) {
         callback_default();
@@ -46,8 +53,10 @@ void send_position_update()
     buffer_tx[0] = cmd_id;
     if (checksum_error)
       buffer_tx[1] = CMD_CHECKSUM_ERROR; // cmd_execution_status
+    else if (mcu_cmd_execution_in_progress)
+      buffer_tx[1] = IN_PROGRESS;
     else
-      buffer_tx[1] = mcu_cmd_execution_in_progress ? IN_PROGRESS : COMPLETED_WITHOUT_ERRORS; // cmd_execution_status
+      buffer_tx[1] = mcu_cmd_execution_status; // COMPLETED_WITHOUT_ERRORS or CMD_EXECUTION_ERROR
 
     uint32_t X_pos_int32t = uint32_t( X_use_encoder ? X_pos : int32_t(tmc4361A_currentPosition(&tmc4361[x])) );
     buffer_tx[2] = byte(X_pos_int32t >> 24);

--- a/firmware/controller/src/serial_communication.cpp
+++ b/firmware/controller/src/serial_communication.cpp
@@ -26,11 +26,8 @@ void process_serial_message()
       // Reset watchdog timer on every valid serial message
       last_serial_message_time = millis();
 
-      // Reset execution status for this new command; callbacks set it to
-      // CMD_EXECUTION_ERROR if they detect a failure (e.g. tmc4361A_moveTo
-      // returning non-zero, or a filter-wheel move arriving before
-      // INITFILTERWHEEL) so the host can distinguish a real success from
-      // a silently dropped move.
+      // Default the status to success; callbacks call mark_move_failed()
+      // on the failure path to override it before the next status broadcast.
       mcu_cmd_execution_status = COMPLETED_WITHOUT_ERRORS;
 
       CommandCallback p_callback = cmd_map[buffer_rx[1]];

--- a/firmware/controller/src/serial_communication.cpp
+++ b/firmware/controller/src/serial_communication.cpp
@@ -28,7 +28,14 @@ void process_serial_message()
 
       // Default the status to success; callbacks call mark_move_failed()
       // on the failure path to override it before the next status broadcast.
-      mcu_cmd_execution_status = COMPLETED_WITHOUT_ERRORS;
+      // Skip for HEARTBEAT — the keepalive has no result to report, and
+      // resetting here would clobber a pending CMD_EXECUTION_ERROR from a
+      // previous command if the broadcast hasn't fired yet. Any future
+      // background-sender command should be added to this skip list.
+      if (buffer_rx[1] != HEARTBEAT)
+      {
+          mcu_cmd_execution_status = COMPLETED_WITHOUT_ERRORS;
+      }
 
       CommandCallback p_callback = cmd_map[buffer_rx[1]];
       if (!p_callback) {

--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -203,6 +203,7 @@ class CMD_SET:
     SET_WATCHDOG_TIMEOUT = 40  # Set serial watchdog timeout and enable
     SET_PIN_LEVEL = 41
     HEARTBEAT = 42  # No-op keepalive for watchdog
+    MOVETO_W2 = 43  # Absolute move on the W2 filter wheel
     INITFILTERWHEEL_W2 = 252
     INITFILTERWHEEL = 253
     INITIALIZE = 254

--- a/software/control/firmware_sim_serial.py
+++ b/software/control/firmware_sim_serial.py
@@ -80,11 +80,13 @@ class FirmwareConstants:
             "MOVE_Z",
             "MOVE_THETA",
             "MOVE_W",
+            "MOVE_W2",
             "HOME_OR_ZERO",
             "MOVETO_X",
             "MOVETO_Y",
             "MOVETO_Z",
             "MOVETO_W",
+            "MOVETO_W2",
             "SET_LIM",
             "TURN_ON_ILLUMINATION",
             "TURN_OFF_ILLUMINATION",
@@ -360,6 +362,8 @@ class FirmwareSimSerial(AbstractCephlaMicroSerial):
             self.theta += get_position()
         elif cmd_code == self.fw.get("MOVE_W"):
             self.w += get_position()
+        elif cmd_code == self.fw.get("MOVE_W2"):
+            self.w += get_position()
         elif cmd_code == self.fw.get("MOVETO_X"):
             self.x = get_position()
         elif cmd_code == self.fw.get("MOVETO_Y"):
@@ -367,6 +371,8 @@ class FirmwareSimSerial(AbstractCephlaMicroSerial):
         elif cmd_code == self.fw.get("MOVETO_Z"):
             self.z = get_position()
         elif cmd_code == self.fw.get("MOVETO_W"):
+            self.w = get_position()
+        elif cmd_code == self.fw.get("MOVETO_W2"):
             self.w = get_position()
         elif cmd_code == self.fw.get("HOME_OR_ZERO"):
             axis = cmd[2]

--- a/software/control/firmware_sim_serial.py
+++ b/software/control/firmware_sim_serial.py
@@ -164,6 +164,7 @@ class FirmwareSimSerial(AbstractCephlaMicroSerial):
         self.z = 0
         self.theta = 0
         self.w = 0
+        self.w2 = 0
 
         # Button/switch state
         self.joystick_button = False
@@ -363,7 +364,7 @@ class FirmwareSimSerial(AbstractCephlaMicroSerial):
         elif cmd_code == self.fw.get("MOVE_W"):
             self.w += get_position()
         elif cmd_code == self.fw.get("MOVE_W2"):
-            self.w += get_position()
+            self.w2 += get_position()
         elif cmd_code == self.fw.get("MOVETO_X"):
             self.x = get_position()
         elif cmd_code == self.fw.get("MOVETO_Y"):
@@ -373,7 +374,7 @@ class FirmwareSimSerial(AbstractCephlaMicroSerial):
         elif cmd_code == self.fw.get("MOVETO_W"):
             self.w = get_position()
         elif cmd_code == self.fw.get("MOVETO_W2"):
-            self.w = get_position()
+            self.w2 = get_position()
         elif cmd_code == self.fw.get("HOME_OR_ZERO"):
             axis = cmd[2]
             # home_type at cmd[3] indicates HOME_NEGATIVE, HOME_POSITIVE, or ZERO
@@ -392,6 +393,8 @@ class FirmwareSimSerial(AbstractCephlaMicroSerial):
                 self.y = 0
             elif axis == self.fw.get("AXIS_W", 5):
                 self.w = 0
+            elif axis == self.fw.get("AXIS_W2", 6):
+                self.w2 = 0
         elif cmd_code == self.fw.get("RESET"):
             # Reset clears positions
             self.x = 0
@@ -399,6 +402,7 @@ class FirmwareSimSerial(AbstractCephlaMicroSerial):
             self.z = 0
             self.theta = 0
             self.w = 0
+            self.w2 = 0
 
         # Build and queue response
         status = self.fw.get("COMPLETED_WITHOUT_ERRORS", 0)

--- a/software/control/microcontroller.py
+++ b/software/control/microcontroller.py
@@ -1074,41 +1074,30 @@ class Microcontroller:
     def move_x_usteps(self, usteps):
         self._move_axis_usteps(usteps, CMD_SET.MOVE_X)
 
-    def move_x_to_usteps(self, usteps):
+    def _move_axis_to_usteps(self, usteps, axis_command_code):
         payload = self._int_to_payload(usteps, 4)
         cmd = bytearray(self.tx_buffer_length)
-        cmd[1] = CMD_SET.MOVETO_X
+        cmd[1] = axis_command_code
         cmd[2] = payload >> 24
         cmd[3] = (payload >> 16) & 0xFF
         cmd[4] = (payload >> 8) & 0xFF
         cmd[5] = payload & 0xFF
         self.send_command(cmd)
+
+    def move_x_to_usteps(self, usteps):
+        self._move_axis_to_usteps(usteps, CMD_SET.MOVETO_X)
 
     def move_y_usteps(self, usteps):
         self._move_axis_usteps(usteps, CMD_SET.MOVE_Y)
 
     def move_y_to_usteps(self, usteps):
-        payload = self._int_to_payload(usteps, 4)
-        cmd = bytearray(self.tx_buffer_length)
-        cmd[1] = CMD_SET.MOVETO_Y
-        cmd[2] = payload >> 24
-        cmd[3] = (payload >> 16) & 0xFF
-        cmd[4] = (payload >> 8) & 0xFF
-        cmd[5] = payload & 0xFF
-        self.send_command(cmd)
+        self._move_axis_to_usteps(usteps, CMD_SET.MOVETO_Y)
 
     def move_z_usteps(self, usteps):
         self._move_axis_usteps(usteps, CMD_SET.MOVE_Z)
 
     def move_z_to_usteps(self, usteps):
-        payload = self._int_to_payload(usteps, 4)
-        cmd = bytearray(self.tx_buffer_length)
-        cmd[1] = CMD_SET.MOVETO_Z
-        cmd[2] = payload >> 24
-        cmd[3] = (payload >> 16) & 0xFF
-        cmd[4] = (payload >> 8) & 0xFF
-        cmd[5] = payload & 0xFF
-        self.send_command(cmd)
+        self._move_axis_to_usteps(usteps, CMD_SET.MOVETO_Z)
 
     def move_theta_usteps(self, usteps):
         self._move_axis_usteps(usteps, CMD_SET.MOVE_THETA)
@@ -1120,24 +1109,10 @@ class Microcontroller:
         self._move_axis_usteps(usteps, CMD_SET.MOVE_W2)
 
     def move_w_to_usteps(self, usteps):
-        payload = self._int_to_payload(usteps, 4)
-        cmd = bytearray(self.tx_buffer_length)
-        cmd[1] = CMD_SET.MOVETO_W
-        cmd[2] = payload >> 24
-        cmd[3] = (payload >> 16) & 0xFF
-        cmd[4] = (payload >> 8) & 0xFF
-        cmd[5] = payload & 0xFF
-        self.send_command(cmd)
+        self._move_axis_to_usteps(usteps, CMD_SET.MOVETO_W)
 
     def move_w2_to_usteps(self, usteps):
-        payload = self._int_to_payload(usteps, 4)
-        cmd = bytearray(self.tx_buffer_length)
-        cmd[1] = CMD_SET.MOVETO_W2
-        cmd[2] = payload >> 24
-        cmd[3] = (payload >> 16) & 0xFF
-        cmd[4] = (payload >> 8) & 0xFF
-        cmd[5] = payload & 0xFF
-        self.send_command(cmd)
+        self._move_axis_to_usteps(usteps, CMD_SET.MOVETO_W2)
 
     def set_off_set_velocity_x(self, off_set_velocity):
         # off_set_velocity is in mm/s
@@ -1633,14 +1608,8 @@ class Microcontroller:
                     and self._cmd_id_mcu == self._cmd_id
                     and self._cmd_execution_status == CMD_EXECUTION_STATUS.CMD_EXECUTION_ERROR
                 ):
-                    # Firmware reported it couldn't execute this command (e.g.
-                    # tmc4361A_moveTo returned non-zero, or a filter-wheel move
-                    # arrived before INITFILTERWHEEL). Fail fast so callers
-                    # don't pay the full 5 s `wait_till_operation_is_completed`
-                    # timeout waiting for a completion that will never arrive.
-                    # Marked recoverable=True so the abort logs at WARNING —
-                    # callers like SquidFilterWheel handle this via a software
-                    # resend, falling back to re-home + retry.
+                    # Fail fast so callers don't wait the full ack timeout
+                    # for a completion the firmware says will never arrive.
                     self.abort_current_command(
                         reason="firmware reported CMD_EXECUTION_ERROR",
                         recoverable=True,

--- a/software/control/microcontroller.py
+++ b/software/control/microcontroller.py
@@ -46,6 +46,7 @@ _CMD_NAMES = {
     CMD_SET.SET_DAC80508_REFDIV_GAIN: "SET_DAC80508_REFDIV_GAIN",
     CMD_SET.SET_ILLUMINATION_INTENSITY_FACTOR: "SET_ILLUMINATION_INTENSITY_FACTOR",
     CMD_SET.MOVETO_W: "MOVETO_W",
+    CMD_SET.MOVETO_W2: "MOVETO_W2",
     CMD_SET.SET_LIM_SWITCH_POLARITY: "SET_LIM_SWITCH_POLARITY",
     CMD_SET.CONFIGURE_STEPPER_DRIVER: "CONFIGURE_STEPPER_DRIVER",
     CMD_SET.SET_MAX_VELOCITY_ACCELERATION: "SET_MAX_VELOCITY_ACCELERATION",
@@ -185,12 +186,13 @@ class SimSerial(AbstractCephlaMicroSerial):
     # Simulated firmware version
     # v1.0: multi-port illumination support
     # v1.1: serial watchdog for illumination auto-shutoff
+    # v1.2: CMD_EXECUTION_ERROR reported on failed moves + MOVETO_W2 command
     FIRMWARE_VERSION_MAJOR = 1
-    FIRMWARE_VERSION_MINOR = 1
+    FIRMWARE_VERSION_MINOR = 2
 
     @staticmethod
     def response_bytes_for(
-        command_id, execution_status, x, y, z, theta, joystick_button, switch, firmware_version=(1, 1)
+        command_id, execution_status, x, y, z, theta, joystick_button, switch, firmware_version=(1, 2)
     ) -> bytes:
         """
         - byte 0: command ID (1 byte)
@@ -1117,6 +1119,26 @@ class Microcontroller:
     def move_w2_usteps(self, usteps):
         self._move_axis_usteps(usteps, CMD_SET.MOVE_W2)
 
+    def move_w_to_usteps(self, usteps):
+        payload = self._int_to_payload(usteps, 4)
+        cmd = bytearray(self.tx_buffer_length)
+        cmd[1] = CMD_SET.MOVETO_W
+        cmd[2] = payload >> 24
+        cmd[3] = (payload >> 16) & 0xFF
+        cmd[4] = (payload >> 8) & 0xFF
+        cmd[5] = payload & 0xFF
+        self.send_command(cmd)
+
+    def move_w2_to_usteps(self, usteps):
+        payload = self._int_to_payload(usteps, 4)
+        cmd = bytearray(self.tx_buffer_length)
+        cmd[1] = CMD_SET.MOVETO_W2
+        cmd[2] = payload >> 24
+        cmd[3] = (payload >> 16) & 0xFF
+        cmd[4] = (payload >> 8) & 0xFF
+        cmd[5] = payload & 0xFF
+        self.send_command(cmd)
+
     def set_off_set_velocity_x(self, off_set_velocity):
         # off_set_velocity is in mm/s
         cmd = bytearray(self.tx_buffer_length)
@@ -1460,10 +1482,22 @@ class Microcontroller:
 
             self._warn_if_reads_stale()
 
-    def abort_current_command(self, reason):
+    def abort_current_command(self, reason, recoverable: bool = False):
+        """Mark the current MCU command as aborted.
+
+        Args:
+            reason: Human-readable reason; surfaced in the CommandAborted exception.
+            recoverable: If True, log at WARNING — caller will retry or handle the
+                failure (e.g. a filter wheel re-home + retry on CMD_EXECUTION_ERROR).
+                If False (default), log at ERROR (operator attention warranted).
+        """
         cmd_type = self.last_command[1] if self.last_command is not None else -1
         cmd_name = _CMD_NAMES.get(cmd_type, f"UNKNOWN({cmd_type})")
-        self.log.error(f"[MCU] !!! Command {self._cmd_id} ({cmd_name}) ABORTED: {reason}")
+        msg = f"[MCU] Command {self._cmd_id} ({cmd_name}) aborted: {reason}"
+        if recoverable:
+            self.log.warning(msg)
+        else:
+            self.log.error(msg)
         self.last_command_aborted_error = CommandAborted(reason=reason, command_id=self._cmd_id)
         self.mcu_cmd_execution_in_progress = False
 
@@ -1594,6 +1628,23 @@ class Microcontroller:
                     else:
                         self.log.error("[MCU] !!! checksum error, resending command")
                         self.resend_last_command()
+                elif (
+                    self.mcu_cmd_execution_in_progress
+                    and self._cmd_id_mcu == self._cmd_id
+                    and self._cmd_execution_status == CMD_EXECUTION_STATUS.CMD_EXECUTION_ERROR
+                ):
+                    # Firmware reported it couldn't execute this command (e.g.
+                    # tmc4361A_moveTo returned non-zero, or a filter-wheel move
+                    # arrived before INITFILTERWHEEL). Fail fast so callers
+                    # don't pay the full 5 s `wait_till_operation_is_completed`
+                    # timeout waiting for a completion that will never arrive.
+                    # Marked recoverable=True so the abort logs at WARNING —
+                    # callers like SquidFilterWheel handle this via a software
+                    # resend, falling back to re-home + retry.
+                    self.abort_current_command(
+                        reason="firmware reported CMD_EXECUTION_ERROR",
+                        recoverable=True,
+                    )
                 elif (
                     self.mcu_cmd_execution_in_progress
                     and self._cmd_id_mcu != self._cmd_id

--- a/software/squid/filter_wheel_controller/cephla.py
+++ b/software/squid/filter_wheel_controller/cephla.py
@@ -70,10 +70,14 @@ class SquidFilterWheel(AbstractFilterWheelController):
     # The protocol_axis_to_internal() function in firmware handles this conversion.
     _MOTOR_SLOT_TO_AXIS = {3: AXIS.W, 4: AXIS.W2}
 
-    # Errors that the re-home + retry recovery path can recover from.
-    # CommandAborted is raised when firmware reports CMD_EXECUTION_ERROR
-    # (the motor confirmed it didn't move); TimeoutError is raised when
-    # the ack never arrives within the wait window (motor state uncertain).
+    # Map motor_slot_index to the Microcontroller method names that drive
+    # that axis. Keeps the slot→method dispatch in one place instead of
+    # branching `if motor_slot == 3 / == 4` at every call site.
+    _MOTOR_SLOT_MCU_METHODS = {
+        3: {"home": "home_w", "move_to_usteps": "move_w_to_usteps"},
+        4: {"home": "home_w2", "move_to_usteps": "move_w2_to_usteps"},
+    }
+
     _RECOVERABLE_MOVE_ERRORS = (TimeoutError, CommandAborted)
 
     def _configure_wheel(self, wheel_id: int, config: SquidFilterWheelConfig):
@@ -111,25 +115,24 @@ class SquidFilterWheel(AbstractFilterWheelController):
     def _target_pos_to_usteps(config: SquidFilterWheelConfig, target_pos: int) -> int:
         """Absolute target microstep address for a given slot index.
 
-        After homing, the firmware re-anchors the tmc4361 X_ACTUAL counter
-        to 0 (operations.cpp:finalize_homing_w), so slot 0 sits at
-        `_delta_to_usteps(config.offset)` and each subsequent slot is one
-        step_size further along.
+        Assumes the firmware anchors X_ACTUAL to 0 at the home reference
+        (see finalize_homing_w / finalize_homing_w2 in firmware).
         """
         step_size_mm = SCREW_PITCH_W_MM / (config.max_index - config.min_index + 1)
         target_mm_from_home = config.offset + (target_pos - config.min_index) * step_size_mm
         return SquidFilterWheel._delta_to_usteps(target_mm_from_home)
 
+    def _mcu_method(self, wheel_id: int, action: str):
+        """Resolve the Microcontroller method for `action` on this wheel's axis."""
+        motor_slot = self._configs[wheel_id].motor_slot_index
+        methods = self._MOTOR_SLOT_MCU_METHODS.get(motor_slot)
+        if methods is None:
+            raise ValueError(f"Unsupported motor_slot_index: {motor_slot}. Expected 3 (W) or 4 (W2).")
+        return getattr(self.microcontroller, methods[action])
+
     def _move_to_usteps(self, wheel_id: int, usteps: int):
         """Dispatch an absolute MOVETO_W / MOVETO_W2 by motor_slot_index."""
-        config = self._configs[wheel_id]
-        motor_slot = config.motor_slot_index
-        if motor_slot == 3:
-            self.microcontroller.move_w_to_usteps(usteps)
-        elif motor_slot == 4:
-            self.microcontroller.move_w2_to_usteps(usteps)
-        else:
-            raise ValueError(f"Unsupported motor_slot_index: {motor_slot}")
+        self._mcu_method(wheel_id, "move_to_usteps")(usteps)
 
     def _move_to_position(self, wheel_id: int, target_pos: int):
         """Move wheel to target position using absolute MOVETO; recover on failure.
@@ -177,8 +180,6 @@ class SquidFilterWheel(AbstractFilterWheelController):
             _log.warning(f"Filter wheel {wheel_id} move uncertain ({e}); re-homing to re-sync...")
 
         self._home_wheel(wheel_id)
-        # _home_wheel re-anchored the firmware coordinate to 0; recompute
-        # the absolute target against the (unchanged) slot index.
         target_usteps = self._target_pos_to_usteps(config, target_pos)
         try:
             self._move_to_usteps(wheel_id, target_usteps)
@@ -190,31 +191,20 @@ class SquidFilterWheel(AbstractFilterWheelController):
             raise
 
     def _home_wheel(self, wheel_id: int):
-        """Home a specific wheel, then drive to slot 0 (min_index) absolutely.
+        """Home a wheel, then drive to slot 0 absolutely.
 
-        After firmware homing, the tmc4361 X_ACTUAL counter is anchored to
-        0 (operations.cpp:finalize_homing_w). The host then drives to the
-        absolute offset that aligns the wheel with the first filter slot.
+        The firmware anchors the driver's X_ACTUAL counter to 0 at the
+        home reference, so the host can target absolute slot positions
+        as `slot_index * usteps_per_slot + offset_usteps` thereafter.
         """
         config = self._configs[wheel_id]
-        motor_slot = config.motor_slot_index
 
-        if motor_slot == 3:
-            self.microcontroller.home_w()
-        elif motor_slot == 4:
-            self.microcontroller.home_w2()
-        else:
-            raise ValueError(f"Unsupported motor_slot_index: {motor_slot}")
-
-        # Wait for homing to complete (needs longer timeout)
+        self._mcu_method(wheel_id, "home")()
         self.microcontroller.wait_till_operation_is_completed(15)
 
-        # Drive to slot 0 (min_index) using the firmware's now-anchored
-        # absolute coordinate frame.
         self._move_to_usteps(wheel_id, self._delta_to_usteps(config.offset))
         self.microcontroller.wait_till_operation_is_completed()
 
-        # Reset position tracking
         self._positions[wheel_id] = config.min_index
 
     def initialize(self, filter_wheel_indices: List[int]):

--- a/software/squid/filter_wheel_controller/cephla.py
+++ b/software/squid/filter_wheel_controller/cephla.py
@@ -3,7 +3,7 @@ from typing import List, Dict, Optional, Union
 
 import squid.logging
 from control._def import *
-from control.microcontroller import Microcontroller
+from control.microcontroller import CommandAborted, Microcontroller
 from squid.abc import AbstractFilterWheelController, FilterWheelInfo
 from squid.config import SquidFilterWheelConfig
 
@@ -70,6 +70,12 @@ class SquidFilterWheel(AbstractFilterWheelController):
     # The protocol_axis_to_internal() function in firmware handles this conversion.
     _MOTOR_SLOT_TO_AXIS = {3: AXIS.W, 4: AXIS.W2}
 
+    # Errors that the re-home + retry recovery path can recover from.
+    # CommandAborted is raised when firmware reports CMD_EXECUTION_ERROR
+    # (the motor confirmed it didn't move); TimeoutError is raised when
+    # the ack never arrives within the wait window (motor state uncertain).
+    _RECOVERABLE_MOVE_ERRORS = (TimeoutError, CommandAborted)
+
     def _configure_wheel(self, wheel_id: int, config: SquidFilterWheelConfig):
         """Configure a single filter wheel motor."""
         motor_slot = config.motor_slot_index
@@ -90,41 +96,59 @@ class SquidFilterWheel(AbstractFilterWheelController):
             self.microcontroller.configure_stage_pid(axis, config.transitions_per_revolution, ENCODER_FLIP_DIR_W)
             self.microcontroller.turn_on_stage_pid(axis, ENABLE_PID_W)
 
-    def _move_wheel(self, wheel_id: int, delta: float):
-        """Move a specific wheel by delta distance.
+    @staticmethod
+    def _delta_to_usteps(delta_mm: float) -> int:
+        """Microsteps the firmware will be commanded to step for `delta_mm` mm.
 
-        Args:
-            wheel_id: The ID of the wheel to move.
-            delta: The distance to move (in mm, typically fraction of screw pitch).
+        Includes STAGE_MOVEMENT_SIGN_W so the result already accounts for
+        which direction the motor needs to drive to advance through slots.
         """
-        config = self._configs[wheel_id]
-        motor_slot = config.motor_slot_index
-        usteps = int(
-            STAGE_MOVEMENT_SIGN_W * delta / (SCREW_PITCH_W_MM / (MICROSTEPPING_DEFAULT_W * FULLSTEPS_PER_REV_W))
+        return int(
+            STAGE_MOVEMENT_SIGN_W * delta_mm / (SCREW_PITCH_W_MM / (MICROSTEPPING_DEFAULT_W * FULLSTEPS_PER_REV_W))
         )
 
+    @staticmethod
+    def _target_pos_to_usteps(config: SquidFilterWheelConfig, target_pos: int) -> int:
+        """Absolute target microstep address for a given slot index.
+
+        After homing, the firmware re-anchors the tmc4361 X_ACTUAL counter
+        to 0 (operations.cpp:finalize_homing_w), so slot 0 sits at
+        `_delta_to_usteps(config.offset)` and each subsequent slot is one
+        step_size further along.
+        """
+        step_size_mm = SCREW_PITCH_W_MM / (config.max_index - config.min_index + 1)
+        target_mm_from_home = config.offset + (target_pos - config.min_index) * step_size_mm
+        return SquidFilterWheel._delta_to_usteps(target_mm_from_home)
+
+    def _move_to_usteps(self, wheel_id: int, usteps: int):
+        """Dispatch an absolute MOVETO_W / MOVETO_W2 by motor_slot_index."""
+        config = self._configs[wheel_id]
+        motor_slot = config.motor_slot_index
         if motor_slot == 3:
-            self.microcontroller.move_w_usteps(usteps)
+            self.microcontroller.move_w_to_usteps(usteps)
         elif motor_slot == 4:
-            self.microcontroller.move_w2_usteps(usteps)
+            self.microcontroller.move_w2_to_usteps(usteps)
         else:
             raise ValueError(f"Unsupported motor_slot_index: {motor_slot}")
 
     def _move_to_position(self, wheel_id: int, target_pos: int):
-        """Move wheel to target position with automatic re-home on failure.
+        """Move wheel to target position using absolute MOVETO; recover on failure.
 
-        If the movement times out (e.g., motor stall), this method will:
-        1. Log a warning
-        2. Re-home the wheel to re-synchronize position tracking
-        3. Retry the movement to the target position
-        4. Raise an exception if retry also fails
+        Recovery is conditioned on failure type, because the absolute-move
+        approach already self-corrects on the next *successful* command —
+        the goal here is just to make sure that next command actually goes
+        out, with the right re-home cost.
 
-        Args:
-            wheel_id: The ID of the wheel to move.
-            target_pos: The target position index.
+        - CommandAborted (CMD_EXECUTION_ERROR): firmware rejected the move
+          before the motor moved (e.g. tmc4361A_moveTo returned non-zero
+          or move arrived before INITFILTERWHEEL). The motor didn't move;
+          a plain resend is safe and avoids the ~4 s re-home cost.
+        - TimeoutError (ack never arrived): motor state is uncertain (could
+          be partially moved). Re-home to re-anchor the coordinate frame,
+          then retry to the same absolute target.
 
         Raises:
-            TimeoutError: If both the initial move and retry after re-home fail.
+            TimeoutError or CommandAborted: If all attempts fail.
         """
         config = self._configs[wheel_id]
         current_pos = self._positions[wheel_id]
@@ -132,37 +156,45 @@ class SquidFilterWheel(AbstractFilterWheelController):
         if target_pos == current_pos:
             return
 
-        step_size = SCREW_PITCH_W_MM / (config.max_index - config.min_index + 1)
-        delta = (target_pos - current_pos) * step_size
+        target_usteps = self._target_pos_to_usteps(config, target_pos)
 
         try:
-            self._move_wheel(wheel_id, delta)
+            self._move_to_usteps(wheel_id, target_usteps)
             self.microcontroller.wait_till_operation_is_completed()
             self._positions[wheel_id] = target_pos
-        except TimeoutError:
-            _log.warning(f"Filter wheel {wheel_id} movement timed out. " f"Re-homing to re-sync position tracking...")
-            # Re-home to re-synchronize position tracking
-            self._home_wheel(wheel_id)
-
-            # Retry the movement (position is now at min_index after homing)
-            current_pos = self._positions[wheel_id]
-            delta = (target_pos - current_pos) * step_size
+            return
+        except CommandAborted as e:
+            _log.warning(f"Filter wheel {wheel_id} command aborted ({e}); resending in software...")
             try:
-                self._move_wheel(wheel_id, delta)
+                self._move_to_usteps(wheel_id, target_usteps)
                 self.microcontroller.wait_till_operation_is_completed()
                 self._positions[wheel_id] = target_pos
-                _log.info(f"Filter wheel {wheel_id} recovery successful, now at position {target_pos}")
-            except TimeoutError:
-                _log.error(
-                    f"Filter wheel {wheel_id} movement failed even after re-home. " f"Hardware may need attention."
-                )
-                raise
+                _log.info(f"Filter wheel {wheel_id} software resend succeeded, now at position {target_pos}")
+                return
+            except self._RECOVERABLE_MOVE_ERRORS as e2:
+                _log.warning(f"Filter wheel {wheel_id} resend also failed ({e2}); re-homing to re-sync...")
+        except TimeoutError as e:
+            _log.warning(f"Filter wheel {wheel_id} move uncertain ({e}); re-homing to re-sync...")
+
+        self._home_wheel(wheel_id)
+        # _home_wheel re-anchored the firmware coordinate to 0; recompute
+        # the absolute target against the (unchanged) slot index.
+        target_usteps = self._target_pos_to_usteps(config, target_pos)
+        try:
+            self._move_to_usteps(wheel_id, target_usteps)
+            self.microcontroller.wait_till_operation_is_completed()
+            self._positions[wheel_id] = target_pos
+            _log.info(f"Filter wheel {wheel_id} recovery via re-home succeeded, now at position {target_pos}")
+        except self._RECOVERABLE_MOVE_ERRORS:
+            _log.error(f"Filter wheel {wheel_id} movement failed even after re-home. Hardware may need attention.")
+            raise
 
     def _home_wheel(self, wheel_id: int):
-        """Home a specific wheel.
+        """Home a specific wheel, then drive to slot 0 (min_index) absolutely.
 
-        Args:
-            wheel_id: The ID of the wheel to home.
+        After firmware homing, the tmc4361 X_ACTUAL counter is anchored to
+        0 (operations.cpp:finalize_homing_w). The host then drives to the
+        absolute offset that aligns the wheel with the first filter slot.
         """
         config = self._configs[wheel_id]
         motor_slot = config.motor_slot_index
@@ -177,8 +209,9 @@ class SquidFilterWheel(AbstractFilterWheelController):
         # Wait for homing to complete (needs longer timeout)
         self.microcontroller.wait_till_operation_is_completed(15)
 
-        # Move to offset position
-        self._move_wheel(wheel_id, config.offset)
+        # Drive to slot 0 (min_index) using the firmware's now-anchored
+        # absolute coordinate frame.
+        self._move_to_usteps(wheel_id, self._delta_to_usteps(config.offset))
         self.microcontroller.wait_till_operation_is_completed()
 
         # Reset position tracking
@@ -311,8 +344,3 @@ class SquidFilterWheel(AbstractFilterWheelController):
     def close(self):
         """Close the filter wheel controller (no-op for SQUID)."""
         pass
-
-    # Backward compatibility methods
-    def move_w(self, delta: float):
-        """Move the first wheel by delta. For backward compatibility."""
-        self._move_wheel(1, delta)

--- a/software/squid/filter_wheel_controller/cephla.py
+++ b/software/squid/filter_wheel_controller/cephla.py
@@ -188,6 +188,9 @@ class SquidFilterWheel(AbstractFilterWheelController):
             return
         except CommandAborted as e:
             _log.warning(f"Filter wheel {wheel_id} command aborted ({e}); resending in software...")
+            # Clear the pending abort so the next send_command doesn't log
+            # a spurious "not cleared before new command sent" warning.
+            self.microcontroller.acknowledge_aborted_command()
             try:
                 self._move_to_usteps(wheel_id, target_usteps)
                 self.microcontroller.wait_till_operation_is_completed()
@@ -196,11 +199,12 @@ class SquidFilterWheel(AbstractFilterWheelController):
                 return
             except self._RECOVERABLE_MOVE_ERRORS as e2:
                 _log.warning(f"Filter wheel {wheel_id} resend also failed ({e2}); re-homing to re-sync...")
+                if isinstance(e2, CommandAborted):
+                    self.microcontroller.acknowledge_aborted_command()
         except TimeoutError as e:
             _log.warning(f"Filter wheel {wheel_id} move uncertain ({e}); re-homing to re-sync...")
 
         self._home_wheel(wheel_id)
-        target_usteps = self._target_pos_to_usteps(config, target_pos)
         try:
             self._move_to_usteps(wheel_id, target_usteps)
             self.microcontroller.wait_till_operation_is_completed()
@@ -211,7 +215,7 @@ class SquidFilterWheel(AbstractFilterWheelController):
             raise
 
     def _home_wheel(self, wheel_id: int):
-        """Home a wheel, then drive to slot 0 absolutely.
+        """Home a wheel, then drive to its first slot (config.min_index) absolutely.
 
         The firmware anchors the driver's X_ACTUAL counter to 0 at the
         home reference, so the host can target absolute slot positions

--- a/software/squid/filter_wheel_controller/cephla.py
+++ b/software/squid/filter_wheel_controller/cephla.py
@@ -80,8 +80,25 @@ class SquidFilterWheel(AbstractFilterWheelController):
 
     _RECOVERABLE_MOVE_ERRORS = (TimeoutError, CommandAborted)
 
+    # Minimum firmware that anchors the W/W2 driver position to 0 at home
+    # (finalize_homing_w/_w2) and reports CMD_EXECUTION_ERROR on failed
+    # moves. Sending MOVETO_W against older firmware would target the
+    # wrong absolute slot because X_ACTUAL would still be at the
+    # limit-switch latch value.
+    _MIN_FIRMWARE_VERSION = (1, 2)
+
     def _configure_wheel(self, wheel_id: int, config: SquidFilterWheelConfig):
         """Configure a single filter wheel motor."""
+        fw = self.microcontroller.firmware_version
+        if fw < self._MIN_FIRMWARE_VERSION:
+            min_major, min_minor = self._MIN_FIRMWARE_VERSION
+            raise RuntimeError(
+                f"SquidFilterWheel requires firmware >= v{min_major}.{min_minor} "
+                f"(got v{fw[0]}.{fw[1]}). Older firmware does not anchor the W "
+                f"axis to 0 after homing, so absolute MOVETO_W targets would "
+                f"land at the wrong slot. Re-flash firmware from firmware/controller."
+            )
+
         motor_slot = config.motor_slot_index
         axis = self._MOTOR_SLOT_TO_AXIS.get(motor_slot)
         if axis is None:

--- a/software/squid/filter_wheel_controller/cephla.py
+++ b/software/squid/filter_wheel_controller/cephla.py
@@ -42,6 +42,19 @@ class SquidFilterWheel(AbstractFilterWheelController):
 
         self.microcontroller = microcontroller
 
+        # Fail loudly on a host/firmware version mismatch before any moves
+        # are issued — runs unconditionally (including the skip_init restart
+        # path) because firmware could have been re-flashed between launches.
+        fw = self.microcontroller.firmware_version
+        if fw < self._MIN_FIRMWARE_VERSION:
+            min_major, min_minor = self._MIN_FIRMWARE_VERSION
+            raise RuntimeError(
+                f"SquidFilterWheel requires firmware >= v{min_major}.{min_minor} "
+                f"(got v{fw[0]}.{fw[1]}). Older firmware does not anchor the W "
+                f"axis to 0 after homing, so absolute MOVETO_W targets would "
+                f"land at the wrong slot. Re-flash firmware from firmware/controller."
+            )
+
         # Convert single config to dict format for uniform handling
         if isinstance(configs, SquidFilterWheelConfig):
             self._configs: Dict[int, SquidFilterWheelConfig] = {1: configs}
@@ -89,16 +102,6 @@ class SquidFilterWheel(AbstractFilterWheelController):
 
     def _configure_wheel(self, wheel_id: int, config: SquidFilterWheelConfig):
         """Configure a single filter wheel motor."""
-        fw = self.microcontroller.firmware_version
-        if fw < self._MIN_FIRMWARE_VERSION:
-            min_major, min_minor = self._MIN_FIRMWARE_VERSION
-            raise RuntimeError(
-                f"SquidFilterWheel requires firmware >= v{min_major}.{min_minor} "
-                f"(got v{fw[0]}.{fw[1]}). Older firmware does not anchor the W "
-                f"axis to 0 after homing, so absolute MOVETO_W targets would "
-                f"land at the wrong slot. Re-flash firmware from firmware/controller."
-            )
-
         motor_slot = config.motor_slot_index
         axis = self._MOTOR_SLOT_TO_AXIS.get(motor_slot)
         if axis is None:

--- a/software/squid/filter_wheel_controller/cephla.py
+++ b/software/squid/filter_wheel_controller/cephla.py
@@ -50,9 +50,11 @@ class SquidFilterWheel(AbstractFilterWheelController):
             min_major, min_minor = self._MIN_FIRMWARE_VERSION
             raise RuntimeError(
                 f"SquidFilterWheel requires firmware >= v{min_major}.{min_minor} "
-                f"(got v{fw[0]}.{fw[1]}). Older firmware does not anchor the W "
-                f"axis to 0 after homing, so absolute MOVETO_W targets would "
-                f"land at the wrong slot. Re-flash firmware from firmware/controller."
+                f"(got v{fw[0]}.{fw[1]}). Older firmware does not anchor the "
+                f"filter-wheel driver position to 0 after homing, so absolute "
+                f"MOVETO targets would land at the wrong slot; the W2 MOVETO "
+                f"command also does not exist on older firmware. Re-flash "
+                f"firmware from firmware/controller."
             )
 
         # Convert single config to dict format for uniform handling
@@ -223,14 +225,33 @@ class SquidFilterWheel(AbstractFilterWheelController):
         The firmware anchors the driver's X_ACTUAL counter to 0 at the
         home reference, so the host can target absolute slot positions
         as `slot_index * usteps_per_slot + offset_usteps` thereafter.
+
+        On failure, `_positions[wheel_id]` is *not* updated and may now be
+        stale relative to physical hardware — callers should treat the
+        wheel's position as unknown until a successful home completes.
         """
         config = self._configs[wheel_id]
 
-        self._mcu_method(wheel_id, "home")()
-        self.microcontroller.wait_till_operation_is_completed(15)
+        try:
+            self._mcu_method(wheel_id, "home")()
+            self.microcontroller.wait_till_operation_is_completed(15)
+        except Exception:
+            _log.error(
+                f"Filter wheel {wheel_id} home command failed; physical "
+                f"position is unknown and tracked position may be stale."
+            )
+            raise
 
-        self._move_to_usteps(wheel_id, self._delta_to_usteps(config.offset))
-        self.microcontroller.wait_till_operation_is_completed()
+        try:
+            self._move_to_usteps(wheel_id, self._delta_to_usteps(config.offset))
+            self.microcontroller.wait_till_operation_is_completed()
+        except Exception:
+            _log.error(
+                f"Filter wheel {wheel_id} home succeeded but offset move "
+                f"failed; wheel is at the home reference, not slot "
+                f"{config.min_index}. Tracked position not updated."
+            )
+            raise
 
         self._positions[wheel_id] = config.min_index
 

--- a/software/squid/filter_wheel_controller/cephla.py
+++ b/software/squid/filter_wheel_controller/cephla.py
@@ -199,11 +199,14 @@ class SquidFilterWheel(AbstractFilterWheelController):
                 return
             except self._RECOVERABLE_MOVE_ERRORS as e2:
                 _log.warning(f"Filter wheel {wheel_id} resend also failed ({e2}); re-homing to re-sync...")
-                if isinstance(e2, CommandAborted):
-                    self.microcontroller.acknowledge_aborted_command()
         except TimeoutError as e:
             _log.warning(f"Filter wheel {wheel_id} move uncertain ({e}); re-homing to re-sync...")
 
+        # Clear any pending abort (set when wait_till_operation_is_completed
+        # raised CommandAborted) so the home command's send_command doesn't
+        # log a spurious "not cleared before new command sent" warning.
+        if self.microcontroller.last_command_aborted_error is not None:
+            self.microcontroller.acknowledge_aborted_command()
         self._home_wheel(wheel_id)
         try:
             self._move_to_usteps(wheel_id, target_usteps)

--- a/software/tests/control/test_microcontroller.py
+++ b/software/tests/control/test_microcontroller.py
@@ -243,3 +243,30 @@ def test_set_trigger_mode():
     assert micro.last_command[2] == 1
 
     micro.close()
+
+
+def test_abort_current_command_recoverable_logs_at_warning(caplog):
+    """recoverable=True → WARNING (caller will retry); default → ERROR (operator attention)."""
+    import logging
+
+    micro = get_test_micro()
+    try:
+        micro.turn_off_all_ports()
+        micro.wait_till_operation_is_completed()
+        caplog.clear()
+
+        with caplog.at_level(logging.WARNING, logger="squid.Microcontroller"):
+            micro.abort_current_command(reason="test recoverable", recoverable=True)
+            recoverable_records = [r for r in caplog.records if "test recoverable" in r.message]
+            assert recoverable_records, "expected a log record for the recoverable abort"
+            assert all(r.levelno == logging.WARNING for r in recoverable_records)
+
+        caplog.clear()
+        micro.acknowledge_aborted_command()
+        with caplog.at_level(logging.WARNING, logger="squid.Microcontroller"):
+            micro.abort_current_command(reason="test fatal")
+            fatal_records = [r for r in caplog.records if "test fatal" in r.message]
+            assert fatal_records, "expected a log record for the default abort"
+            assert all(r.levelno == logging.ERROR for r in fatal_records)
+    finally:
+        micro.close()

--- a/software/tests/control/test_microcontroller.py
+++ b/software/tests/control/test_microcontroller.py
@@ -1,3 +1,4 @@
+import logging
 import time
 
 import pytest
@@ -247,8 +248,6 @@ def test_set_trigger_mode():
 
 def test_abort_current_command_recoverable_logs_at_warning(caplog):
     """recoverable=True → WARNING (caller will retry); default → ERROR (operator attention)."""
-    import logging
-
     micro = get_test_micro()
     try:
         micro.turn_off_all_ports()

--- a/software/tests/squid/test_filter_wheel.py
+++ b/software/tests/squid/test_filter_wheel.py
@@ -233,6 +233,8 @@ class TestSquidFilterWheelAbsoluteMove:
 
         assert getattr(mc, move_to_attr).call_count == 2
         getattr(mc, home_attr).assert_not_called()
+        # Absolute-MOVETO path must not fall back to relative MOVE.
+        getattr(mc, move_rel_attr).assert_not_called()
         assert wheel_inst._positions[1] == 4
 
     @pytest.mark.parametrize("motor_slot,move_to_attr,move_rel_attr,home_attr", AXIS_PARAMS)
@@ -254,6 +256,8 @@ class TestSquidFilterWheelAbsoluteMove:
         # Three MOVETO calls: the failed initial attempt, the home-offset
         # move inside _home_wheel, and the post-home retry to slot 4.
         assert getattr(mc, move_to_attr).call_count == 3
+        # Absolute-MOVETO path must not fall back to relative MOVE.
+        getattr(mc, move_rel_attr).assert_not_called()
         assert wheel_inst._positions[1] == 4
 
     def test_home_uses_absolute_moveto_for_offset(self, wheel, w_config):

--- a/software/tests/squid/test_filter_wheel.py
+++ b/software/tests/squid/test_filter_wheel.py
@@ -73,8 +73,10 @@ class TestSquidFilterWheelSkipInit:
 
     @pytest.fixture
     def mock_microcontroller(self):
-        """Create a mock microcontroller."""
-        return MagicMock()
+        """Create a mock microcontroller running v1.2+ firmware."""
+        mc = MagicMock()
+        mc.firmware_version = (1, 2)
+        return mc
 
     @pytest.fixture
     def squid_config(self):
@@ -149,15 +151,30 @@ class TestSquidFilterWheelAbsoluteMove:
             transitions_per_revolution=4000,
         )
 
+    # (motor_slot, move_to_attr, move_rel_attr, home_attr) for each wheel axis.
+    AXIS_PARAMS = [
+        pytest.param(3, "move_w_to_usteps", "move_w_usteps", "home_w", id="W"),
+        pytest.param(4, "move_w2_to_usteps", "move_w2_usteps", "home_w2", id="W2"),
+    ]
+
+    @staticmethod
+    def _build_wheel(motor_slot):
+        config = SquidFilterWheelConfig(
+            max_index=8,
+            min_index=1,
+            offset=0.008,
+            motor_slot_index=motor_slot,
+            transitions_per_revolution=4000,
+        )
+        mc = MagicMock()
+        mc.firmware_version = (1, 2)
+        return SquidFilterWheel(mc, config, skip_init=True), mc, config
+
     @pytest.fixture
     def wheel(self, w_config):
         mc = MagicMock()
+        mc.firmware_version = (1, 2)
         return SquidFilterWheel(mc, w_config, skip_init=True), mc
-
-    @pytest.fixture
-    def wheel_w2(self, w2_config):
-        mc = MagicMock()
-        return SquidFilterWheel(mc, w2_config, skip_init=True), mc
 
     def test_move_to_position_uses_absolute_moveto_for_w(self, wheel, w_config):
         """Moving slot 1 → slot 5 issues MOVETO_W with absolute target usteps."""
@@ -170,9 +187,9 @@ class TestSquidFilterWheelAbsoluteMove:
         mc.move_w_usteps.assert_not_called()
         assert wheel_inst._positions[1] == 5
 
-    def test_move_to_position_uses_absolute_moveto_for_w2(self, wheel_w2, w2_config):
+    def test_move_to_position_uses_absolute_moveto_for_w2(self, w2_config):
         """Wheel on W2 axis routes to MOVETO_W2, not MOVE_W2."""
-        wheel_inst, mc = wheel_w2
+        wheel_inst, mc, _ = self._build_wheel(motor_slot=4)
 
         expected_usteps = SquidFilterWheel._target_pos_to_usteps(w2_config, 3)
         wheel_inst._move_to_position(1, 3)
@@ -197,11 +214,14 @@ class TestSquidFilterWheelAbsoluteMove:
         # 7 step_sizes between slot 1 and slot 8
         assert u8 - u1 == 7 * step
 
-    def test_command_aborted_triggers_software_resend_not_rehome(self, wheel):
+    @pytest.mark.parametrize("motor_slot,move_to_attr,move_rel_attr,home_attr", AXIS_PARAMS)
+    def test_command_aborted_triggers_software_resend_not_rehome(
+        self, motor_slot, move_to_attr, move_rel_attr, home_attr
+    ):
         """CMD_EXECUTION_ERROR → resend the same MOVETO; do NOT re-home."""
         from control.microcontroller import CommandAborted
 
-        wheel_inst, mc = wheel
+        wheel_inst, mc, _ = self._build_wheel(motor_slot)
 
         # First wait raises CommandAborted, second succeeds.
         mc.wait_till_operation_is_completed.side_effect = [
@@ -211,28 +231,29 @@ class TestSquidFilterWheelAbsoluteMove:
 
         wheel_inst._move_to_position(1, 4)
 
-        assert mc.move_w_to_usteps.call_count == 2
-        mc.home_w.assert_not_called()
+        assert getattr(mc, move_to_attr).call_count == 2
+        getattr(mc, home_attr).assert_not_called()
         assert wheel_inst._positions[1] == 4
 
-    def test_timeout_skips_resend_and_goes_straight_to_rehome(self, wheel):
+    @pytest.mark.parametrize("motor_slot,move_to_attr,move_rel_attr,home_attr", AXIS_PARAMS)
+    def test_timeout_skips_resend_and_goes_straight_to_rehome(self, motor_slot, move_to_attr, move_rel_attr, home_attr):
         """Ack timeout → re-home + retry (no cheap resend, motor state is uncertain)."""
-        wheel_inst, mc = wheel
+        wheel_inst, mc, _ = self._build_wheel(motor_slot)
 
         # First move times out; home succeeds; retry succeeds.
         mc.wait_till_operation_is_completed.side_effect = [
             TimeoutError("ack timeout"),
-            None,  # home_w wait
+            None,  # home wait
             None,  # home offset move wait
             None,  # retry MOVETO wait
         ]
 
         wheel_inst._move_to_position(1, 4)
 
-        mc.home_w.assert_called_once()
-        # Three MOVETO_W calls: the failed initial attempt, the home-offset
+        getattr(mc, home_attr).assert_called_once()
+        # Three MOVETO calls: the failed initial attempt, the home-offset
         # move inside _home_wheel, and the post-home retry to slot 4.
-        assert mc.move_w_to_usteps.call_count == 3
+        assert getattr(mc, move_to_attr).call_count == 3
         assert wheel_inst._positions[1] == 4
 
     def test_home_uses_absolute_moveto_for_offset(self, wheel, w_config):
@@ -246,3 +267,46 @@ class TestSquidFilterWheelAbsoluteMove:
         mc.move_w_to_usteps.assert_called_once_with(expected_offset_usteps)
         mc.move_w_usteps.assert_not_called()
         assert wheel_inst._positions[1] == w_config.min_index
+
+
+class TestSquidFilterWheelFirmwareVersionGate:
+    """Tests for the firmware version requirement on SquidFilterWheel."""
+
+    @pytest.fixture
+    def squid_config(self):
+        return SquidFilterWheelConfig(
+            max_index=8,
+            min_index=1,
+            offset=0.008,
+            motor_slot_index=3,
+            transitions_per_revolution=4000,
+        )
+
+    @pytest.mark.parametrize("firmware_version", [(0, 0), (1, 0), (1, 1)])
+    def test_init_raises_on_pre_v1_2_firmware(self, squid_config, firmware_version):
+        """Constructing SquidFilterWheel must reject firmware older than v1.2."""
+        mc = MagicMock()
+        mc.firmware_version = firmware_version
+        with pytest.raises(RuntimeError, match="firmware >= v1.2"):
+            SquidFilterWheel(mc, squid_config)
+
+    def test_init_succeeds_on_v1_2_firmware(self, squid_config):
+        """v1.2 exactly should be accepted (it's the minimum required version)."""
+        mc = MagicMock()
+        mc.firmware_version = (1, 2)
+        SquidFilterWheel(mc, squid_config)  # no raise
+
+    def test_init_succeeds_on_newer_firmware(self, squid_config):
+        """Future firmware versions should also be accepted."""
+        mc = MagicMock()
+        mc.firmware_version = (2, 0)
+        SquidFilterWheel(mc, squid_config)  # no raise
+
+    def test_skip_init_still_checks_version(self, squid_config):
+        """skip_init=True skips MCU init but version check runs in _configure_wheel
+        only when skip_init=False — so skip_init=True with old firmware does not
+        raise. This documents the (intentional) gap: skip_init exists for restart
+        flows where the firmware was already validated on first init."""
+        mc = MagicMock()
+        mc.firmware_version = (1, 1)
+        SquidFilterWheel(mc, squid_config, skip_init=True)  # no raise

--- a/software/tests/squid/test_filter_wheel.py
+++ b/software/tests/squid/test_filter_wheel.py
@@ -8,6 +8,24 @@ from squid.config import FilterWheelConfig, FilterWheelControllerVariant, SquidF
 from squid.filter_wheel_controller.cephla import SquidFilterWheel
 
 
+def _make_squid_config(motor_slot: int = 3) -> SquidFilterWheelConfig:
+    """Default 8-slot SquidFilterWheelConfig used across the test module."""
+    return SquidFilterWheelConfig(
+        max_index=8,
+        min_index=1,
+        offset=0.008,
+        motor_slot_index=motor_slot,
+        transitions_per_revolution=4000,
+    )
+
+
+def _make_mock_mc(firmware_version=(1, 2)) -> MagicMock:
+    """MagicMock microcontroller with a configured firmware_version."""
+    mc = MagicMock()
+    mc.firmware_version = firmware_version
+    return mc
+
+
 def test_create_simulated_filter_wheel():
     """Test that we can create a simulated filter wheel controller."""
     controller = squid.filter_wheel_controller.utils.SimulatedFilterWheelController(
@@ -73,21 +91,11 @@ class TestSquidFilterWheelSkipInit:
 
     @pytest.fixture
     def mock_microcontroller(self):
-        """Create a mock microcontroller running v1.2+ firmware."""
-        mc = MagicMock()
-        mc.firmware_version = (1, 2)
-        return mc
+        return _make_mock_mc()
 
     @pytest.fixture
     def squid_config(self):
-        """Create a SquidFilterWheelConfig for testing."""
-        return SquidFilterWheelConfig(
-            max_index=8,
-            min_index=1,
-            offset=0.008,
-            motor_slot_index=3,
-            transitions_per_revolution=4000,
-        )
+        return _make_squid_config()
 
     def test_skip_init_skips_mcu_initialization(self, mock_microcontroller, squid_config):
         """skip_init=True should skip init_filter_wheel and configure_squidfilter calls."""
@@ -133,23 +141,11 @@ class TestSquidFilterWheelAbsoluteMove:
 
     @pytest.fixture
     def w_config(self):
-        return SquidFilterWheelConfig(
-            max_index=8,
-            min_index=1,
-            offset=0.008,
-            motor_slot_index=3,  # W
-            transitions_per_revolution=4000,
-        )
+        return _make_squid_config(motor_slot=3)
 
     @pytest.fixture
     def w2_config(self):
-        return SquidFilterWheelConfig(
-            max_index=8,
-            min_index=1,
-            offset=0.008,
-            motor_slot_index=4,  # W2
-            transitions_per_revolution=4000,
-        )
+        return _make_squid_config(motor_slot=4)
 
     # (motor_slot, move_to_attr, move_rel_attr, home_attr) for each wheel axis.
     AXIS_PARAMS = [
@@ -159,21 +155,13 @@ class TestSquidFilterWheelAbsoluteMove:
 
     @staticmethod
     def _build_wheel(motor_slot):
-        config = SquidFilterWheelConfig(
-            max_index=8,
-            min_index=1,
-            offset=0.008,
-            motor_slot_index=motor_slot,
-            transitions_per_revolution=4000,
-        )
-        mc = MagicMock()
-        mc.firmware_version = (1, 2)
+        config = _make_squid_config(motor_slot=motor_slot)
+        mc = _make_mock_mc()
         return SquidFilterWheel(mc, config, skip_init=True), mc, config
 
     @pytest.fixture
     def wheel(self, w_config):
-        mc = MagicMock()
-        mc.firmware_version = (1, 2)
+        mc = _make_mock_mc()
         return SquidFilterWheel(mc, w_config, skip_init=True), mc
 
     def test_move_to_position_uses_absolute_moveto_for_w(self, wheel, w_config):
@@ -278,32 +266,19 @@ class TestSquidFilterWheelFirmwareVersionGate:
 
     @pytest.fixture
     def squid_config(self):
-        return SquidFilterWheelConfig(
-            max_index=8,
-            min_index=1,
-            offset=0.008,
-            motor_slot_index=3,
-            transitions_per_revolution=4000,
-        )
+        return _make_squid_config()
 
     @pytest.mark.parametrize("firmware_version", [(0, 0), (1, 0), (1, 1)])
     def test_init_raises_on_pre_v1_2_firmware(self, squid_config, firmware_version):
         """Constructing SquidFilterWheel must reject firmware older than v1.2."""
-        mc = MagicMock()
-        mc.firmware_version = firmware_version
+        mc = _make_mock_mc(firmware_version=firmware_version)
         with pytest.raises(RuntimeError, match="firmware >= v1.2"):
             SquidFilterWheel(mc, squid_config)
 
-    def test_init_succeeds_on_v1_2_firmware(self, squid_config):
-        """v1.2 exactly should be accepted (it's the minimum required version)."""
-        mc = MagicMock()
-        mc.firmware_version = (1, 2)
-        SquidFilterWheel(mc, squid_config)  # no raise
-
-    def test_init_succeeds_on_newer_firmware(self, squid_config):
-        """Future firmware versions should also be accepted."""
-        mc = MagicMock()
-        mc.firmware_version = (2, 0)
+    @pytest.mark.parametrize("firmware_version", [(1, 2), (2, 0)])
+    def test_init_succeeds_on_supported_firmware(self, squid_config, firmware_version):
+        """v1.2 (the minimum) and any newer version should be accepted."""
+        mc = _make_mock_mc(firmware_version=firmware_version)
         SquidFilterWheel(mc, squid_config)  # no raise
 
     def test_skip_init_also_checks_version(self, squid_config):
@@ -312,7 +287,6 @@ class TestSquidFilterWheelFirmwareVersionGate:
         Restart flows could be running against a re-flashed (possibly downgraded)
         firmware, so the check must not be bypassed.
         """
-        mc = MagicMock()
-        mc.firmware_version = (1, 1)
+        mc = _make_mock_mc(firmware_version=(1, 1))
         with pytest.raises(RuntimeError, match="firmware >= v1.2"):
             SquidFilterWheel(mc, squid_config, skip_init=True)

--- a/software/tests/squid/test_filter_wheel.py
+++ b/software/tests/squid/test_filter_wheel.py
@@ -260,6 +260,26 @@ class TestSquidFilterWheelAbsoluteMove:
         mc.move_w_usteps.assert_not_called()
         assert wheel_inst._positions[1] == w_config.min_index
 
+    @pytest.mark.parametrize("motor_slot,move_to_attr,move_rel_attr,home_attr", AXIS_PARAMS)
+    def test_rehome_retry_failure_propagates(self, motor_slot, move_to_attr, move_rel_attr, home_attr):
+        """When the post-rehome retry also fails, _move_to_position must re-raise."""
+        wheel_inst, mc, _ = self._build_wheel(motor_slot)
+
+        # Initial move times out → re-home → offset move succeeds → retry times out → raise.
+        mc.wait_till_operation_is_completed.side_effect = [
+            TimeoutError("initial move ack timeout"),
+            None,  # home wait
+            None,  # home offset move wait
+            TimeoutError("post-rehome retry ack timeout"),
+        ]
+
+        with pytest.raises(TimeoutError, match="post-rehome retry"):
+            wheel_inst._move_to_position(1, 4)
+
+        getattr(mc, home_attr).assert_called_once()
+        # Position must not be updated to target on failure.
+        assert wheel_inst._positions[1] != 4
+
 
 class TestSquidFilterWheelFirmwareVersionGate:
     """Tests for the firmware version requirement on SquidFilterWheel."""

--- a/software/tests/squid/test_filter_wheel.py
+++ b/software/tests/squid/test_filter_wheel.py
@@ -302,11 +302,13 @@ class TestSquidFilterWheelFirmwareVersionGate:
         mc.firmware_version = (2, 0)
         SquidFilterWheel(mc, squid_config)  # no raise
 
-    def test_skip_init_still_checks_version(self, squid_config):
-        """skip_init=True skips MCU init but version check runs in _configure_wheel
-        only when skip_init=False — so skip_init=True with old firmware does not
-        raise. This documents the (intentional) gap: skip_init exists for restart
-        flows where the firmware was already validated on first init."""
+    def test_skip_init_also_checks_version(self, squid_config):
+        """Version check runs in __init__ so it fires regardless of skip_init.
+
+        Restart flows could be running against a re-flashed (possibly downgraded)
+        firmware, so the check must not be bypassed.
+        """
         mc = MagicMock()
         mc.firmware_version = (1, 1)
-        SquidFilterWheel(mc, squid_config, skip_init=True)  # no raise
+        with pytest.raises(RuntimeError, match="firmware >= v1.2"):
+            SquidFilterWheel(mc, squid_config, skip_init=True)

--- a/software/tests/squid/test_filter_wheel.py
+++ b/software/tests/squid/test_filter_wheel.py
@@ -118,3 +118,131 @@ class TestSquidFilterWheelSkipInit:
         mock_microcontroller.set_pid_arguments.assert_called_once()
         mock_microcontroller.configure_stage_pid.assert_called_once()
         mock_microcontroller.turn_on_stage_pid.assert_called_once()
+
+
+class TestSquidFilterWheelAbsoluteMove:
+    """Tests for the absolute-MOVETO move path on the filter wheel.
+
+    Verifies the wheel issues MOVETO_W / MOVETO_W2 with absolute microstep
+    targets computed against a home-anchored coordinate frame, and that
+    error recovery splits cleanly: CommandAborted → cheap resend,
+    TimeoutError → re-home + retry.
+    """
+
+    @pytest.fixture
+    def w_config(self):
+        return SquidFilterWheelConfig(
+            max_index=8,
+            min_index=1,
+            offset=0.008,
+            motor_slot_index=3,  # W
+            transitions_per_revolution=4000,
+        )
+
+    @pytest.fixture
+    def w2_config(self):
+        return SquidFilterWheelConfig(
+            max_index=8,
+            min_index=1,
+            offset=0.008,
+            motor_slot_index=4,  # W2
+            transitions_per_revolution=4000,
+        )
+
+    @pytest.fixture
+    def wheel(self, w_config):
+        mc = MagicMock()
+        return SquidFilterWheel(mc, w_config, skip_init=True), mc
+
+    @pytest.fixture
+    def wheel_w2(self, w2_config):
+        mc = MagicMock()
+        return SquidFilterWheel(mc, w2_config, skip_init=True), mc
+
+    def test_move_to_position_uses_absolute_moveto_for_w(self, wheel, w_config):
+        """Moving slot 1 → slot 5 issues MOVETO_W with absolute target usteps."""
+        wheel_inst, mc = wheel
+
+        expected_usteps = SquidFilterWheel._target_pos_to_usteps(w_config, 5)
+        wheel_inst._move_to_position(1, 5)
+
+        mc.move_w_to_usteps.assert_called_once_with(expected_usteps)
+        mc.move_w_usteps.assert_not_called()
+        assert wheel_inst._positions[1] == 5
+
+    def test_move_to_position_uses_absolute_moveto_for_w2(self, wheel_w2, w2_config):
+        """Wheel on W2 axis routes to MOVETO_W2, not MOVE_W2."""
+        wheel_inst, mc = wheel_w2
+
+        expected_usteps = SquidFilterWheel._target_pos_to_usteps(w2_config, 3)
+        wheel_inst._move_to_position(1, 3)
+
+        mc.move_w2_to_usteps.assert_called_once_with(expected_usteps)
+        mc.move_w2_usteps.assert_not_called()
+        assert wheel_inst._positions[1] == 3
+
+    def test_move_to_same_position_is_noop(self, wheel):
+        """Asking for the current slot issues no MCU command."""
+        wheel_inst, mc = wheel
+        wheel_inst._move_to_position(1, 1)
+        mc.move_w_to_usteps.assert_not_called()
+
+    def test_target_usteps_advances_monotonically_with_slot(self, w_config):
+        """Each slot is one step_size further from home along the absolute frame."""
+        u1 = SquidFilterWheel._target_pos_to_usteps(w_config, 1)
+        u2 = SquidFilterWheel._target_pos_to_usteps(w_config, 2)
+        u8 = SquidFilterWheel._target_pos_to_usteps(w_config, 8)
+        step = u2 - u1
+        assert step > 0
+        # 7 step_sizes between slot 1 and slot 8
+        assert u8 - u1 == 7 * step
+
+    def test_command_aborted_triggers_software_resend_not_rehome(self, wheel):
+        """CMD_EXECUTION_ERROR → resend the same MOVETO; do NOT re-home."""
+        from control.microcontroller import CommandAborted
+
+        wheel_inst, mc = wheel
+
+        # First wait raises CommandAborted, second succeeds.
+        mc.wait_till_operation_is_completed.side_effect = [
+            CommandAborted(reason="firmware reported CMD_EXECUTION_ERROR", command_id=1),
+            None,
+        ]
+
+        wheel_inst._move_to_position(1, 4)
+
+        assert mc.move_w_to_usteps.call_count == 2
+        mc.home_w.assert_not_called()
+        assert wheel_inst._positions[1] == 4
+
+    def test_timeout_skips_resend_and_goes_straight_to_rehome(self, wheel):
+        """Ack timeout → re-home + retry (no cheap resend, motor state is uncertain)."""
+        wheel_inst, mc = wheel
+
+        # First move times out; home succeeds; retry succeeds.
+        mc.wait_till_operation_is_completed.side_effect = [
+            TimeoutError("ack timeout"),
+            None,  # home_w wait
+            None,  # home offset move wait
+            None,  # retry MOVETO wait
+        ]
+
+        wheel_inst._move_to_position(1, 4)
+
+        mc.home_w.assert_called_once()
+        # Three MOVETO_W calls: the failed initial attempt, the home-offset
+        # move inside _home_wheel, and the post-home retry to slot 4.
+        assert mc.move_w_to_usteps.call_count == 3
+        assert wheel_inst._positions[1] == 4
+
+    def test_home_uses_absolute_moveto_for_offset(self, wheel, w_config):
+        """After firmware home, host drives to the offset slot via MOVETO_W (absolute)."""
+        wheel_inst, mc = wheel
+
+        wheel_inst._home_wheel(1)
+
+        expected_offset_usteps = SquidFilterWheel._delta_to_usteps(w_config.offset)
+        mc.home_w.assert_called_once()
+        mc.move_w_to_usteps.assert_called_once_with(expected_offset_usteps)
+        mc.move_w_usteps.assert_not_called()
+        assert wheel_inst._positions[1] == w_config.min_index

--- a/software/tests/test_multiport_illumination_bugs.py
+++ b/software/tests/test_multiport_illumination_bugs.py
@@ -374,13 +374,13 @@ class TestResponseVersionParsing:
         mcu = Microcontroller(sim, reset_and_initialize=False)
 
         # Before any command, version might be (0, 0)
-        # After command, SimSerial returns 1.1
+        # After command, SimSerial returns the simulated version.
 
         mcu.turn_off_all_ports()
         mcu.wait_till_operation_is_completed()
 
         # Should now have version from SimSerial
-        assert mcu.firmware_version == (1, 1)
+        assert mcu.firmware_version == (1, 2)
         mcu.close()
 
     def test_supports_multi_port_false_for_v0(self):

--- a/software/tests/test_multiport_illumination_edge_cases.py
+++ b/software/tests/test_multiport_illumination_edge_cases.py
@@ -248,13 +248,13 @@ class TestFirmwareVersionCheck:
 
     def test_firmware_version_detected_at_init(self, mcu):
         """Firmware version should be detected during Microcontroller init."""
-        # Version is read from response byte 22 (nibble-encoded)
-        # SimSerial reports version 1.1 (multi-port + watchdog)
-        # Early detection sends TURN_OFF_ALL_PORTS during __init__
+        # Version is read from response byte 22 (nibble-encoded).
+        # SimSerial reports the latest simulated version; early detection
+        # sends TURN_OFF_ALL_PORTS during __init__ to populate it.
         assert hasattr(mcu, "firmware_version")
         assert mcu.firmware_version is not None
         # Version should already be populated - no need to send a command first
-        assert mcu.firmware_version == (1, 1)
+        assert mcu.firmware_version == (1, 2)
 
     def test_supports_multi_port_accurate_at_init(self, mcu):
         """supports_multi_port() should return accurate result immediately after init."""

--- a/software/tests/test_multiport_illumination_protocol.py
+++ b/software/tests/test_multiport_illumination_protocol.py
@@ -484,8 +484,8 @@ class TestFirmwareVersionBehavior:
         mcu.turn_off_all_ports()
         mcu.wait_till_operation_is_completed()
 
-        # Now version should be detected (SimSerial reports 1.1)
-        assert mcu.firmware_version == (1, 1)
+        # Now version should be detected (SimSerial reports the latest simulated version)
+        assert mcu.firmware_version == (1, 2)
 
     def test_supports_multi_port_true_for_v1(self, mcu):
         """supports_multi_port() should return True for v1.0+."""
@@ -507,7 +507,7 @@ class TestFirmwareVersionBehavior:
         mcu.wait_till_operation_is_completed()
         v3 = mcu.firmware_version
 
-        assert v1 == v2 == v3 == (1, 1)
+        assert v1 == v2 == v3 == (1, 2)
 
 
 class TestMultiPortMaskEdgeCases:

--- a/software/tests/test_watchdog.py
+++ b/software/tests/test_watchdog.py
@@ -125,8 +125,8 @@ class TestHeartbeat:
 
 
 class TestFirmwareVersionForWatchdog:
-    def test_version_detected_as_1_1(self, mcu):
-        """SimSerial should report firmware version 1.1."""
+    def test_version_detected(self, mcu):
+        """SimSerial should report the simulated firmware version after a command."""
         mcu.turn_off_all_ports()
         mcu.wait_till_operation_is_completed()
-        assert mcu.firmware_version == (1, 1)
+        assert mcu.firmware_version == (1, 2)


### PR DESCRIPTION
## Summary

Fixes a class of silent filter-wheel position desyncs by combining a firmware root-cause fix with a host-side switch to absolute MOVETO addressing. Alternative design to #539 — same firmware fix, but defers the W-position broadcast + post-move verification layer in favor of containment via absolute addressing. Lighter wire format, symmetric W/W2 coverage, simpler recovery flow.

## Failure mode it fixes

Production incident: `main_hcs.log.1` showed a `MOVE_W` for slot 2→1 returning "complete" in **5.9 ms** when the physical move requires ~150 ms; host trusted the ack and updated `tracked_position`, leaving every subsequent filter switch off by one slot until the user manually re-homed.

Root cause in `stage_commands.cpp`: each move callback only set `mcu_cmd_execution_in_progress = true` *inside* the `if (tmc4361A_moveTo(...) == 0)` success branch. When `moveTo` returned non-zero, or the early `if (!enable_filterwheel) return;` fired, the flag stayed false, and the next status broadcast reported `COMPLETED_WITHOUT_ERRORS` for the new `cmd_id` even though no motion happened. With no encoder feedback on W/W2 (`HAS_ENCODER_W is False`), the host had no way to notice.

X/Y/Z don't manifest this as a persistent desync because the firmware broadcasts their position in every status packet — the host doesn't keep a separate tracker that can drift. The filter wheel was the one axis where this turned into off-by-one until manual intervention.

## What changed

### Firmware

**Root-cause fix:**
- New `mcu_cmd_execution_status` byte global; reset to `COMPLETED_WITHOUT_ERRORS` on every received command and overwritten to `CMD_EXECUTION_ERROR` by a `mark_move_failed()` helper.
- All move callbacks (`MOVE_X/Y/Z/W/W2`, `MOVETO_X/Y/Z/W`) restructured to set `in_progress = true` **before** `tmc4361A_moveTo` and call `mark_move_failed()` on the failure / disabled-filterwheel paths.
- `send_position_update` reports the new status byte when the MCU is idle.

**Enable absolute filter-wheel addressing:**
- `finalize_homing_w` / `finalize_homing_w2` now call `tmc4361A_setCurrentPosition(&tmc4361[w/w2], 0)`, anchoring the driver coordinate to 0 at the home reference. Previously X_ACTUAL was left at the hardware-dependent limit-switch latch value, making absolute targets meaningless.
- New `MOVETO_W2` protocol command (= 43) + `callback_move_to_w2` (mirror of `callback_move_to_w`). Completes symmetric absolute-move coverage for dual-wheel setups.
- `FIRMWARE_VERSION_MINOR` bumped 1 → 2.

### Host

**CMD_EXECUTION_ERROR fail-fast:**
- Receive loop now distinguishes `CMD_EXECUTION_ERROR` from ack timeout and aborts immediately via `abort_current_command(recoverable=True)`, saving the full 5 s `wait_till_operation_is_completed` wait when the firmware tells us the move was rejected.
- `recoverable=True` logs at WARNING — caller will retry.

**Filter wheel absolute moves:**
- `SquidFilterWheel._move_to_position` computes absolute microstep target = `(target_pos - min_index) * usteps_per_slot + offset_usteps`, anchored to the now-zeroed firmware coordinate frame. Issues `MOVETO_W` / `MOVETO_W2` instead of relative `MOVE_W` / `MOVE_W2`.
- Recovery splits on failure type:
  - **CommandAborted** (firmware-confirmed no motion): cheap software resend without re-home (saves ~4 s).
  - **TimeoutError** (motor state uncertain): re-home + retry against the same absolute target.
- `_home_wheel`'s offset move switched to absolute MOVETO for symmetry; every motion in the controller now goes through one path.
- New `move_w_to_usteps` / `move_w2_to_usteps` helpers + `MOVETO_W2` wired through `firmware_sim_serial.py`.

**Firmware version gate:**
- `SquidFilterWheel.__init__` raises `RuntimeError` if `microcontroller.firmware_version < (1, 2)`. The host now sends `MOVETO_W` against a post-home `X_ACTUAL = 0` frame that older firmware does not establish; running the new host against pre-v1.2 firmware would silently send absolute targets that land at the wrong slot. Loud-fail at startup beats silent miscoordination weeks later.
- The check runs unconditionally — including on the `skip_init=True` restart path — because firmware could have been re-flashed (or downgraded) between launches.

## Why absolute + fail-fast is enough (vs. broadcast + verify)

**Containment, not persistent detection.** With relative `MOVE_W`, a silently-failed move leaves the host's `_positions` cache pointing at slot N+1 while hardware is still at slot N. The *next* relative move computes delta from the (drifted) host position, so hardware reaches slot N+1 while host thinks slot N+2 — divergence compounds.

With absolute `MOVETO_W` targeting slot N+2, the firmware drives to N+2 regardless of host's stale belief. Hardware and host re-converge on the very next successful move. One missed slot vs. persistent N-slot drift.

**What's still possible:** a mechanical stall mid-move where the driver thinks it stepped but the motor didn't. Open-loop steppers without encoders can't detect this firmware-side. Detecting it requires the W-position broadcast + verification (PR #539's second layer). That can be added in a follow-up PR if a stall-class incident is ever reported.

## Failure-mode coverage

| Scenario | Before | After |
|---|---|---|
| `tmc4361A_moveTo` returns non-zero | Silent COMPLETED ack, host desyncs | Firmware reports CMD_EXECUTION_ERROR, host fails fast, resends in software |
| `enable_filterwheel == false` (move before INITFILTERWHEEL) | Silent COMPLETED ack | Same fail-fast path |
| Ack times out (motor state uncertain) | 5 s wait + host desync | 5 s wait + re-home + retry against same absolute target |
| Motor stalls / misses steps mid-move | Silent COMPLETED ack, persistent off-by-N | Same single-move desync as before, but next successful MOVETO re-converges. Persistence eliminated. |
| Old firmware (< v1.2) | n/a | **Host refuses to initialize the filter wheel** (`RuntimeError` at construction). Re-flash firmware to proceed. |

## Known limitations / follow-up

- **`home()` failure path.** The public `home()` method has no built-in recovery: if firmware homing itself times out (e.g. limit switch fault, stuck wheel), the exception bubbles up and `_positions` is left un-updated. Callers must handle / re-home manually. `_home_wheel` now logs a clear message identifying which sub-step failed (the home command itself vs. the post-home offset move) so bench operators get an actionable error, but actual recovery is left as a follow-up.
- **`_delta_to_usteps` duplication.** The static helper in `cephla.py` duplicates the formula in `squid.config.AxisConfig.convert_real_units_to_ustep`. A clean refactor would give `SquidFilterWheelConfig` a `W_AXIS: AxisConfig` field built from the W-axis constants, mirroring the stage pattern. Out of scope for this PR — `AxisConfig` is a heavy pydantic model with many required fields, and it uses `round()` while the current helper uses `int()`; switching changes positioning by ±1 ustep at fractional boundaries.
- **MCU status-byte attribution race** ([#541](https://github.com/Cephla-Lab/Squid/issues/541)). The firmware resets `mcu_cmd_execution_status = COMPLETED_WITHOUT_ERRORS` at the start of every received command, which can clobber a pending `CMD_EXECUTION_ERROR` before the next position broadcast fires. The `HEARTBEAT` skip guard added in this PR closes the dominant in-practice case; the general fix (status tagged with `cmd_id` + reset-after-observe) is a protocol change tracked separately.

## Test plan

- [x] `pytest tests/squid/test_filter_wheel.py` — 23 passed. Adds: absolute-target math, MOVETO_W2 routing, CommandAborted resend + TimeoutError re-home parametrized for both W and W2, home-via-absolute-offset, firmware-version gate (3 reject + 2 accept cases).
- [x] `pytest tests/control/test_microcontroller.py` — 7 passed, 1 skipped. Adds: `abort_current_command(recoverable=True)` logs at WARNING; default logs at ERROR.
- [x] `pytest tests/control/test_firmware_sim_serial.py` — 23 passed.
- [x] `pytest tests/control/test_firmware_protocol.py` — 14 passed.
- [x] Affected-files suite (filter wheel + microcontroller + multiport + watchdog) — all passing.
- [x] `black --check --config pyproject.toml` clean on all edited Python files.
- [ ] **Build firmware locally and flash to a test Teensy** — I can't compile firmware from this environment; please verify the C++ builds and the v1.2 status packet parses correctly on a real bench unit before merging.
- [ ] **Exercise the CMD_EXECUTION_ERROR fail-fast path** (proxy for the production trigger): send `MOVE_W` before `INITFILTERWHEEL`. Confirm the host aborts within ~ms (not the 5 s ack timeout) and re-homes instead of advancing `tracked_position`. The production incident likely went through the sibling `tmc4361A_moveTo` non-zero path, which is harder to repro deterministically; both paths share the same fix.
- [ ] **Verify absolute slot positioning end-to-end**: command `MOVETO_W` to slot N's expected microstep address after homing; confirm the wheel physically lands on slot N.
- [ ] **Confirm boot safety**: cold-boot a unit with no filter wheel hardware connected; confirm no SPI hang from the (now-gated) setCurrentPosition path.
- [ ] **Verify firmware-version gate**: connect host to a pre-v1.2 firmware unit; confirm `SquidFilterWheel` construction raises `RuntimeError` with a clear remediation message.

## Relationship to #539

This is an alternative design to #539. Both:
- Fix the root-cause firmware bug the same way (in_progress flag + CMD_EXECUTION_ERROR + mark_move_failed).
- Add `MOVETO_W2` symmetry.

The two PRs differ in the second layer:
- **#539**: broadcasts W microstep position in status bytes 19-20, verifies host-computed expected delta on every move. Detects mechanical stalls in addition to the firmware silent-ack class.
- **This PR**: switches the filter wheel to absolute MOVETO so silent failures (firmware-detected or mechanical) don't compound across moves. Wire format unchanged, W2 covered symmetrically out of the box.

Maintainers' call which approach to ship; this PR can stand alone, and the broadcast/verify layer can be added on top later if a stall-class incident is ever reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

