### PR TITLE
feat: enable encoder closed-loop PID for filter wheel W/W2

### DIFF
--- a/firmware/controller/src/commands/commands.cpp
+++ b/firmware/controller/src/commands/commands.cpp
@@ -132,11 +132,11 @@ void callback_configure_stage_pid()
         tmc4361A_init_PID(&tmc4361[axis], 25, 25, axes_pid_arg[axis].p, axes_pid_arg[axis].i, axes_pid_arg[axis].d, tmc4361A_vmmToMicrosteps(&tmc4361[axis], MAX_VELOCITY_Z_mm), 4096, 2);
     else if (axis == w) {
         if (enable_filterwheel == true)
-            tmc4361A_init_PID(&tmc4361[axis], 2, 2, axes_pid_arg[axis].p, axes_pid_arg[axis].i, axes_pid_arg[axis].d, tmc4361A_vmmToMicrosteps(&tmc4361[axis], MAX_VELOCITY_W_mm), 4096, 2);
+            tmc4361A_init_PID(&tmc4361[axis], 20, 20, axes_pid_arg[axis].p, axes_pid_arg[axis].i, axes_pid_arg[axis].d, tmc4361A_vmmToMicrosteps(&tmc4361[axis], MAX_VELOCITY_W_mm), 4096, 2);
     }
     else if (axis == w2) {
         if (enable_filterwheel_w2 == true)
-            tmc4361A_init_PID(&tmc4361[axis], 2, 2, axes_pid_arg[axis].p, axes_pid_arg[axis].i, axes_pid_arg[axis].d, tmc4361A_vmmToMicrosteps(&tmc4361[axis], MAX_VELOCITY_W_mm), 4096, 2);
+            tmc4361A_init_PID(&tmc4361[axis], 20, 20, axes_pid_arg[axis].p, axes_pid_arg[axis].i, axes_pid_arg[axis].d, tmc4361A_vmmToMicrosteps(&tmc4361[axis], MAX_VELOCITY_W_mm), 4096, 2);
     }
 }
 

--- a/software/squid/filter_wheel_controller/cephla.py
+++ b/software/squid/filter_wheel_controller/cephla.py
@@ -120,7 +120,8 @@ class SquidFilterWheel(AbstractFilterWheelController):
         if HAS_ENCODER_W:
             self.microcontroller.set_pid_arguments(axis, PID_P_W, PID_I_W, PID_D_W)
             self.microcontroller.configure_stage_pid(axis, config.transitions_per_revolution, ENCODER_FLIP_DIR_W)
-            self.microcontroller.turn_on_stage_pid(axis, ENABLE_PID_W)
+            if ENABLE_PID_W:
+                self.microcontroller.turn_on_stage_pid(axis)
 
     @staticmethod
     def _delta_to_usteps(delta_mm: float) -> int:

--- a/software/tests/squid/test_filter_wheel.py
+++ b/software/tests/squid/test_filter_wheel.py
@@ -4,6 +4,7 @@ import pytest
 
 import squid.config
 import squid.filter_wheel_controller.utils
+from control._def import AXIS
 from squid.config import FilterWheelConfig, FilterWheelControllerVariant, SquidFilterWheelConfig
 from squid.filter_wheel_controller.cephla import SquidFilterWheel
 
@@ -121,13 +122,25 @@ class TestSquidFilterWheelSkipInit:
         mock_microcontroller.configure_squidfilter.assert_called_once()
 
     @patch("squid.filter_wheel_controller.cephla.HAS_ENCODER_W", True)
+    @patch("squid.filter_wheel_controller.cephla.ENABLE_PID_W", True)
     def test_normal_init_configures_encoder_pid(self, mock_microcontroller, squid_config):
-        """skip_init=False with HAS_ENCODER_W=True should configure encoder PID."""
+        """HAS_ENCODER_W=True + ENABLE_PID_W=True should configure and engage PID."""
         SquidFilterWheel(mock_microcontroller, squid_config, skip_init=False)
 
         mock_microcontroller.set_pid_arguments.assert_called_once()
         mock_microcontroller.configure_stage_pid.assert_called_once()
-        mock_microcontroller.turn_on_stage_pid.assert_called_once()
+        # turn_on_stage_pid takes axis only — passing extra args would TypeError.
+        mock_microcontroller.turn_on_stage_pid.assert_called_once_with(AXIS.W)
+
+    @patch("squid.filter_wheel_controller.cephla.HAS_ENCODER_W", True)
+    @patch("squid.filter_wheel_controller.cephla.ENABLE_PID_W", False)
+    def test_encoder_without_pid_skips_turn_on(self, mock_microcontroller, squid_config):
+        """HAS_ENCODER_W=True + ENABLE_PID_W=False configures encoder but leaves PID off."""
+        SquidFilterWheel(mock_microcontroller, squid_config, skip_init=False)
+
+        mock_microcontroller.set_pid_arguments.assert_called_once()
+        mock_microcontroller.configure_stage_pid.assert_called_once()
+        mock_microcontroller.turn_on_stage_pid.assert_not_called()
 
 
 class TestSquidFilterWheelAbsoluteMove:

--- a/software/tests/squid/test_filter_wheel.py
+++ b/software/tests/squid/test_filter_wheel.py
@@ -121,22 +121,29 @@ class TestSquidFilterWheelSkipInit:
         mock_microcontroller.init_filter_wheel.assert_called_once()
         mock_microcontroller.configure_squidfilter.assert_called_once()
 
+    @pytest.mark.parametrize(
+        "motor_slot,expected_axis",
+        [pytest.param(3, AXIS.W, id="W"), pytest.param(4, AXIS.W2, id="W2")],
+    )
     @patch("squid.filter_wheel_controller.cephla.HAS_ENCODER_W", True)
     @patch("squid.filter_wheel_controller.cephla.ENABLE_PID_W", True)
-    def test_normal_init_configures_encoder_pid(self, mock_microcontroller, squid_config):
+    def test_normal_init_configures_encoder_pid(self, mock_microcontroller, motor_slot, expected_axis):
         """HAS_ENCODER_W=True + ENABLE_PID_W=True should configure and engage PID."""
-        SquidFilterWheel(mock_microcontroller, squid_config, skip_init=False)
+        config = _make_squid_config(motor_slot=motor_slot)
+        SquidFilterWheel(mock_microcontroller, config, skip_init=False)
 
         mock_microcontroller.set_pid_arguments.assert_called_once()
         mock_microcontroller.configure_stage_pid.assert_called_once()
         # turn_on_stage_pid takes axis only — passing extra args would TypeError.
-        mock_microcontroller.turn_on_stage_pid.assert_called_once_with(AXIS.W)
+        mock_microcontroller.turn_on_stage_pid.assert_called_once_with(expected_axis)
 
+    @pytest.mark.parametrize("motor_slot", [3, 4], ids=["W", "W2"])
     @patch("squid.filter_wheel_controller.cephla.HAS_ENCODER_W", True)
     @patch("squid.filter_wheel_controller.cephla.ENABLE_PID_W", False)
-    def test_encoder_without_pid_skips_turn_on(self, mock_microcontroller, squid_config):
+    def test_encoder_without_pid_skips_turn_on(self, mock_microcontroller, motor_slot):
         """HAS_ENCODER_W=True + ENABLE_PID_W=False configures encoder but leaves PID off."""
-        SquidFilterWheel(mock_microcontroller, squid_config, skip_init=False)
+        config = _make_squid_config(motor_slot=motor_slot)
+        SquidFilterWheel(mock_microcontroller, config, skip_init=False)
 
         mock_microcontroller.set_pid_arguments.assert_called_once()
         mock_microcontroller.configure_stage_pid.assert_called_once()


### PR DESCRIPTION
## Summary

Enables the existing-but-dormant W/W2 encoder closed-loop path so the filter wheel **physically reaches** its commanded slot every move, with no error accumulation over many moves. Stacks on top of #540.

## Why

The Cephla filter wheel has no detent — the motor itself must hold each slot position. With open-loop control and no encoder feedback (current default), two failure modes are not covered by #540:

1. **In-motion step loss**: motor commanded but ramp completed with some pulses unrealized. XACTUAL still reads "at target", host trusts it, the wheel is off by one slot. #540's `CMD_EXECUTION_ERROR` doesn't catch this because the callback executed fine.
2. **Idle drift between moves**: with no detent and motor de-energized after the ramp, external forces (vibration, optical coupling friction) can rotate the wheel between commanded moves. Next move's absolute target is now physically wrong.

Enabling the TMC4361A's hardware PID loop (already wired in firmware for X/Y/Z) closes both gaps. PID continuously drives `ENC_POS → X_TARGET` during the move *and* holds position at rest. Position error cannot accumulate because every commanded position is referenced to encoder counts, not to the previous (potentially drifted) XACTUAL.

## What changed

### Firmware

- `commands.cpp:135,139` — Widen W/W2 `target_tolerance` / `pid_tolerance` from `2 → 20` microsteps. Tolerance is in microstep units (XACTUAL vs ENC_POS, after the chip scales encoder counts to match). With 200 fullsteps/rev × 64 microstepping = 12,800 microsteps/rev, 20 microsteps ≈ **0.56°** physical angle — well inside the 45°-per-slot accuracy needed for filter selection. The previous value of 2 (≈0.056°) was overkill for slot-level positioning and risked PID dither at rest.

### Host

- `cephla.py:120-124` — **Bug fix.** `Microcontroller.turn_on_stage_pid(self, axis)` takes a single positional arg, but the call site passed `(axis, ENABLE_PID_W)`. This was a latent `TypeError` that would fire the instant `HAS_ENCODER_W=True`. Fixed by dropping the extra arg and gating the call on `if ENABLE_PID_W:` — so `HAS_ENCODER_W=True, ENABLE_PID_W=False` is now a valid configuration (configure encoder for diagnostics, but leave PID disengaged).

### Tests

- `test_filter_wheel.py` — Patch `ENABLE_PID_W=True` in the existing PID-enable test so it still exercises the call, and assert `assert_called_once_with(expected_axis)` to guard against the old `(axis, ENABLE_PID_W)` signature regression. Add a new test for the `HAS_ENCODER_W=True / ENABLE_PID_W=False` cell. Both tests are parametrized over W (motor_slot=3) and W2 (motor_slot=4), matching the `AXIS_PARAMS` pattern used by the adjacent `TestSquidFilterWheelAbsoluteMove` class.

## Bench validation (out of PR scope, machine-side)

Enabling on a real machine requires three machine-config / verification steps that don't belong in this PR:

1. Set `has_encoder_w = True` and `enable_pid_w = True` under `[GENERAL]` in the machine `.ini`. The existing override loader in `control/_def.py` picks these up.
2. Confirm `transitions_per_revolution = 4000` (`_def.py:1080,1087`) matches the actual encoder CPR. If not, override per wheel in the multi-wheel YAML.
3. Power up with the changes, command a small `MOVE_W`, read `ENC_POS` via SPI/tools. If encoder direction is opposite to commanded delta, flip `ENCODER_FLIP_DIR_W = True` in `_def.py:695`.

## Relationship to #540

Complementary, not overlapping:

| Failure mode | Caught by #540 | Caught by this PR |
|---|---|---|
| Move callback never executed (silent ack) | ✅ `CMD_EXECUTION_ERROR` | — |
| Motor moved, but lost steps mid-ramp | ❌ (XACTUAL still reads target) | ✅ PID auto-corrects via `ENC_POS` |
| Wheel drifted while idle (no detent) | ❌ | ✅ PID holds position at rest |
| Relative-move chaining drift | ✅ Absolute MOVETO | ✅ (also via encoder anchoring) |

#540's design is "containment via absolute addressing + report errors honestly". This PR adds "active correction via encoder", which is what a detent-less filter wheel actually needs.

## Test plan

- [x] `pytest tests/squid/test_filter_wheel.py` — 28 passed (24 existing + 4 parametrized: PID-on × {W, W2} and PID-off × {W, W2})
- [x] `black --config pyproject.toml --check` clean on edited Python files
- [ ] **Bench**: flash firmware to a test Teensy, enable flags in machine .ini, verify `transitions_per_revolution` and `ENCODER_FLIP_DIR_W` empirically
- [ ] **Bench**: 100-cycle drift test (home → cycle through all 8 slots × 100 → verify encoder ends within tolerance of expected) to confirm error doesn't accumulate
- [ ] **Bench**: listen for dither at rest after a move settles; if audible, loosen `target_tolerance` further before changing PID gains

🤖 Generated with [Claude Code](https://claude.com/claude-code)