### PR TITLE
fix(firmware): close strobe ISR race that leaves old channel HIGH on switch

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -23,6 +23,18 @@ pip install platformio
 brew install platformio
 ```
 
+`pio run -t upload` shells out to [`teensy_loader_cli`](https://github.com/PaulStoffregen/teensy_loader_cli) to flash the board, so install that too:
+
+```bash
+# Ubuntu / Debian
+sudo apt install teensy-loader-cli
+
+# macOS
+brew install teensy_loader_cli
+```
+
+On Linux, also install the [PJRC udev rules](https://www.pjrc.com/teensy/00-teensy.rules) into `/etc/udev/rules.d/` so non-root users can flash.
+
 ### Quick Start
 
 ```bash

--- a/firmware/controller/src/constants.h
+++ b/firmware/controller/src/constants.h
@@ -10,8 +10,10 @@
 // Version 1.0 = first version with multi-port illumination support
 // Version 1.1 = serial watchdog for illumination auto-shutoff
 // Version 1.2 = CMD_EXECUTION_ERROR reported on failed moves + MOVETO_W2 command
+// Version 1.3 = strobe ISR latches illumination source at start (race fix when
+//               channel switched during live HW-triggered acquisition)
 #define FIRMWARE_VERSION_MAJOR 1
-#define FIRMWARE_VERSION_MINOR 2
+#define FIRMWARE_VERSION_MINOR 3
 
 #include "def/def_v1.h"
 

--- a/firmware/controller/src/functions.cpp
+++ b/firmware/controller/src/functions.cpp
@@ -340,7 +340,15 @@ static void turn_off_illumination_source(int source)
       // Unknown source code: fall back to a global shutdown so a forgotten
       // case (e.g. a future D6 in the ON switch but not here) can't leave
       // a pin stuck HIGH — the original bug class this fix is preventing.
-      turn_off_all_ports();
+      // turn_off_all_ports() unconditionally clears illumination_is_on, which
+      // would violate this helper's "doesn't touch illumination_is_on" contract
+      // and bypass the ISR's guarded clear (which keeps the flag set if Python
+      // has switched to a different active source). Save and restore the flag.
+      {
+        bool prev_illumination_is_on = illumination_is_on;
+        turn_off_all_ports();
+        illumination_is_on = prev_illumination_is_on;
+      }
       break;
   }
 }

--- a/firmware/controller/src/functions.cpp
+++ b/firmware/controller/src/functions.cpp
@@ -340,15 +340,10 @@ static void turn_off_illumination_source(int source)
       // Unknown source code: fall back to a global shutdown so a forgotten
       // case (e.g. a future D6 in the ON switch but not here) can't leave
       // a pin stuck HIGH — the original bug class this fix is preventing.
-      // turn_off_all_ports() unconditionally clears illumination_is_on, which
-      // would violate this helper's "doesn't touch illumination_is_on" contract
-      // and bypass the ISR's guarded clear (which keeps the flag set if Python
-      // has switched to a different active source). Save and restore the flag.
-      {
-        bool prev_illumination_is_on = illumination_is_on;
-        turn_off_all_ports();
-        illumination_is_on = prev_illumination_is_on;
-      }
+      // Use the pins-only variant so this helper honors its "doesn't touch
+      // illumination_is_on" contract; the ISR call sites own the guarded
+      // clear of that flag.
+      turn_off_all_ports_pins_only();
       break;
   }
 }
@@ -478,10 +473,11 @@ void set_port_intensity(int port_index, uint16_t intensity)
   illumination_port_intensity[port_index] = intensity;  // Store unscaled for reference
 }
 
-// Safety shutdown: turns off ALL illumination (discrete ports + LED matrix).
-// Called by the serial watchdog and TURN_OFF_ALL_PORTS command.
-// Intentionally broad: when this fires, everything should go dark.
-void turn_off_all_ports()
+// Drive every illumination port LOW and clear the LED matrix without touching
+// the global illumination_is_on flag. Used by turn_off_illumination_source()'s
+// default-case fallback, where the ISR call sites own the guarded clear of
+// illumination_is_on and must not see a transient false from this helper.
+static void turn_off_all_ports_pins_only()
 {
   for (int i = 0; i < NUM_ILLUMINATION_PORTS; i++)
   {
@@ -493,6 +489,14 @@ void turn_off_all_ports()
     }
   }
   clear_matrix(matrix);
+}
+
+// Safety shutdown: turns off ALL illumination (discrete ports + LED matrix).
+// Called by the serial watchdog and TURN_OFF_ALL_PORTS command.
+// Intentionally broad: when this fires, everything should go dark.
+void turn_off_all_ports()
+{
+  turn_off_all_ports_pins_only();
   illumination_is_on = false;
 }
 

--- a/firmware/controller/src/functions.cpp
+++ b/firmware/controller/src/functions.cpp
@@ -210,6 +210,9 @@ IntervalTimer strobeTimer;
 
 CRGB matrix[NUM_LEDS] = {0};
 
+// Forward declaration: defined later in this file alongside turn_off_all_ports.
+static void turn_off_all_ports_pins_only();
+
 // Turn on the port/matrix corresponding to a specific source code, without
 // touching the global illumination_is_on flag. The strobe ISR uses this with
 // the latched source so the ON pin matches what the OFF helper will turn off

--- a/firmware/controller/src/functions.cpp
+++ b/firmware/controller/src/functions.cpp
@@ -195,6 +195,11 @@ bool strobe_on[6] = {false, false, false, false, false, false};
 unsigned long strobe_delay[6] = {0, 0, 0, 0, 0, 0};
 uint32_t illumination_on_time[6] = {0, 0, 0, 0, 0, 0};
 long timestamp_trigger_rising_edge[6] = {0, 0, 0, 0, 0, 0};
+// Source latched at strobe start, used at strobe end to turn off the SAME
+// port we turned on. Without this, a channel switch (set_illumination from
+// Python) between strobe start and end would cause the strobe end to turn off
+// the new channel and leave the old one stuck HIGH.
+int strobe_active_source[6] = {0, 0, 0, 0, 0, 0};
 volatile uint8_t trigger_mode = 0;
 IntervalTimer strobeTimer;
 
@@ -267,14 +272,17 @@ void turn_on_illumination()
   }
 }
 
-void turn_off_illumination()
+// Turn off the port/matrix corresponding to a specific source code, without
+// touching the global illumination_is_on flag. The strobe ISR uses this to
+// turn off the SAME source it turned on at strobe start, even if Python has
+// since updated `illumination_source` while changing channels.
+static void turn_off_illumination_source(int source)
 {
-  // Update per-port state for D1-D5 sources (backward compatibility with new multi-port tracking)
-  int port_index = illumination_source_to_port_index(illumination_source);
+  int port_index = illumination_source_to_port_index(source);
   if (port_index >= 0)
     illumination_port_is_on[port_index] = false;
 
-  switch(illumination_source)
+  switch(source)
   {
     case ILLUMINATION_SOURCE_LED_ARRAY_FULL:
       clear_matrix(matrix);
@@ -321,6 +329,11 @@ void turn_off_illumination()
       digitalWrite(PIN_ILLUMINATION_D5, LOW);
       break;
   }
+}
+
+void turn_off_illumination()
+{
+  turn_off_illumination_source(illumination_source);
   illumination_is_on = false;
 }
 
@@ -474,9 +487,14 @@ void ISR_strobeTimer()
         if ( ((micros() - timestamp_trigger_rising_edge[camera_channel]) >= strobe_delay[camera_channel]) && strobe_output_level[camera_channel] == LOW )
         {
           strobe_output_level[camera_channel] = HIGH;
+          // Latch the source we turn on, so we turn off the same one below
+          // even if illumination_source changes during the pulse.
+          strobe_active_source[camera_channel] = illumination_source;
           turn_on_illumination();
           delayMicroseconds(illumination_on_time[camera_channel]);
-          turn_off_illumination();
+          turn_off_illumination_source(strobe_active_source[camera_channel]);
+          if (illumination_source == strobe_active_source[camera_channel])
+            illumination_is_on = false;
           strobe_output_level[camera_channel] = LOW;
           control_strobe[camera_channel] = false;
         }
@@ -486,13 +504,23 @@ void ISR_strobeTimer()
         // start the strobe
         if ( ((micros() - timestamp_trigger_rising_edge[camera_channel]) >= strobe_delay[camera_channel]) && strobe_output_level[camera_channel] == LOW )
         {
+          // Latch source before turning on, so the strobe-end branch below
+          // turns off the SAME port even if Python changes illumination_source
+          // between start and end (the race that left e.g. 640 nm stuck HIGH
+          // after switching to 405 nm during live HW-triggered acquisition).
+          strobe_active_source[camera_channel] = illumination_source;
           turn_on_illumination();
           strobe_output_level[camera_channel] = HIGH;
         }
         // end the strobe
         if (((micros() - timestamp_trigger_rising_edge[camera_channel]) >= strobe_delay[camera_channel] + illumination_on_time[camera_channel]) && strobe_output_level[camera_channel] == HIGH)
         {
-          turn_off_illumination();
+          turn_off_illumination_source(strobe_active_source[camera_channel]);
+          // Only clear illumination_is_on if the active source is still the
+          // one we strobed. If Python has switched channels and explicitly
+          // turned on the new source, leave illumination_is_on as Python set it.
+          if (illumination_source == strobe_active_source[camera_channel])
+            illumination_is_on = false;
           strobe_output_level[camera_channel] = LOW;
           control_strobe[camera_channel] = false;
         }

--- a/firmware/controller/src/functions.cpp
+++ b/firmware/controller/src/functions.cpp
@@ -198,8 +198,9 @@ long timestamp_trigger_rising_edge[6] = {0, 0, 0, 0, 0, 0};
 // Source latched at strobe start, used at strobe end to turn off the SAME
 // port we turned on. Without this, a channel switch (set_illumination from
 // Python) between strobe start and end would cause the strobe end to turn off
-// the new channel and leave the old one stuck HIGH.
-int strobe_active_source[6] = {0, 0, 0, 0, 0, 0};
+// the new channel and leave the old one stuck HIGH. Written and read only
+// inside ISR_strobeTimer, so neither volatile nor noInterrupts() are required.
+static int strobe_active_source[6] = {0, 0, 0, 0, 0, 0};
 volatile uint8_t trigger_mode = 0;
 IntervalTimer strobeTimer;
 
@@ -209,16 +210,17 @@ IntervalTimer strobeTimer;
 
 CRGB matrix[NUM_LEDS] = {0};
 
-void turn_on_illumination()
+// Turn on the port/matrix corresponding to a specific source code, without
+// touching the global illumination_is_on flag. The strobe ISR uses this with
+// the latched source so the ON pin matches what the OFF helper will turn off
+// (symmetric with turn_off_illumination_source()).
+static void turn_on_illumination_source(int source)
 {
-  illumination_is_on = true;
-
-  // Update per-port state for D1-D5 sources (backward compatibility with new multi-port tracking)
-  int port_index = illumination_source_to_port_index(illumination_source);
+  int port_index = illumination_source_to_port_index(source);
   if (port_index >= 0)
     illumination_port_is_on[port_index] = true;
 
-  switch (illumination_source)
+  switch (source)
   {
     case ILLUMINATION_SOURCE_LED_ARRAY_FULL:
       turn_on_LED_matrix_pattern(matrix, ILLUMINATION_SOURCE_LED_ARRAY_FULL, led_matrix_r, led_matrix_g, led_matrix_b);
@@ -270,6 +272,12 @@ void turn_on_illumination()
         digitalWrite(PIN_ILLUMINATION_D5, HIGH);
       break;
   }
+}
+
+void turn_on_illumination()
+{
+  illumination_is_on = true;
+  turn_on_illumination_source(illumination_source);
 }
 
 // Turn off the port/matrix corresponding to a specific source code, without
@@ -327,6 +335,12 @@ static void turn_off_illumination_source(int source)
       break;
     case ILLUMINATION_D5:
       digitalWrite(PIN_ILLUMINATION_D5, LOW);
+      break;
+    default:
+      // Unknown source code: fall back to a global shutdown so a forgotten
+      // case (e.g. a future D6 in the ON switch but not here) can't leave
+      // a pin stuck HIGH — the original bug class this fix is preventing.
+      turn_off_all_ports();
       break;
   }
 }
@@ -486,11 +500,14 @@ void ISR_strobeTimer()
         // if the illumination on time is smaller than 30 ms, use delayMicroseconds to control the pulse length to avoid pulse length jitter
         if ( ((micros() - timestamp_trigger_rising_edge[camera_channel]) >= strobe_delay[camera_channel]) && strobe_output_level[camera_channel] == LOW )
         {
-          strobe_output_level[camera_channel] = HIGH;
           // Latch the source we turn on, so we turn off the same one below
-          // even if illumination_source changes during the pulse.
+          // even if illumination_source changes during the pulse. Both ON and
+          // OFF helpers below take the latched source explicitly, so the pin
+          // toggled HIGH here is exactly the one toggled LOW after the delay.
           strobe_active_source[camera_channel] = illumination_source;
-          turn_on_illumination();
+          illumination_is_on = true;
+          turn_on_illumination_source(strobe_active_source[camera_channel]);
+          strobe_output_level[camera_channel] = HIGH;
           delayMicroseconds(illumination_on_time[camera_channel]);
           turn_off_illumination_source(strobe_active_source[camera_channel]);
           if (illumination_source == strobe_active_source[camera_channel])
@@ -508,8 +525,11 @@ void ISR_strobeTimer()
           // turns off the SAME port even if Python changes illumination_source
           // between start and end (the race that left e.g. 640 nm stuck HIGH
           // after switching to 405 nm during live HW-triggered acquisition).
+          // Both helpers take the latched source explicitly to make the ON/OFF
+          // pair symmetric.
           strobe_active_source[camera_channel] = illumination_source;
-          turn_on_illumination();
+          illumination_is_on = true;
+          turn_on_illumination_source(strobe_active_source[camera_channel]);
           strobe_output_level[camera_channel] = HIGH;
         }
         // end the strobe

--- a/firmware/controller/src/globals.cpp
+++ b/firmware/controller/src/globals.cpp
@@ -130,7 +130,7 @@ bool enable_filterwheel_w2 = false;
 /***************************************************************************************************/
 /***************************************** illumination ********************************************/
 /***************************************************************************************************/
-int illumination_source = 0;
+volatile int illumination_source = 0;
 uint16_t illumination_intensity = 65535;
 // Illumination intensity scaling factor - scales DAC output for different hardware:
 //   0.6 = Squid LEDs (0-1.5V output range)
@@ -141,7 +141,7 @@ float illumination_intensity_factor = 0.6;
 uint8_t led_matrix_r = 0;
 uint8_t led_matrix_g = 0;
 uint8_t led_matrix_b = 0;
-bool illumination_is_on = false;
+volatile bool illumination_is_on = false;
 
 // Multi-port illumination control (all ports off and at zero intensity by default)
 bool illumination_port_is_on[NUM_ILLUMINATION_PORTS] = {false};

--- a/firmware/controller/src/globals.h
+++ b/firmware/controller/src/globals.h
@@ -133,13 +133,15 @@ extern bool enable_filterwheel_w2;
 /***************************************************************************************************/
 /***************************************** illumination ********************************************/
 /***************************************************************************************************/
-extern int illumination_source;
+// volatile: read/written from both ISR_strobeTimer() and main-loop command callbacks
+extern volatile int illumination_source;
 extern uint16_t illumination_intensity;
 extern float illumination_intensity_factor;
 extern uint8_t led_matrix_r;
 extern uint8_t led_matrix_g;
 extern uint8_t led_matrix_b;
-extern bool illumination_is_on;
+// volatile: cleared at strobe end inside ISR, read by set_illumination() in main loop
+extern volatile bool illumination_is_on;
 
 // Multi-port illumination control (supports up to 16 ports D1-D16)
 #define NUM_ILLUMINATION_PORTS 16

--- a/software/control/microcontroller.py
+++ b/software/control/microcontroller.py
@@ -187,12 +187,14 @@ class SimSerial(AbstractCephlaMicroSerial):
     # v1.0: multi-port illumination support
     # v1.1: serial watchdog for illumination auto-shutoff
     # v1.2: CMD_EXECUTION_ERROR reported on failed moves + MOVETO_W2 command
+    # v1.3: strobe ISR latches illumination source at start (race fix for
+    #       channel switch during live HW-triggered acquisition)
     FIRMWARE_VERSION_MAJOR = 1
-    FIRMWARE_VERSION_MINOR = 2
+    FIRMWARE_VERSION_MINOR = 3
 
     @staticmethod
     def response_bytes_for(
-        command_id, execution_status, x, y, z, theta, joystick_button, switch, firmware_version=(1, 2)
+        command_id, execution_status, x, y, z, theta, joystick_button, switch, firmware_version=(1, 3)
     ) -> bytes:
         """
         - byte 0: command ID (1 byte)

--- a/software/tests/squid/test_filter_wheel.py
+++ b/software/tests/squid/test_filter_wheel.py
@@ -19,7 +19,7 @@ def _make_squid_config(motor_slot: int = 3) -> SquidFilterWheelConfig:
     )
 
 
-def _make_mock_mc(firmware_version=(1, 2)) -> MagicMock:
+def _make_mock_mc(firmware_version=(1, 3)) -> MagicMock:
     """MagicMock microcontroller with a configured firmware_version."""
     mc = MagicMock()
     mc.firmware_version = firmware_version

--- a/software/tests/test_multiport_illumination_bugs.py
+++ b/software/tests/test_multiport_illumination_bugs.py
@@ -380,7 +380,7 @@ class TestResponseVersionParsing:
         mcu.wait_till_operation_is_completed()
 
         # Should now have version from SimSerial
-        assert mcu.firmware_version == (1, 2)
+        assert mcu.firmware_version == (1, 3)
         mcu.close()
 
     def test_supports_multi_port_false_for_v0(self):

--- a/software/tests/test_multiport_illumination_edge_cases.py
+++ b/software/tests/test_multiport_illumination_edge_cases.py
@@ -254,7 +254,7 @@ class TestFirmwareVersionCheck:
         assert hasattr(mcu, "firmware_version")
         assert mcu.firmware_version is not None
         # Version should already be populated - no need to send a command first
-        assert mcu.firmware_version == (1, 2)
+        assert mcu.firmware_version == (1, 3)
 
     def test_supports_multi_port_accurate_at_init(self, mcu):
         """supports_multi_port() should return accurate result immediately after init."""

--- a/software/tests/test_multiport_illumination_protocol.py
+++ b/software/tests/test_multiport_illumination_protocol.py
@@ -485,7 +485,7 @@ class TestFirmwareVersionBehavior:
         mcu.wait_till_operation_is_completed()
 
         # Now version should be detected (SimSerial reports the latest simulated version)
-        assert mcu.firmware_version == (1, 2)
+        assert mcu.firmware_version == (1, 3)
 
     def test_supports_multi_port_true_for_v1(self, mcu):
         """supports_multi_port() should return True for v1.0+."""
@@ -507,7 +507,7 @@ class TestFirmwareVersionBehavior:
         mcu.wait_till_operation_is_completed()
         v3 = mcu.firmware_version
 
-        assert v1 == v2 == v3 == (1, 2)
+        assert v1 == v2 == v3 == (1, 3)
 
 
 class TestMultiPortMaskEdgeCases:

--- a/software/tests/test_watchdog.py
+++ b/software/tests/test_watchdog.py
@@ -129,4 +129,4 @@ class TestFirmwareVersionForWatchdog:
         """SimSerial should report the simulated firmware version after a command."""
         mcu.turn_off_all_ports()
         mcu.wait_till_operation_is_completed()
-        assert mcu.firmware_version == (1, 2)
+        assert mcu.firmware_version == (1, 3)


### PR DESCRIPTION
## Summary

Fixes a race in the Teensy firmware's strobe ISR where switching channels (e.g. 640 nm → 405 nm) during live HW-triggered acquisition could leave the old channel's port stuck HIGH. The strobe-start and strobe-end branches both read the global `illumination_source`; if Python's channel-switch sequence (`turn_off_illumination` → `set_illumination(new)` → `turn_on_illumination`) ran between them, the strobe-end turned off the *new* port and the *old* one stayed energized.

- Latch `illumination_source` into a per-camera-channel array `strobe_active_source[]` at strobe start, and use that latched value at strobe end — the ISR always extinguishes the port it lit.
- Extract symmetric `turn_on_illumination_source(int)` and `turn_off_illumination_source(int)` helpers; the public `turn_on_illumination()`/`turn_off_illumination()` keep their existing behavior (read the global, update `illumination_is_on`).
- Mark `illumination_source` and `illumination_is_on` `volatile` (they cross the ISR/main-loop boundary on Cortex-M7).
- Add a `default:` case in `turn_off_illumination_source()` that falls back to `turn_off_all_ports()` — defensive against a future D-port being added to the ON switch but forgotten in the OFF switch (the same failure class this fix prevents).
- Bump firmware 1.2 → 1.3, with matching bump in `FirmwareSimSerial` so version-gated Python code stays consistent under `--simulation`.

## Test plan

- [x] PlatformIO build for Teensy 4.1 (`pio run -e teensy41`) — clean, no new warnings, `firmware.hex` produced
- [x] `pytest software/tests/control/test_firmware_sim_serial.py tests/control/test_microcontroller.py tests/squid/test_filter_wheel.py tests/control/test_def.py` — 87 passed, 1 pre-existing skip
- [x] `python3 main_hcs.py --simulation --verbose` — app boots clean, MCU heartbeats steady
- [ ] **Hardware verification still required** — the race lives in C++ ISR code that `FirmwareSimSerial` does not model. Flash to a real Teensy and reproduce the original repro (HW-triggered live → switch 640 → 405) to confirm 640 nm goes dark.

## Known follow-ups (not in this PR)

Surfaced by review, all pre-existing in master, deferred to keep this PR focused:

- `led_matrix_r/g/b`, `illumination_intensity`, and `illumination_port_is_on[]` are not `volatile` despite being read in ISR context.
- `set_illumination()`, `set_illumination_led_matrix()`, `turn_off_illumination()`, and `turn_off_all_ports()` are non-atomic vs the strobe ISR — main-loop callbacks don't use `noInterrupts()`.
- `set_illumination()` calling `turn_on_illumination()` mid-strobe (when `illumination_is_on==true`) can briefly drive two ports HIGH simultaneously.
- `turn_off_port()` doesn't clear `illumination_is_on`, so the multi-port API can desync the flag from the physical pin set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)