### PR TITLE
fix: populate region_shapes for flexible/single/template regions

### DIFF
--- a/software/control/core/scan_coordinates.py
+++ b/software/control/core/scan_coordinates.py
@@ -317,6 +317,7 @@ class ScanCoordinates:
         if scan_coordinates:  # Only add region if there are valid coordinates
             self._log.info(f"Added Flexible Region: {region_id}")
             self.region_centers[region_id] = [center_x, center_y, center_z]
+            self.region_shapes[region_id] = "Square"
             self.region_fov_coordinates[region_id] = scan_coordinates
             self._update_callback(
                 AddScanCoordinateRegion(fov_centers=FovCenter.from_scan_coordinates(scan_coordinates))
@@ -329,6 +330,7 @@ class ScanCoordinates:
             raise ValueError(f"FOV with center (x,y)={center_x},{center_y} is not valid, cannot add region.")
 
         self.region_centers[region_id] = [center_x, center_y, center_z]
+        self.region_shapes[region_id] = "Square"
         self.region_fov_coordinates[region_id] = [(center_x, center_y)]
         self._update_callback(AddScanCoordinateRegion(fov_centers=[FovCenter(x_mm=center_x, y_mm=center_y)]))
 
@@ -353,6 +355,7 @@ class ScanCoordinates:
         if scan_coordinates:  # Only add region if there are valid coordinates
             self._log.info(f"Added Flexible Region: {region_id}")
             self.region_centers[region_id] = [center_x, center_y, center_z]
+            self.region_shapes[region_id] = "Square"
             self.region_fov_coordinates[region_id] = scan_coordinates
             self._update_callback(
                 AddScanCoordinateRegion(fov_centers=FovCenter.from_scan_coordinates(scan_coordinates))
@@ -459,6 +462,7 @@ class ScanCoordinates:
             if self.validate_coordinates(x, y):
                 scan_coordinates.append((x, y))
         self.region_centers[region_id] = [x_mm, y_mm, z_mm]
+        self.region_shapes[region_id] = "Square"
         self.region_fov_coordinates[region_id] = scan_coordinates
         self._update_callback(AddScanCoordinateRegion(fov_centers=FovCenter.from_scan_coordinates(scan_coordinates)))
 


### PR DESCRIPTION
## Summary

Fixes a `KeyError` that crashes the GUI when enabling **Use Focus Map** in flexible-multipoint acquisition after loading a region list.

## Bug

```
File "control/core/scan_coordinates.py", line 614, in get_region_shape
    return self.region_shapes[region_id]
KeyError: 'R0'
```

Repro: switch to flexible multipoint, load a list of regions (e.g. `R0..R3`), check **Use Focus Map** → crash.

## Root cause

`ScanCoordinates` keeps three parallel dicts keyed by `region_id`: `region_centers`, `region_fov_coordinates`, and `region_shapes`. Only `add_region` (well-plate) and `set_manual_coordinates` populate `region_shapes`. The other four add methods write the first two dicts but skip `region_shapes`:

- `add_flexible_region`
- `add_flexible_region_with_step_size`
- `add_single_fov_region`
- `add_template_region`

`validate_region` only checks `region_centers` and `region_fov_coordinates`, so it returns `True` for these regions and the subsequent `self.region_shapes[region_id]` lookup in `get_region_shape` raises `KeyError`. The focus-map grid generator hits this path through `region_contains_coordinate` → `get_region_shape`.

## Fix

Set `self.region_shapes[region_id] = "Square"` in the four missing add methods. `region_contains_coordinate` only special-cases `"Circle"` (radius check); rectangular grids correctly fall through to the bounding-box test, so `"Square"` is the right value for these grid-based regions.

## Test plan

- [x] Reproduce the crash on `master`: load region list in flexible mode, enable Use Focus Map → `KeyError`
- [x] Apply fix → enabling Use Focus Map works without exception
- [ ] Regression: well-plate mode and manual ROI still produce correct shape behavior (Circle/Square/Manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)