### PR TITLE
config: migrate filter_controller_enable to USE_EMISSION_FILTER_WHEEL

### DIFF
--- a/software/configurations/configuration_Squid+.ini
+++ b/software/configurations/configuration_Squid+.ini
@@ -4,6 +4,8 @@ version = 2.0
 camera_type = Toupcam
 _camera_type_options = [Default, FLIR, Toupcam, Hamamatsu]
 controller_sn = None
+USE_EMISSION_FILTER_WHEEL = False
+EMISSION_FILTER_WHEEL_TYPE = "SQUID"
 support_scimicroscopy_led_array = False
 scimicroscopy_led_array_sn = None
 scimicroscopy_led_array_distance = 50
@@ -152,9 +154,6 @@ default_multipoint_ny = 1
 
 inverted_objective = True
 _inverted_objective_options = [True, False]
-
-filter_controller_enable = False
-_filter_controller_enable_options = [True, False]
 
 illumination_intensity_factor = 0.6
 

--- a/software/configurations/configuration_Squid+_Cicero_LDI.ini
+++ b/software/configurations/configuration_Squid+_Cicero_LDI.ini
@@ -1,7 +1,11 @@
 [GENERAL]
+version = 2.0
+
 camera_type = Hamamatsu
 _camera_type_options = [Default, FLIR, Toupcam, Hamamatsu, Tucsen]
 controller_sn = None
+USE_EMISSION_FILTER_WHEEL = False
+EMISSION_FILTER_WHEEL_TYPE = "SQUID"
 support_scimicroscopy_led_array = False
 scimicroscopy_led_array_sn = None
 scimicroscopy_led_array_distance = 50
@@ -156,9 +160,6 @@ default_multipoint_ny = 1
 
 inverted_objective = True
 _inverted_objective_options = [True, False]
-
-filter_controller_enable = False
-_filter_controller_enable_options = [True, False]
 
 illumination_intensity_factor = 1
 

--- a/software/configurations/configuration_Squid+_Kinetix_LDI_XLight_Xeryon.ini
+++ b/software/configurations/configuration_Squid+_Kinetix_LDI_XLight_Xeryon.ini
@@ -170,9 +170,6 @@ default_multipoint_ny = 1
 inverted_objective = True
 _inverted_objective_options = [True, False]
 
-filter_controller_enable = False
-_filter_controller_enable_options = [True, False]
-
 illumination_intensity_factor = 1
 
 [CAMERA_CONFIG]

--- a/software/configurations/configuration_Squid+_Tucsen.ini
+++ b/software/configurations/configuration_Squid+_Tucsen.ini
@@ -4,6 +4,8 @@ version = 2.0
 camera_type = Tucsen
 _camera_type_options = [Default, FLIR, Toupcam, Hamamatsu, Tucsen]
 controller_sn = None
+USE_EMISSION_FILTER_WHEEL = False
+EMISSION_FILTER_WHEEL_TYPE = "SQUID"
 support_scimicroscopy_led_array = False
 scimicroscopy_led_array_sn = None
 scimicroscopy_led_array_distance = 50
@@ -152,9 +154,6 @@ default_multipoint_ny = 1
 
 inverted_objective = True
 _inverted_objective_options = [True, False]
-
-filter_controller_enable = False
-_filter_controller_enable_options = [True, False]
 
 illumination_intensity_factor = 0.6
 

--- a/software/configurations/configuration_Squid+_Tucsen_Libra.ini
+++ b/software/configurations/configuration_Squid+_Tucsen_Libra.ini
@@ -4,6 +4,8 @@ version = 2.0
 camera_type = Tucsen
 _camera_type_options = [Default, FLIR, Toupcam, Hamamatsu, Tucsen]
 controller_sn = None
+USE_EMISSION_FILTER_WHEEL = False
+EMISSION_FILTER_WHEEL_TYPE = "SQUID"
 support_scimicroscopy_led_array = False
 scimicroscopy_led_array_sn = None
 scimicroscopy_led_array_distance = 50
@@ -152,9 +154,6 @@ default_multipoint_ny = 1
 
 inverted_objective = True
 _inverted_objective_options = [True, False]
-
-filter_controller_enable = False
-_filter_controller_enable_options = [True, False]
 
 illumination_intensity_factor = 0.6
 


### PR DESCRIPTION
## Summary
- Rename `filter_controller_enable` to `USE_EMISSION_FILTER_WHEEL` and add `EMISSION_FILTER_WHEEL_TYPE = \"SQUID\"` across the Squid+ configs (Squid+, Cicero LDI, Kinetix LDI XLight Xeryon, Tucsen, Tucsen Libra).
- Add `version = 2.0` to the Cicero LDI config to match the other Squid+ variants.
- Normalize trailing newlines in the Squid+, Tucsen, and Tucsen Libra configs.

## Test plan
- [ ] Launch each affected config in simulation and confirm the emission filter wheel is correctly disabled by default.
- [ ] Confirm no remaining references to `filter_controller_enable` in the configs being shipped to instruments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)