### PR TITLE
Change upload protocol from teensy-cli to teensy-gui

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -23,17 +23,11 @@ pip install platformio
 brew install platformio
 ```
 
-`pio run -t upload` shells out to [`teensy_loader_cli`](https://github.com/PaulStoffregen/teensy_loader_cli) to flash the board, so install that too:
+`pio run -t upload` flashes the board with the [Teensy Loader](https://www.pjrc.com/teensy/loader.html) application, which PlatformIO bundles in its Teensy platform tools (`tool-teensy`) — there is no separate uploader to install. During upload the Teensy Loader window opens, the board is automatically rebooted into the bootloader, and the firmware is flashed.
 
-```bash
-# Ubuntu / Debian
-sudo apt install teensy-loader-cli
+> **Note:** The Teensy Loader is a graphical application, so uploading normally requires a desktop (display) environment. On platforms where the GUI app is unavailable (e.g. Linux ARM), PlatformIO automatically falls back to the command-line loader (`teensy_loader_cli`).
 
-# macOS
-brew install teensy_loader_cli
-```
-
-On Linux, also install the [PJRC udev rules](https://www.pjrc.com/teensy/00-teensy.rules) into `/etc/udev/rules.d/` so non-root users can flash.
+On Linux, install the [PJRC udev rules](https://www.pjrc.com/teensy/00-teensy.rules) into `/etc/udev/rules.d/` so non-root users can flash. A copy ships with PlatformIO at `~/.platformio/packages/tool-teensy/00-teensy.rules`.
 
 ### Quick Start
 

--- a/firmware/controller/platformio.ini
+++ b/firmware/controller/platformio.ini
@@ -26,7 +26,7 @@ lib_deps =
     bakercp/PacketSerial@^1.4.0
 
 ; Upload settings
-upload_protocol = teensy-cli
+upload_protocol = teensy-gui
 
 ; Monitor settings
 monitor_speed = 2000000


### PR DESCRIPTION
## What

Switch the controller firmware's PlatformIO `upload_protocol` from `teensy-cli` to `teensy-gui`, and update the firmware README to match.

## Why

`teensy-gui` is the default upload protocol for Teensy boards in PlatformIO, and it's already what `firmware/joystick` uses (the joystick env doesn't override the protocol). The controller was the only env explicitly pinned to `teensy-cli`; this aligns it with the board default and the joystick.

Behavior difference:
- **`teensy-cli`** runs `teensy_reboot -s` followed by `teensy_loader_cli`, which is why the README told users to `apt install` / `brew install` `teensy_loader_cli` separately.
- **`teensy-gui`** runs `teensy_post_compile -reboot`, driving the **Teensy Loader GUI app**. Both `teensy_post_compile` and the GUI loader are bundled in PlatformIO's `tool-teensy` package, so there's no separate uploader to install, and the board auto-reboots into the bootloader.

## Changes

- `firmware/controller/platformio.ini`: `upload_protocol = teensy-cli` → `teensy-gui`
- `firmware/README.md`: drop the separate `teensy_loader_cli` install step; document the bundled Teensy Loader, the desktop/display requirement, the automatic CLI fallback on platforms without the GUI app (e.g. Linux ARM), and that the udev rules ship with `tool-teensy`.

## Notes

The Teensy Loader is a graphical app, so uploads normally need a desktop environment. On platforms where the GUI app is unavailable (e.g. Linux ARM), PlatformIO automatically falls back to `teensy_loader_cli`.
