### PR TITLE
fix: clear line-profiler preview when toggled off mid-drawing

### DIFF
--- a/software/control/core/core.py
+++ b/software/control/core/core.py
@@ -824,6 +824,7 @@ class ImageDisplayWindow(QMainWindow):
         self.line_profiler_plot.setLabel("bottom", "Position")
         self.line_profiler_widget.hide()  # Initially hidden
         self.line_profiler_manual_range = False  # Flag to track if y-range is manually set
+        self.line_profiler_plot.sigRangeChanged.connect(self._on_range_changed)
 
         # Create splitter
         self.splitter = QSplitter(Qt.Vertical)
@@ -928,9 +929,6 @@ class ImageDisplayWindow(QMainWindow):
             self.line_start_pos = None
             self.line_end_pos = None
             self._active_view().setCursor(self.normal_cursor)
-
-        # Connect to the view range changed signal to detect manual range changes
-        self.line_profiler_plot.sigRangeChanged.connect(self._on_range_changed)
 
     def _on_range_changed(self, view_range):
         """Handle manual range changes in the line profiler plot."""

--- a/software/control/core/core.py
+++ b/software/control/core/core.py
@@ -923,19 +923,11 @@ class ImageDisplayWindow(QMainWindow):
             self.line_profiler_widget.hide()
             if self.line_roi is not None:
                 self.line_roi.hide()
-            # Clean up any in-progress drawing preview (first click made, second click not yet)
-            view = self.graphics_widget.view.getView() if self.show_LUT else self.graphics_widget.view
-            if self.preview_line is not None:
-                view.removeItem(self.preview_line)
-                self.preview_line = None
-            if self.start_point_marker is not None:
-                view.removeItem(self.start_point_marker)
-                self.start_point_marker = None
+            self._remove_line_preview_items()
             self.is_drawing_line = False
             self.line_start_pos = None
             self.line_end_pos = None
-            # Reset cursor to normal
-            view.setCursor(self.normal_cursor)
+            self._active_view().setCursor(self.normal_cursor)
 
         # Connect to the view range changed signal to detect manual range changes
         self.line_profiler_plot.sigRangeChanged.connect(self._on_range_changed)
@@ -943,6 +935,18 @@ class ImageDisplayWindow(QMainWindow):
     def _on_range_changed(self, view_range):
         """Handle manual range changes in the line profiler plot."""
         self.line_profiler_manual_range = True
+
+    def _active_view(self):
+        return self.graphics_widget.view.getView() if self.show_LUT else self.graphics_widget.view
+
+    def _remove_line_preview_items(self):
+        view = self._active_view()
+        if self.preview_line is not None:
+            view.removeItem(self.preview_line)
+            self.preview_line = None
+        if self.start_point_marker is not None:
+            view.removeItem(self.start_point_marker)
+            self.start_point_marker = None
 
     def create_line_roi(self):
         """Create a line ROI for intensity profiling."""
@@ -1119,11 +1123,7 @@ class ImageDisplayWindow(QMainWindow):
         """Handle mouse clicks for both line drawing and other interactions."""
         if self.is_drawing_line:
             try:
-                # Get the view that received the click
-                if self.show_LUT:
-                    view = self.graphics_widget.view.getView()
-                else:
-                    view = self.graphics_widget.view
+                view = self._active_view()
 
                 # Convert click position to view coordinates
                 pos = evt.pos()
@@ -1142,37 +1142,17 @@ class ImageDisplayWindow(QMainWindow):
                         pen=pg.mkPen("y", width=2),
                         brush=pg.mkBrush("y"),
                     )
-                    if self.show_LUT:
-                        self.graphics_widget.view.getView().addItem(self.start_point_marker)
-                    else:
-                        self.graphics_widget.view.addItem(self.start_point_marker)
+                    view.addItem(self.start_point_marker)
 
                     # Create preview line
                     self.preview_line = pg.PlotDataItem(pen=pg.mkPen("y", width=2, style=Qt.DashLine))
-                    if self.show_LUT:
-                        self.graphics_widget.view.getView().addItem(self.preview_line)
-                    else:
-                        self.graphics_widget.view.addItem(self.preview_line)
+                    view.addItem(self.preview_line)
                 else:
                     # Second click - finish drawing
                     self.line_end_pos = (view_coord.x(), view_coord.y())
                     self._log.info(f"Line end position set to: {self.line_end_pos}")
 
-                    # Remove preview line and start point marker
-                    if self.preview_line is not None:
-                        if self.show_LUT:
-                            self.graphics_widget.view.getView().removeItem(self.preview_line)
-                        else:
-                            self.graphics_widget.view.removeItem(self.preview_line)
-                        self.preview_line = None
-
-                    if self.start_point_marker is not None:
-                        if self.show_LUT:
-                            self.graphics_widget.view.getView().removeItem(self.start_point_marker)
-                        else:
-                            self.graphics_widget.view.removeItem(self.start_point_marker)
-                        self.start_point_marker = None
-
+                    self._remove_line_preview_items()
                     self.create_line_roi()
                     self.is_drawing_line = False
                     # Reset cursor to normal
@@ -1182,19 +1162,7 @@ class ImageDisplayWindow(QMainWindow):
                 self.is_drawing_line = False
                 self.line_start_pos = None
                 self.line_end_pos = None
-                # Clean up any remaining preview items
-                if self.preview_line is not None:
-                    if self.show_LUT:
-                        self.graphics_widget.view.getView().removeItem(self.preview_line)
-                    else:
-                        self.graphics_widget.view.removeItem(self.preview_line)
-                    self.preview_line = None
-                if self.start_point_marker is not None:
-                    if self.show_LUT:
-                        self.graphics_widget.view.getView().removeItem(self.start_point_marker)
-                    else:
-                        self.graphics_widget.view.removeItem(self.start_point_marker)
-                    self.start_point_marker = None
+                self._remove_line_preview_items()
             return
 
         # Handle double clicks for other purposes

--- a/software/control/core/core.py
+++ b/software/control/core/core.py
@@ -923,11 +923,19 @@ class ImageDisplayWindow(QMainWindow):
             self.line_profiler_widget.hide()
             if self.line_roi is not None:
                 self.line_roi.hide()
+            # Clean up any in-progress drawing preview (first click made, second click not yet)
+            view = self.graphics_widget.view.getView() if self.show_LUT else self.graphics_widget.view
+            if self.preview_line is not None:
+                view.removeItem(self.preview_line)
+                self.preview_line = None
+            if self.start_point_marker is not None:
+                view.removeItem(self.start_point_marker)
+                self.start_point_marker = None
+            self.is_drawing_line = False
+            self.line_start_pos = None
+            self.line_end_pos = None
             # Reset cursor to normal
-            if self.show_LUT:
-                self.graphics_widget.view.getView().setCursor(self.normal_cursor)
-            else:
-                self.graphics_widget.view.setCursor(self.normal_cursor)
+            view.setCursor(self.normal_cursor)
 
         # Connect to the view range changed signal to detect manual range changes
         self.line_profiler_plot.sigRangeChanged.connect(self._on_range_changed)


### PR DESCRIPTION
## Summary
- If the user opened Line Profiler, placed the start point on the image, then toggled the button off before placing the end point, the yellow start dot and dashed preview line stayed on the image.
- Drawing state flags (`is_drawing_line`, `line_start_pos`, `line_end_pos`) were also left set, which would break the next drawing attempt.
- Fix: in the toggle-off branch of `toggle_line_profiler`, remove any in-progress `preview_line` / `start_point_marker` from the view and reset the drawing state.

## Test plan
- [x] Open the GUI, click **Line Profiler**, click once on the image to place the start dot.
- [x] Click **Line Profiler** again to quit — confirm the yellow dot and dashed line disappear.
- [x] Click **Line Profiler** a third time and draw a full line (two clicks) — confirm a fresh ROI is created normally.
- [x] Existing flow (two consecutive clicks to create an ROI, then toggle off to hide it, toggle on to show it) still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)