### PR TITLE
log: enable per-acquisition log by default

### DIFF
--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -833,7 +833,7 @@ RESUME_LIVE_AFTER_ACQUISITION = True
 
 # When enabled, each multipoint acquisition will write a second log file scoped to that acquisition at:
 #   <base_path>/<experiment_ID>/acquisition.log
-ENABLE_PER_ACQUISITION_LOG = False
+ENABLE_PER_ACQUISITION_LOG = True
 
 # Memory profiling - when enabled, shows real-time RAM usage in status bar during acquisition
 # and logs periodic memory snapshots to help diagnose memory issues


### PR DESCRIPTION
## Summary
- Flip `ENABLE_PER_ACQUISITION_LOG` in `control/_def.py` from `False` to `True` so each multipoint acquisition writes a scoped `acquisition.log` next to the experiment data by default.

## Test plan
- [ ] Run a multipoint acquisition and confirm `<base_path>/<experiment_ID>/acquisition.log` is created and populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)