### PR TITLE
feat: reorderable channel acquisition sequence in multipoint widgets

### DIFF
--- a/software/control/channel_sequence.py
+++ b/software/control/channel_sequence.py
@@ -78,8 +78,6 @@ class ChannelOrderDelegate(QStyledItemDelegate):
     item data is never modified.
     """
 
-    _GUTTER_SAMPLE = "[99]  "  # widest expected badge (assumes <= 99 selected channels)
-
     def __init__(self, list_widget, controller=None):
         super().__init__(list_widget)
         self._controller = controller
@@ -108,9 +106,13 @@ class ChannelOrderDelegate(QStyledItemDelegate):
         painter.setPen(self._arrow_color(palette, enabled))
         painter.drawText(rect, Qt.AlignCenter, glyph)
 
-    @classmethod
-    def _gutter_width(cls, font_metrics):
-        return font_metrics.horizontalAdvance(cls._GUTTER_SAMPLE)
+    @staticmethod
+    def _gutter_width(font_metrics, count):
+        # Reserve room for the widest badge actually in use ("[9]" for <=9
+        # selected, "[99]" for 10-99) plus one trailing space, so the names align
+        # with only a tight gap after the bracket regardless of channel count.
+        digits = len(str(max(count, 1)))
+        return font_metrics.horizontalAdvance("[" + "9" * digits + "] ")
 
     @staticmethod
     def _arrow_rects(rect):
@@ -122,7 +124,8 @@ class ChannelOrderDelegate(QStyledItemDelegate):
 
     def sizeHint(self, option, index):
         size = super().sizeHint(option, index)
-        size.setWidth(size.width() + self._gutter_width(option.fontMetrics))
+        _, count = self._position_and_count(index)
+        size.setWidth(size.width() + self._gutter_width(option.fontMetrics, count))
         return size
 
     def paint(self, painter, option, index):
@@ -137,14 +140,14 @@ class ChannelOrderDelegate(QStyledItemDelegate):
 
         text_rect = style.subElementRect(QStyle.SE_ItemViewItemText, opt, widget)
         fm = opt.fontMetrics
-        gutter = self._gutter_width(fm)
+        position, count = self._position_and_count(index)
+        gutter = self._gutter_width(fm, count)
         alignment = Qt.AlignVCenter | Qt.AlignLeft
 
         painter.save()
         selected = bool(opt.state & QStyle.State_Selected)
         text_pen = opt.palette.color(QPalette.HighlightedText if selected else QPalette.Text)
         painter.setPen(text_pen)
-        position, count = self._position_and_count(index)
         name_rect = QRect(text_rect)
         name_rect.setLeft(text_rect.left() + gutter)
         if position is not None:

--- a/software/control/channel_sequence.py
+++ b/software/control/channel_sequence.py
@@ -59,8 +59,12 @@ def save_cached_order(cache_key, names, path=_CACHE_PATH):
             with open(path, "r") as f:
                 data = yaml.safe_load(f) or {}
         data[cache_key] = list(names)
-        with open(path, "w") as f:
+        # Atomic write: a crash mid-dump must not truncate the file shared by all
+        # three widgets and wipe every saved sequence.
+        tmp = path + ".tmp"
+        with open(tmp, "w") as f:
             yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+        os.replace(tmp, path)
     except Exception as e:
         _log.warning(f"Failed to save channel sequence cache: {e}")
 
@@ -167,7 +171,7 @@ class ChannelOrderDelegate(QStyledItemDelegate):
         # controller, consuming press AND release so the click does not also
         # toggle the row's selection.
         if self._controller is not None and self.badge_for_index(index) is not None:
-            if event.type() in (QEvent.MouseButtonPress, QEvent.MouseButtonRelease):
+            if event.type() in (QEvent.MouseButtonPress, QEvent.MouseButtonRelease) and event.button() == Qt.LeftButton:
                 pos = event.position().toPoint() if hasattr(event, "position") else event.pos()
                 up_rect, down_rect = self._arrow_rects(option.rect)
                 if up_rect.contains(pos) or down_rect.contains(pos):
@@ -195,7 +199,13 @@ class ChannelSequenceController(QObject):
         self._cache_key = cache_key
         self._cache_path = cache_path
         self._suppress = False
-        self._pending_rebuild = False
+        # Owned single-shot timer for the deferred selection rebuild. Parenting
+        # it to the controller (itself parented to the list) means it is
+        # destroyed with the widget, so a queued rebuild can never fire on a
+        # torn-down list.
+        self._rebuild_timer = QTimer(self)
+        self._rebuild_timer.setSingleShot(True)
+        self._rebuild_timer.timeout.connect(self._flush_selection_rebuild)
 
         list_widget.setSelectionMode(QAbstractItemView.MultiSelection)
         list_widget.setItemDelegate(ChannelOrderDelegate(list_widget, controller=self))
@@ -288,12 +298,9 @@ class ChannelSequenceController(QObject):
                 existing.add(n)
         self._included_order = new_order
         self._save()
-        if not self._pending_rebuild:
-            self._pending_rebuild = True
-            QTimer.singleShot(0, self._flush_selection_rebuild)
+        self._rebuild_timer.start(0)  # coalesce rapid selections into one deferred rebuild
 
     def _flush_selection_rebuild(self):
-        self._pending_rebuild = False
         self._rebuild()
 
     def move_up(self, name):

--- a/software/control/channel_sequence.py
+++ b/software/control/channel_sequence.py
@@ -211,6 +211,21 @@ class ChannelSequenceController(QObject):
         self._rebuild()
 
         list_widget.itemSelectionChanged.connect(self._on_selection_changed)
+        # Disable drag-to-select (see eventFilter): clicks toggle channels, but
+        # dragging across rows must not rubber-band a whole range. Cache the
+        # viewport so eventFilter compares by identity and never dereferences
+        # the (possibly torn-down) list.
+        self._viewport = list_widget.viewport()
+        self._viewport.installEventFilter(self)
+
+    def eventFilter(self, obj, event):
+        # Swallow mouse-move events over the list viewport while a button is
+        # held, so a click-drag does not extend the selection across rows.
+        # Discrete clicks (press/release) and the per-row arrow clicks are
+        # unaffected.
+        if obj is self._viewport and event.type() == QEvent.MouseMove and event.buttons():
+            return True
+        return super().eventFilter(obj, event)
 
     def _config_order(self):
         return list(self._get_names())

--- a/software/control/channel_sequence.py
+++ b/software/control/channel_sequence.py
@@ -104,16 +104,9 @@ class ChannelOrderDelegate(QStyledItemDelegate):
         painter.setPen(self._arrow_color(palette, enabled))
         painter.drawText(rect, Qt.AlignCenter, glyph)
 
-    def _is_last_selected_row(self, index):
-        selected_rows = [i.row() for i in self.parent().selectedIndexes()]
-        return bool(selected_rows) and index.row() == max(selected_rows)
-
     @classmethod
     def _gutter_width(cls, font_metrics):
-        s = cls._GUTTER_SAMPLE
-        if hasattr(font_metrics, "horizontalAdvance"):  # Qt >= 5.11
-            return font_metrics.horizontalAdvance(s)
-        return font_metrics.width(s)
+        return font_metrics.horizontalAdvance(cls._GUTTER_SAMPLE)
 
     @staticmethod
     def _arrow_rects(rect):
@@ -162,7 +155,7 @@ class ChannelOrderDelegate(QStyledItemDelegate):
         painter.drawText(name_rect, alignment, fm.elidedText(name, Qt.ElideRight, max(0, name_rect.width())))
         painter.restore()
 
-        if self._is_last_selected_row(index):
+        if position is not None and position == count:  # last channel in the block
             painter.save()
             painter.setPen(opt.palette.color(QPalette.Mid))
             r = option.rect
@@ -257,7 +250,7 @@ class ChannelSequenceController(QObject):
         try:
             config_order = self._config_order()
             order = display_order(self._included_order, config_order)
-            included_set = {n for n in self._included_order if n in set(config_order)}
+            included_set = set(reconcile_included(self._included_order, config_order))
             self._list.clear()
             for name in order:
                 self._list.addItem(name)

--- a/software/control/channel_sequence.py
+++ b/software/control/channel_sequence.py
@@ -1,0 +1,323 @@
+import os
+
+import yaml
+from qtpy.QtCore import QEvent, QItemSelectionModel, QObject, QRect, Qt, QTimer
+from qtpy.QtGui import QColor, QPalette
+from qtpy.QtWidgets import (
+    QAbstractItemView,
+    QApplication,
+    QStyle,
+    QStyledItemDelegate,
+    QStyleOptionViewItem,
+)
+
+import squid.logging
+
+_log = squid.logging.get_logger(__name__)
+
+_CACHE_PATH = "cache/channel_sequence.yaml"
+
+
+def display_order(included_order, config_order):
+    """Included channels first (in their order, filtered to those present in
+    config_order), then the remaining config channels in config order."""
+    config_set = set(config_order)
+    included = [name for name in included_order if name in config_set]
+    included_set = set(included)
+    rest = [name for name in config_order if name not in included_set]
+    return included + rest
+
+
+def reconcile_included(included_order, config_order):
+    """Drop names no longer present in config_order; preserve relative order."""
+    config_set = set(config_order)
+    return [name for name in included_order if name in config_set]
+
+
+def load_cached_order(cache_key, path=_CACHE_PATH):
+    """Return the cached list of included channel names for `cache_key`, or []."""
+    try:
+        if not os.path.exists(path):
+            return []
+        with open(path, "r") as f:
+            data = yaml.safe_load(f) or {}
+        value = data.get(cache_key, [])
+        return list(value) if isinstance(value, list) else []
+    except Exception as e:
+        _log.warning(f"Failed to load channel sequence cache: {e}")
+        return []
+
+
+def save_cached_order(cache_key, names, path=_CACHE_PATH):
+    """Persist included channel names for `cache_key`, merging with other keys."""
+    try:
+        directory = os.path.dirname(path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
+        data = {}
+        if os.path.exists(path):
+            with open(path, "r") as f:
+                data = yaml.safe_load(f) or {}
+        data[cache_key] = list(names)
+        with open(path, "w") as f:
+            yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+    except Exception as e:
+        _log.warning(f"Failed to save channel sequence cache: {e}")
+
+
+class ChannelOrderDelegate(QStyledItemDelegate):
+    """Renders each channel row: a "[N]" acquisition-position badge in a fixed
+    left gutter, the channel name at a fixed x-offset (names stay aligned), and
+    for *selected* rows a pair of up/down (▲/▼) reorder controls at the right.
+    A divider line is drawn under the last selected row. Clicks on the ▲/▼
+    controls are routed to `controller.move_up/move_down(name)` via editorEvent;
+    item data is never modified.
+    """
+
+    _GUTTER_SAMPLE = "[99]  "  # widest expected badge (assumes <= 99 selected channels)
+
+    def __init__(self, list_widget, controller=None):
+        super().__init__(list_widget)
+        self._controller = controller
+
+    def _position_and_count(self, index):
+        """(1-based position of `index` among selected rows or None, total
+        selected count)."""
+        selected_rows = sorted(i.row() for i in self.parent().selectedIndexes())
+        row = index.row()
+        position = selected_rows.index(row) + 1 if row in selected_rows else None
+        return position, len(selected_rows)
+
+    def badge_for_index(self, index):
+        position, _ = self._position_and_count(index)
+        return None if position is None else f"[{position}]"
+
+    @staticmethod
+    def _arrow_color(palette, enabled):
+        # Faded highlighted-text: reads as gray on the selection background and
+        # adapts to the theme; dimmer when the move is disabled (sequence ends).
+        color = QColor(palette.color(QPalette.HighlightedText))
+        color.setAlpha(180 if enabled else 90)
+        return color
+
+    def _draw_arrow(self, painter, palette, rect, glyph, enabled):
+        painter.setPen(self._arrow_color(palette, enabled))
+        painter.drawText(rect, Qt.AlignCenter, glyph)
+
+    def _is_last_selected_row(self, index):
+        selected_rows = [i.row() for i in self.parent().selectedIndexes()]
+        return bool(selected_rows) and index.row() == max(selected_rows)
+
+    @classmethod
+    def _gutter_width(cls, font_metrics):
+        s = cls._GUTTER_SAMPLE
+        if hasattr(font_metrics, "horizontalAdvance"):  # Qt >= 5.11
+            return font_metrics.horizontalAdvance(s)
+        return font_metrics.width(s)
+
+    @staticmethod
+    def _arrow_rects(rect):
+        """The (up, down) clickable arrow rects at the right of a row rect."""
+        w = rect.height()  # square cells, one per arrow
+        up = QRect(rect.right() - 2 * w, rect.top(), w, rect.height())
+        down = QRect(rect.right() - w, rect.top(), w, rect.height())
+        return up, down
+
+    def sizeHint(self, option, index):
+        size = super().sizeHint(option, index)
+        size.setWidth(size.width() + self._gutter_width(option.fontMetrics))
+        return size
+
+    def paint(self, painter, option, index):
+        opt = QStyleOptionViewItem(option)
+        self.initStyleOption(opt, index)
+        name = opt.text
+
+        opt.text = ""
+        widget = opt.widget
+        style = widget.style() if widget is not None else QApplication.style()
+        style.drawControl(QStyle.CE_ItemViewItem, opt, painter, widget)
+
+        text_rect = style.subElementRect(QStyle.SE_ItemViewItemText, opt, widget)
+        fm = opt.fontMetrics
+        gutter = self._gutter_width(fm)
+        alignment = Qt.AlignVCenter | Qt.AlignLeft
+
+        painter.save()
+        selected = bool(opt.state & QStyle.State_Selected)
+        text_pen = opt.palette.color(QPalette.HighlightedText if selected else QPalette.Text)
+        painter.setPen(text_pen)
+        position, count = self._position_and_count(index)
+        name_rect = QRect(text_rect)
+        name_rect.setLeft(text_rect.left() + gutter)
+        if position is not None:
+            painter.drawText(text_rect, alignment, f"[{position}]")
+            # reserve room on the right for the up/down arrows; gray them out at
+            # the ends of the sequence (no up for the first, no down for the last)
+            up_rect, down_rect = self._arrow_rects(option.rect)
+            name_rect.setRight(up_rect.left() - 4)
+            self._draw_arrow(painter, opt.palette, up_rect, "▲", enabled=position > 1)
+            self._draw_arrow(painter, opt.palette, down_rect, "▼", enabled=position < count)
+            painter.setPen(text_pen)  # restore pen for the channel name
+        painter.drawText(name_rect, alignment, fm.elidedText(name, Qt.ElideRight, max(0, name_rect.width())))
+        painter.restore()
+
+        if self._is_last_selected_row(index):
+            painter.save()
+            painter.setPen(opt.palette.color(QPalette.Mid))
+            r = option.rect
+            painter.drawLine(r.left(), r.bottom(), r.right(), r.bottom())
+            painter.restore()
+
+    def editorEvent(self, event, model, option, index):
+        # Route clicks on the per-row ▲/▼ controls (selected rows only) to the
+        # controller, consuming press AND release so the click does not also
+        # toggle the row's selection.
+        if self._controller is not None and self.badge_for_index(index) is not None:
+            if event.type() in (QEvent.MouseButtonPress, QEvent.MouseButtonRelease):
+                pos = event.position().toPoint() if hasattr(event, "position") else event.pos()
+                up_rect, down_rect = self._arrow_rects(option.rect)
+                if up_rect.contains(pos) or down_rect.contains(pos):
+                    if event.type() == QEvent.MouseButtonRelease:
+                        name = index.data()
+                        if up_rect.contains(pos):
+                            self._controller.move_up(name)
+                        else:
+                            self._controller.move_down(name)
+                    return True
+        return super().editorEvent(event, model, option, index)
+
+
+class ChannelSequenceController(QObject):
+    """Manages a multipoint widget's channel QListWidget as an ordered
+    acquisition sequence: selected channels form an ordered block at the top,
+    reordered with the per-row up/down controls drawn by ChannelOrderDelegate
+    (which call move_up/move_down); `included_order` is the single source of
+    truth. Persists to a per-widget cache. Parent it to the list widget."""
+
+    def __init__(self, list_widget, get_names, cache_key, cache_path=_CACHE_PATH):
+        super().__init__(list_widget)
+        self._list = list_widget
+        self._get_names = get_names
+        self._cache_key = cache_key
+        self._cache_path = cache_path
+        self._suppress = False
+        self._pending_rebuild = False
+
+        list_widget.setSelectionMode(QAbstractItemView.MultiSelection)
+        list_widget.setItemDelegate(ChannelOrderDelegate(list_widget, controller=self))
+
+        self._included_order = reconcile_included(load_cached_order(cache_key, self._cache_path), self._config_order())
+        self._rebuild()
+
+        list_widget.itemSelectionChanged.connect(self._on_selection_changed)
+
+    def _config_order(self):
+        return list(self._get_names())
+
+    def ordered_selected_names(self):
+        # Pure read: `_included_order` is updated synchronously on selection, so
+        # this is always correct even while a visual rebuild is still pending.
+        config_set = set(self._config_order())
+        return [n for n in self._included_order if n in config_set]
+
+    def set_included_order(self, names):
+        self._included_order = reconcile_included(list(names), self._config_order())
+        self._rebuild()
+        self._save()
+
+    def refresh(self):
+        self._included_order = reconcile_included(self._included_order, self._config_order())
+        self._rebuild()
+        self._save()
+
+    def _rebuild(self):
+        self._suppress = True
+        # Save/restore the prior blockSignals state (blockSignals is not
+        # ref-counted), so set_included_order()/refresh() are safe to call from a
+        # context that has already blocked the list's signals (e.g. YAML drop).
+        was_blocked = self._list.blockSignals(True)
+        current = self._list.currentItem()
+        current_name = current.text() if current is not None else None
+        try:
+            config_order = self._config_order()
+            order = display_order(self._included_order, config_order)
+            included_set = {n for n in self._included_order if n in set(config_order)}
+            self._list.clear()
+            for name in order:
+                self._list.addItem(name)
+            for i in range(self._list.count()):
+                item = self._list.item(i)
+                if item.text() in included_set:
+                    item.setSelected(True)
+            # Restore the focused (current) row without disturbing the selection,
+            # so repeated up/down presses keep acting on the same channel.
+            if current_name is not None:
+                for i in range(self._list.count()):
+                    if self._list.item(i).text() == current_name:
+                        self._list.setCurrentRow(i, QItemSelectionModel.NoUpdate)
+                        break
+        finally:
+            self._list.blockSignals(was_blocked)
+            self._suppress = False
+        self._list.viewport().update()
+
+    def _on_selection_changed(self):
+        if self._suppress:
+            return
+        # Update _included_order synchronously (so ordered_selected_names() is
+        # always correct), but defer the visual rebuild to the next event-loop
+        # turn: restructuring the list inside its own itemSelectionChanged
+        # handler (during mouse processing) is unsafe, and deferring also
+        # coalesces rapid selections.
+        selected = [i.text() for i in self._list.selectedItems()]
+        selected_set = set(selected)
+        new_order = [n for n in self._included_order if n in selected_set]
+        existing = set(new_order)
+        for n in selected:
+            if n not in existing:
+                new_order.append(n)
+                existing.add(n)
+        self._included_order = new_order
+        self._save()
+        if not self._pending_rebuild:
+            self._pending_rebuild = True
+            QTimer.singleShot(0, self._flush_selection_rebuild)
+
+    def _flush_selection_rebuild(self):
+        self._pending_rebuild = False
+        self._rebuild()
+
+    def move_up(self, name):
+        """Move `name` one position earlier in the acquisition sequence."""
+        self._move(name, -1)
+
+    def move_down(self, name):
+        """Move `name` one position later in the acquisition sequence."""
+        self._move(name, 1)
+
+    def _move(self, name, delta):
+        if name not in self._included_order:
+            return
+        i = self._included_order.index(name)
+        j = i + delta
+        if not (0 <= j < len(self._included_order)):
+            return
+        self._included_order[i], self._included_order[j] = (
+            self._included_order[j],
+            self._included_order[i],
+        )
+        self._rebuild()
+        self._save()
+
+    def _save(self):
+        save_cached_order(self._cache_key, self._included_order, self._cache_path)
+
+
+def enable_channel_sequence(list_widget, get_names, cache_key, cache_path=_CACHE_PATH):
+    """Turn a channel QListWidget into an ordered acquisition sequence with
+    per-row up/down reorder controls. `get_names` returns the channel names in
+    config order. Returns the controller (store it on the widget; read
+    ordered_selected_names() for acquisition, call set_included_order() to
+    restore a saved sequence)."""
+    return ChannelSequenceController(list_widget, get_names, cache_key, cache_path)

--- a/software/control/channel_sequence.py
+++ b/software/control/channel_sequence.py
@@ -34,14 +34,21 @@ def reconcile_included(included_order, config_order):
     return [name for name in included_order if name in config_set]
 
 
+def _read_cache(path):
+    """Read the cache file as a mapping; return {} if it is missing or parses to
+    a non-mapping (corrupt partial write from an older version, manual edit).
+    Normalizing to {} lets save_cached_order self-heal the file by overwriting it."""
+    if not os.path.exists(path):
+        return {}
+    with open(path, "r") as f:
+        loaded = yaml.safe_load(f)
+    return loaded if isinstance(loaded, dict) else {}
+
+
 def load_cached_order(cache_key, path=_CACHE_PATH):
     """Return the cached list of included channel names for `cache_key`, or []."""
     try:
-        if not os.path.exists(path):
-            return []
-        with open(path, "r") as f:
-            data = yaml.safe_load(f) or {}
-        value = data.get(cache_key, [])
+        value = _read_cache(path).get(cache_key, [])
         return list(value) if isinstance(value, list) else []
     except Exception as e:
         _log.warning(f"Failed to load channel sequence cache: {e}")
@@ -54,10 +61,7 @@ def save_cached_order(cache_key, names, path=_CACHE_PATH):
         directory = os.path.dirname(path)
         if directory:
             os.makedirs(directory, exist_ok=True)
-        data = {}
-        if os.path.exists(path):
-            with open(path, "r") as f:
-                data = yaml.safe_load(f) or {}
+        data = _read_cache(path)
         data[cache_key] = list(names)
         # Atomic write: a crash mid-dump must not truncate the file shared by all
         # three widgets and wipe every saved sequence.

--- a/software/control/channel_sequence.py
+++ b/software/control/channel_sequence.py
@@ -109,10 +109,10 @@ class ChannelOrderDelegate(QStyledItemDelegate):
     @staticmethod
     def _gutter_width(font_metrics, count):
         # Reserve room for the widest badge actually in use ("[9]" for <=9
-        # selected, "[99]" for 10-99) plus one trailing space, so the names align
-        # with only a tight gap after the bracket regardless of channel count.
+        # selected, "[99]" for 10-99) plus two trailing spaces, so the names
+        # align with a consistent gap after the bracket regardless of count.
         digits = len(str(max(count, 1)))
-        return font_metrics.horizontalAdvance("[" + "9" * digits + "] ")
+        return font_metrics.horizontalAdvance("[" + "9" * digits + "]  ")
 
     @staticmethod
     def _arrow_rects(rect):

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -2312,6 +2312,8 @@ class HighContentScreeningGui(QMainWindow):
             self.flexibleMultiPointWidget.refresh_channel_list()
         if self.wellplateMultiPointWidget:
             self.wellplateMultiPointWidget.refresh_channel_list()
+        if self.multiPointWithFluidicsWidget:
+            self.multiPointWithFluidicsWidget.refresh_channel_list()
 
     def onTabChanged(self, index):
         is_flexible_acquisition = (

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -7340,7 +7340,8 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, QFrame):
         self.entry_Nt.valueChanged.connect(self.save_multipoint_widget_config_to_cache)
         self.entry_deltaZ.valueChanged.connect(self.save_multipoint_widget_config_to_cache)
         self.entry_NZ.valueChanged.connect(self.save_multipoint_widget_config_to_cache)
-        self.list_configurations.itemSelectionChanged.connect(self.save_multipoint_widget_config_to_cache)
+        # Channel selection/order is persisted by self.channel_sequence (its own
+        # cache), so it is intentionally NOT wired to this settings cache.
         self.checkbox_withAutofocus.toggled.connect(self.save_multipoint_widget_config_to_cache)
         self.checkbox_withReflectionAutofocus.toggled.connect(self.save_multipoint_widget_config_to_cache)
 

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -23,6 +23,7 @@ from control.core.mosaic_utils import format_well_id
 from control.core.geometry_utils import get_effective_well_size, calculate_well_coverage
 from control.microcontroller import Microcontroller
 from control.piezo import PiezoStage
+from control.channel_sequence import enable_channel_sequence
 import control.utils as utils
 import control._def  # Import module for runtime access to MCP-modifiable settings
 from squid.abc import AbstractStage, AbstractCamera, AbstractFilterWheelController
@@ -5493,13 +5494,14 @@ class FlexibleMultiPointWidget(AcquisitionYAMLDropMixin, QFrame):
         self.entry_Nt.setFixedWidth(max_num_width)
 
         self.list_configurations = QListWidget()
-        for microscope_configuration in self.multipointController.liveController.get_channels(
-            self.objectiveStore.current_objective
-        ):
-            self.list_configurations.addItems([microscope_configuration.name])
-        self.list_configurations.setSelectionMode(
-            QAbstractItemView.MultiSelection
-        )  # ref: https://doc.qt.io/qt-5/qabstractitemview.html#SelectionMode-enum
+        self.channel_sequence = enable_channel_sequence(
+            self.list_configurations,
+            lambda: [
+                ch.name
+                for ch in self.multipointController.liveController.get_channels(self.objectiveStore.current_objective)
+            ],
+            cache_key="flexible",
+        )
 
         self.checkbox_withAutofocus = QCheckBox("Contrast AF")
         self.checkbox_withAutofocus.setChecked(MULTIPOINT_CONTRAST_AUTOFOCUS_ENABLE_BY_DEFAULT)
@@ -6044,26 +6046,11 @@ class FlexibleMultiPointWidget(AcquisitionYAMLDropMixin, QFrame):
             save_last_used_saving_path(save_dir_base)
 
     def emit_selected_channels(self):
-        selected_channels = [item.text() for item in self.list_configurations.selectedItems()]
-        self.signal_acquisition_channels.emit(selected_channels)
+        self.signal_acquisition_channels.emit(self.channel_sequence.ordered_selected_names())
 
     def refresh_channel_list(self):
         """Refresh the channel list after configuration changes."""
-        # Remember currently selected channels
-        selected_names = [item.text() for item in self.list_configurations.selectedItems()]
-
-        # Clear and repopulate
-        self.list_configurations.blockSignals(True)
-        self.list_configurations.clear()
-        for config in self.multipointController.liveController.get_channels(self.objectiveStore.current_objective):
-            self.list_configurations.addItem(config.name)
-
-        # Restore selection where possible
-        for i in range(self.list_configurations.count()):
-            item = self.list_configurations.item(i)
-            if item.text() in selected_names:
-                item.setSelected(True)
-        self.list_configurations.blockSignals(False)
+        self.channel_sequence.refresh()
 
     def toggle_acquisition(self, pressed):
         self._log.debug(f"FlexibleMultiPointWidget.toggle_acquisition, {pressed=}")
@@ -6115,9 +6102,7 @@ class FlexibleMultiPointWidget(AcquisitionYAMLDropMixin, QFrame):
             self.multipointController.set_use_fluidics(False)
             self.multipointController.set_skip_saving(self.checkbox_skipSaving.isChecked())
             self.multipointController.set_widget_type("flexible")
-            self.multipointController.set_selected_configurations(
-                (item.text() for item in self.list_configurations.selectedItems())
-            )
+            self.multipointController.set_selected_configurations(self.channel_sequence.ordered_selected_names())
             self.multipointController.start_new_experiment(self.lineEdit_experimentID.text())
 
             if self.checkbox_skipSaving.isChecked():
@@ -6542,9 +6527,7 @@ class FlexibleMultiPointWidget(AcquisitionYAMLDropMixin, QFrame):
             return
 
         # Set the selected channels for acquisition
-        self.multipointController.set_selected_configurations(
-            [item.text() for item in self.list_configurations.selectedItems()]
-        )
+        self.multipointController.set_selected_configurations(self.channel_sequence.ordered_selected_names())
         # Set the acquisition parameters
         self.multipointController.set_deltaZ(0)
         self.multipointController.set_NZ(1)
@@ -6693,13 +6676,9 @@ class FlexibleMultiPointWidget(AcquisitionYAMLDropMixin, QFrame):
             self.entry_Nt.setValue(yaml_data.nt)
             self.entry_dt.setValue(yaml_data.delta_t_s)
 
-            # Channels
+            # Channels (restore selection AND order from the dropped acquisition)
             if yaml_data.channel_names:
-                self.list_configurations.clearSelection()
-                for i in range(self.list_configurations.count()):
-                    item = self.list_configurations.item(i)
-                    if item.text() in yaml_data.channel_names:
-                        item.setSelected(True)
+                self.channel_sequence.set_included_order(yaml_data.channel_names)
 
             # Autofocus
             self.checkbox_withAutofocus.setChecked(yaml_data.contrast_af)
@@ -6979,9 +6958,11 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, QFrame):
         self.combobox_z_stack.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
 
         self.list_configurations = QListWidget()
-        for microscope_configuration in self.liveController.get_channels(self.objectiveStore.current_objective):
-            self.list_configurations.addItems([microscope_configuration.name])
-        self.list_configurations.setSelectionMode(QAbstractItemView.MultiSelection)
+        self.channel_sequence = enable_channel_sequence(
+            self.list_configurations,
+            lambda: [ch.name for ch in self.liveController.get_channels(self.objectiveStore.current_objective)],
+            cache_key="wellplate",
+        )
 
         # Add a combo box for shape selection
         self.combobox_shape = QComboBox()
@@ -7406,7 +7387,6 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, QFrame):
                 "nt": self.entry_Nt.value(),
                 "dz": self.entry_deltaZ.value(),
                 "nz": self.entry_NZ.value(),
-                "selected_channels": [item.text() for item in self.list_configurations.selectedItems()],
                 "contrast_af": self.checkbox_withAutofocus.isChecked(),
                 "laser_af": self.checkbox_withReflectionAutofocus.isChecked(),
             }
@@ -7474,15 +7454,6 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, QFrame):
             self.entry_Nt.setValue(settings.get("nt", 1))
             self.entry_deltaZ.setValue(settings.get("dz", 1.0))
             self.entry_NZ.setValue(settings.get("nz", 1))
-
-            # Restore selected channels
-            selected_channels = settings.get("selected_channels", [])
-            if selected_channels:
-                self.list_configurations.clearSelection()
-                for i in range(self.list_configurations.count()):
-                    item = self.list_configurations.item(i)
-                    if item.text() in selected_channels:
-                        item.setSelected(True)
 
             # Restore autofocus settings
             self.checkbox_withAutofocus.setChecked(settings.get("contrast_af", False))
@@ -8483,9 +8454,7 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, QFrame):
             self.multipointController.set_scan_size(self.entry_scan_size.value())
             self.multipointController.set_overlap_percent(self.entry_overlap.value())
             self.multipointController.set_xy_mode(self.combobox_xy_mode.currentText())
-            self.multipointController.set_selected_configurations(
-                [item.text() for item in self.list_configurations.selectedItems()]
-            )
+            self.multipointController.set_selected_configurations(self.channel_sequence.ordered_selected_names())
             self.multipointController.start_new_experiment(self.lineEdit_experimentID.text())
 
             if self.checkbox_skipSaving.isChecked():
@@ -8626,9 +8595,7 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, QFrame):
             return
 
         # Set the selected channels for acquisition
-        self.multipointController.set_selected_configurations(
-            [item.text() for item in self.list_configurations.selectedItems()]
-        )
+        self.multipointController.set_selected_configurations(self.channel_sequence.ordered_selected_names())
         # Set the acquisition parameters
         self.multipointController.set_deltaZ(0)
         self.multipointController.set_NZ(1)
@@ -8655,26 +8622,11 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, QFrame):
         self.multipointController.set_deltaZ(deltaZ)
 
     def emit_selected_channels(self):
-        selected_channels = [item.text() for item in self.list_configurations.selectedItems()]
-        self.signal_acquisition_channels.emit(selected_channels)
+        self.signal_acquisition_channels.emit(self.channel_sequence.ordered_selected_names())
 
     def refresh_channel_list(self):
         """Refresh the channel list after configuration changes."""
-        # Remember currently selected channels
-        selected_names = [item.text() for item in self.list_configurations.selectedItems()]
-
-        # Clear and repopulate
-        self.list_configurations.blockSignals(True)
-        self.list_configurations.clear()
-        for config in self.liveController.get_channels(self.objectiveStore.current_objective):
-            self.list_configurations.addItem(config.name)
-
-        # Restore selection where possible
-        for i in range(self.list_configurations.count()):
-            item = self.list_configurations.item(i)
-            if item.text() in selected_names:
-                item.setSelected(True)
-        self.list_configurations.blockSignals(False)
+        self.channel_sequence.refresh()
 
     def toggle_coordinate_controls(self, has_coordinates: bool):
         """Toggle button text and control states based on whether coordinates are loaded"""
@@ -8908,13 +8860,9 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, QFrame):
                 if index >= 0:
                     self.combobox_shape.setCurrentIndex(index)
 
-            # Channels
+            # Channels (restore selection AND order from the dropped acquisition)
             if yaml_data.channel_names:
-                self.list_configurations.clearSelection()
-                for i in range(self.list_configurations.count()):
-                    item = self.list_configurations.item(i)
-                    if item.text() in yaml_data.channel_names:
-                        item.setSelected(True)
+                self.channel_sequence.set_included_order(yaml_data.channel_names)
 
             # Autofocus
             self.checkbox_withAutofocus.setChecked(yaml_data.contrast_af)
@@ -9071,11 +9019,14 @@ class MultiPointWithFluidicsWidget(QFrame):
 
         # Channel configurations
         self.list_configurations = QListWidget()
-        for microscope_configuration in self.multipointController.liveController.get_channels(
-            self.objectiveStore.current_objective
-        ):
-            self.list_configurations.addItems([microscope_configuration.name])
-        self.list_configurations.setSelectionMode(QAbstractItemView.MultiSelection)
+        self.channel_sequence = enable_channel_sequence(
+            self.list_configurations,
+            lambda: [
+                ch.name
+                for ch in self.multipointController.liveController.get_channels(self.objectiveStore.current_objective)
+            ],
+            cache_key="fluidics",
+        )
 
         # Reflection AF checkbox
         self.checkbox_withReflectionAutofocus = QCheckBox("Reflection AF")
@@ -9260,9 +9211,7 @@ class MultiPointWithFluidicsWidget(QFrame):
             self.multipointController.set_reflection_af_flag(self.checkbox_withReflectionAutofocus.isChecked())
             self.multipointController.set_base_path(self.lineEdit_savingDir.text())
             self.multipointController.set_use_fluidics(True)  # may be set to False from other widgets
-            self.multipointController.set_selected_configurations(
-                [item.text() for item in self.list_configurations.selectedItems()]
-            )
+            self.multipointController.set_selected_configurations(self.channel_sequence.ordered_selected_names())
             self.multipointController.set_Nt(len(rounds))
             self.multipointController.fluidics.set_rounds(rounds)
             self.multipointController.start_new_experiment(self.lineEdit_experimentID.text())
@@ -9313,8 +9262,11 @@ class MultiPointWithFluidicsWidget(QFrame):
 
     def emit_selected_channels(self):
         """Emit signal with list of selected channel names"""
-        selected_channels = [item.text() for item in self.list_configurations.selectedItems()]
-        self.signal_acquisition_channels.emit(selected_channels)
+        self.signal_acquisition_channels.emit(self.channel_sequence.ordered_selected_names())
+
+    def refresh_channel_list(self):
+        """Refresh the channel list after configuration changes."""
+        self.channel_sequence.refresh()
 
     def acquisition_is_finished(self):
         """Handle acquisition completion"""

--- a/software/tests/control/test_channel_sequence.py
+++ b/software/tests/control/test_channel_sequence.py
@@ -272,3 +272,19 @@ class TestArrowClickIntegration:
         assert ctrl.ordered_selected_names() == ["b", "a", "c"]  # "a" moved later
         selected = [lw.item(i).text() for i in range(lw.count()) if lw.item(i).isSelected()]
         assert "a" in selected  # the arrow click must NOT have deselected "a"
+
+
+class TestDragSelectDisabled:
+    """Dragging across rows must not rubber-band a range of channels; only
+    discrete clicks toggle. The controller's viewport event filter swallows
+    mouse-move events while a button is held."""
+
+    def test_move_with_button_held_is_swallowed(self, qtbot, tmp_path):
+        lw, ctrl = _controller(qtbot, ["a", "b", "c"], path=str(tmp_path / "c.yaml"))
+        dragging = QMouseEvent(QEvent.MouseMove, QPointF(5, 5), Qt.NoButton, Qt.LeftButton, Qt.NoModifier)
+        assert ctrl.eventFilter(lw.viewport(), dragging) is True
+
+    def test_hover_move_without_button_passes_through(self, qtbot, tmp_path):
+        lw, ctrl = _controller(qtbot, ["a", "b", "c"], path=str(tmp_path / "c.yaml"))
+        hover = QMouseEvent(QEvent.MouseMove, QPointF(5, 5), Qt.NoButton, Qt.NoButton, Qt.NoModifier)
+        assert ctrl.eventFilter(lw.viewport(), hover) is False

--- a/software/tests/control/test_channel_sequence.py
+++ b/software/tests/control/test_channel_sequence.py
@@ -251,6 +251,22 @@ class TestArrows:
         assert not handled  # falls through to default handling (selection toggle)
         assert ctrl.ordered_selected_names() == ["a", "b", "c"]
 
+    def test_non_left_click_on_arrow_is_ignored(self, qtbot, tmp_path):
+        lw, ctrl = _controller(qtbot, ["a", "b", "c"], path=str(tmp_path / "c.yaml"))
+        ctrl.set_included_order(["a", "b", "c"])
+        delegate = lw.itemDelegate()
+        opt = QStyleOptionViewItem()
+        opt.rect = QRect(0, 0, 200, 20)
+        index = lw.model().index(_row_of(lw, "a"), 0)
+        up_rect, _ = ChannelOrderDelegate._arrow_rects(opt.rect)
+        right_release = QMouseEvent(
+            QEvent.MouseButtonRelease, QPointF(up_rect.center()), Qt.RightButton, Qt.RightButton, Qt.NoModifier
+        )
+
+        handled = delegate.editorEvent(right_release, lw.model(), opt, index)
+        assert not handled  # right-click on the arrow must not be consumed
+        assert ctrl.ordered_selected_names() == ["a", "b", "c"]  # nor reorder
+
 
 class TestArrowClickIntegration:
     """End-to-end: a real mouse click on an arrow (press+release through the

--- a/software/tests/control/test_channel_sequence.py
+++ b/software/tests/control/test_channel_sequence.py
@@ -1,0 +1,274 @@
+import control.channel_sequence as cs
+from qtpy.QtCore import QEvent, QPointF, QRect, Qt
+from qtpy.QtGui import QMouseEvent, QPainter, QPixmap
+from qtpy.QtTest import QTest
+from qtpy.QtWidgets import QAbstractItemView, QListWidget, QStyleOptionViewItem
+
+from control.channel_sequence import ChannelOrderDelegate, enable_channel_sequence
+
+
+class TestPureOrdering:
+    def test_display_order_included_first_then_config_rest(self):
+        assert cs.display_order(["c", "a"], ["a", "b", "c", "d"]) == ["c", "a", "b", "d"]
+
+    def test_display_order_filters_unknown_included(self):
+        assert cs.display_order(["x", "b"], ["a", "b", "c"]) == ["b", "a", "c"]
+
+    def test_display_order_empty_included_is_config_order(self):
+        assert cs.display_order([], ["a", "b"]) == ["a", "b"]
+
+    def test_reconcile_included_drops_missing_keeps_order(self):
+        assert cs.reconcile_included(["c", "x", "a"], ["a", "b", "c"]) == ["c", "a"]
+
+
+class TestCacheIO:
+    def test_save_then_load_roundtrip(self, tmp_path):
+        path = str(tmp_path / "channel_sequence.yaml")
+        cs.save_cached_order("flexible", ["c", "a"], path=path)
+        assert cs.load_cached_order("flexible", path=path) == ["c", "a"]
+
+    def test_load_missing_file_returns_empty(self, tmp_path):
+        assert cs.load_cached_order("flexible", path=str(tmp_path / "nope.yaml")) == []
+
+    def test_save_merges_keys(self, tmp_path):
+        path = str(tmp_path / "channel_sequence.yaml")
+        cs.save_cached_order("flexible", ["a"], path=path)
+        cs.save_cached_order("wellplate", ["b"], path=path)
+        assert cs.load_cached_order("flexible", path=path) == ["a"]
+        assert cs.load_cached_order("wellplate", path=path) == ["b"]
+
+
+def _list(qtbot, names, selected_rows):
+    lw = QListWidget()
+    qtbot.addWidget(lw)
+    lw.addItems(names)
+    lw.setSelectionMode(QAbstractItemView.MultiSelection)
+    for r in selected_rows:
+        lw.item(r).setSelected(True)
+    return lw
+
+
+def _badge(delegate, lw, row):
+    return delegate.badge_for_index(lw.model().index(row, 0))
+
+
+class TestDelegate:
+    def test_badge_numbers_selected_rows_top_to_bottom(self, qtbot):
+        lw = _list(qtbot, ["a", "b", "c", "d"], selected_rows=[0, 1, 2])
+        delegate = ChannelOrderDelegate(lw)
+        assert _badge(delegate, lw, 0) == "[1]"
+        assert _badge(delegate, lw, 1) == "[2]"
+        assert _badge(delegate, lw, 2) == "[3]"
+        assert _badge(delegate, lw, 3) is None
+
+    def test_sizehint_reserves_gutter(self, qtbot):
+        lw = _list(qtbot, ["a"], selected_rows=[])
+        delegate = ChannelOrderDelegate(lw)
+        opt = QStyleOptionViewItem()
+        idx = lw.model().index(0, 0)
+        delegate.initStyleOption(opt, idx)
+        assert delegate.sizeHint(opt, idx).width() > 0
+
+    def test_paint_runs_without_error(self, qtbot):
+        lw = _list(qtbot, ["a", "b", "c"], selected_rows=[0, 1])
+        delegate = ChannelOrderDelegate(lw)
+        pixmap = QPixmap(220, 22)
+        painter = QPainter(pixmap)
+        try:
+            for row in range(3):
+                opt = QStyleOptionViewItem()
+                opt.rect = QRect(0, 0, 220, 22)
+                idx = lw.model().index(row, 0)
+                delegate.initStyleOption(opt, idx)
+                delegate.paint(painter, opt, idx)
+        finally:
+            painter.end()
+
+
+def _controller(qtbot, names, cache_key="flexible", path=None):
+    lw = QListWidget()
+    qtbot.addWidget(lw)
+    kwargs = {} if path is None else {"cache_path": path}
+    ctrl = enable_channel_sequence(lw, lambda: list(names), cache_key, **kwargs)
+    return lw, ctrl
+
+
+def _rows(lw):
+    return [lw.item(i).text() for i in range(lw.count())]
+
+
+def _row_of(lw, name):
+    return next(i for i in range(lw.count()) if lw.item(i).text() == name)
+
+
+class TestController:
+    def test_initial_population_is_config_order_nothing_selected(self, qtbot, tmp_path):
+        lw, ctrl = _controller(qtbot, ["a", "b", "c"], path=str(tmp_path / "c.yaml"))
+        assert _rows(lw) == ["a", "b", "c"]
+        assert ctrl.ordered_selected_names() == []
+
+    def test_selecting_floats_to_top_block_in_selection_order(self, qtbot, tmp_path):
+        lw, ctrl = _controller(qtbot, ["a", "b", "c", "d"], path=str(tmp_path / "c.yaml"))
+        lw.item(2).setSelected(True)  # c
+        lw.item(0).setSelected(True)  # a
+        assert ctrl.ordered_selected_names() == ["c", "a"]
+        # the visual regroup is deferred to the event loop; wait for it
+        qtbot.waitUntil(lambda: _rows(lw)[:2] == ["c", "a"])
+
+    def test_deselect_drops_out_of_block(self, qtbot, tmp_path):
+        lw, ctrl = _controller(qtbot, ["a", "b", "c"], path=str(tmp_path / "c.yaml"))
+        lw.item(0).setSelected(True)
+        lw.item(1).setSelected(True)
+        lw.item(0).setSelected(False)
+        assert ctrl.ordered_selected_names() == ["b"]
+
+    def test_set_included_order_restores_order_and_highlight(self, qtbot, tmp_path):
+        lw, ctrl = _controller(qtbot, ["a", "b", "c"], path=str(tmp_path / "c.yaml"))
+        ctrl.set_included_order(["c", "a"])
+        assert ctrl.ordered_selected_names() == ["c", "a"]
+        assert _rows(lw)[:2] == ["c", "a"]
+        assert sorted(i.text() for i in lw.selectedItems()) == ["a", "c"]
+
+    def test_set_included_order_filters_unknown_names(self, qtbot, tmp_path):
+        lw, ctrl = _controller(qtbot, ["a", "b"], path=str(tmp_path / "c.yaml"))
+        ctrl.set_included_order(["x", "b"])
+        assert ctrl.ordered_selected_names() == ["b"]
+
+    def test_move_up_reorders_within_block(self, qtbot, tmp_path):
+        lw, ctrl = _controller(qtbot, ["a", "b", "c", "d"], path=str(tmp_path / "c.yaml"))
+        ctrl.set_included_order(["a", "b", "c"])
+        ctrl.move_up("b")
+        assert ctrl.ordered_selected_names() == ["b", "a", "c"]
+        assert _rows(lw)[:3] == ["b", "a", "c"]
+
+    def test_move_down_reorders_within_block(self, qtbot, tmp_path):
+        lw, ctrl = _controller(qtbot, ["a", "b", "c", "d"], path=str(tmp_path / "c.yaml"))
+        ctrl.set_included_order(["a", "b", "c"])
+        ctrl.move_down("b")
+        assert ctrl.ordered_selected_names() == ["a", "c", "b"]
+
+    def test_move_up_at_top_is_noop(self, qtbot, tmp_path):
+        lw, ctrl = _controller(qtbot, ["a", "b", "c"], path=str(tmp_path / "c.yaml"))
+        ctrl.set_included_order(["a", "b"])
+        ctrl.move_up("a")
+        assert ctrl.ordered_selected_names() == ["a", "b"]
+
+    def test_move_down_at_bottom_is_noop(self, qtbot, tmp_path):
+        lw, ctrl = _controller(qtbot, ["a", "b", "c"], path=str(tmp_path / "c.yaml"))
+        ctrl.set_included_order(["a", "b"])
+        ctrl.move_down("b")
+        assert ctrl.ordered_selected_names() == ["a", "b"]
+
+    def test_move_unincluded_is_noop(self, qtbot, tmp_path):
+        lw, ctrl = _controller(qtbot, ["a", "b", "c"], path=str(tmp_path / "c.yaml"))
+        ctrl.set_included_order(["a"])
+        ctrl.move_down("b")  # b is not included
+        assert ctrl.ordered_selected_names() == ["a"]
+
+    def test_repeated_move_up(self, qtbot, tmp_path):
+        lw, ctrl = _controller(qtbot, ["a", "b", "c"], path=str(tmp_path / "c.yaml"))
+        ctrl.set_included_order(["a", "b", "c"])
+        ctrl.move_up("c")
+        ctrl.move_up("c")
+        assert ctrl.ordered_selected_names() == ["c", "a", "b"]
+
+    def test_refresh_drops_missing_and_appends_new(self, qtbot, tmp_path):
+        names = ["a", "b", "c"]
+        lw, ctrl = _controller(qtbot, names, path=str(tmp_path / "c.yaml"))
+        ctrl.set_included_order(["c", "a"])
+        names[:] = ["a", "c", "e"]
+        ctrl.refresh()
+        assert ctrl.ordered_selected_names() == ["c", "a"]
+        assert _rows(lw) == ["c", "a", "e"]
+
+    def test_persistence_restored_on_new_controller(self, qtbot, tmp_path):
+        path = str(tmp_path / "c.yaml")
+        lw1, ctrl1 = _controller(qtbot, ["a", "b", "c"], path=path)
+        ctrl1.set_included_order(["c", "a"])
+        lw2, ctrl2 = _controller(qtbot, ["a", "b", "c"], path=path)
+        assert ctrl2.ordered_selected_names() == ["c", "a"]
+
+    def test_rebuild_does_not_emit_spurious_selection_signals(self, qtbot, tmp_path):
+        lw, ctrl = _controller(qtbot, ["a", "b", "c"], path=str(tmp_path / "c.yaml"))
+        fired = []
+        lw.itemSelectionChanged.connect(lambda: fired.append(1))
+        ctrl.set_included_order(["b"])
+        assert fired == []
+
+
+def _release_at(point):
+    return QMouseEvent(
+        QEvent.MouseButtonRelease,
+        QPointF(point),
+        Qt.LeftButton,
+        Qt.LeftButton,
+        Qt.NoModifier,
+    )
+
+
+class TestArrows:
+    def test_arrow_rects_right_aligned_and_disjoint(self):
+        up, down = ChannelOrderDelegate._arrow_rects(QRect(0, 0, 200, 20))
+        assert up.left() >= 0
+        assert up.right() <= down.left()  # up sits left of down, no overlap
+        assert down.right() <= 200
+
+    def test_up_arrow_click_moves_channel_earlier(self, qtbot, tmp_path):
+        lw, ctrl = _controller(qtbot, ["a", "b", "c"], path=str(tmp_path / "c.yaml"))
+        ctrl.set_included_order(["a", "b", "c"])
+        delegate = lw.itemDelegate()
+        opt = QStyleOptionViewItem()
+        opt.rect = QRect(0, 0, 200, 20)
+        index = lw.model().index(_row_of(lw, "b"), 0)
+        up_rect, _ = ChannelOrderDelegate._arrow_rects(opt.rect)
+
+        handled = delegate.editorEvent(_release_at(up_rect.center()), lw.model(), opt, index)
+        assert handled
+        assert ctrl.ordered_selected_names() == ["b", "a", "c"]
+
+    def test_down_arrow_click_moves_channel_later(self, qtbot, tmp_path):
+        lw, ctrl = _controller(qtbot, ["a", "b", "c"], path=str(tmp_path / "c.yaml"))
+        ctrl.set_included_order(["a", "b", "c"])
+        delegate = lw.itemDelegate()
+        opt = QStyleOptionViewItem()
+        opt.rect = QRect(0, 0, 200, 20)
+        index = lw.model().index(_row_of(lw, "b"), 0)
+        _, down_rect = ChannelOrderDelegate._arrow_rects(opt.rect)
+
+        handled = delegate.editorEvent(_release_at(down_rect.center()), lw.model(), opt, index)
+        assert handled
+        assert ctrl.ordered_selected_names() == ["a", "c", "b"]
+
+    def test_click_outside_arrows_is_not_consumed(self, qtbot, tmp_path):
+        lw, ctrl = _controller(qtbot, ["a", "b", "c"], path=str(tmp_path / "c.yaml"))
+        ctrl.set_included_order(["a", "b", "c"])
+        delegate = lw.itemDelegate()
+        opt = QStyleOptionViewItem()
+        opt.rect = QRect(0, 0, 200, 20)
+        index = lw.model().index(_row_of(lw, "b"), 0)
+
+        handled = delegate.editorEvent(_release_at(QPointF(10, 10)), lw.model(), opt, index)
+        assert not handled  # falls through to default handling (selection toggle)
+        assert ctrl.ordered_selected_names() == ["a", "b", "c"]
+
+
+class TestArrowClickIntegration:
+    """End-to-end: a real mouse click on an arrow (press+release through the
+    view) must reorder WITHOUT toggling the row's selection off. The unit tests
+    above call editorEvent(release) directly and so cannot catch a regression in
+    the press-consumption that prevents the selection toggle."""
+
+    def test_real_click_on_arrow_moves_without_deselecting(self, qtbot, tmp_path):
+        lw, ctrl = _controller(qtbot, ["a", "b", "c"], path=str(tmp_path / "c.yaml"))
+        ctrl.set_included_order(["a", "b", "c"])
+        lw.resize(360, 240)
+        with qtbot.waitExposed(lw):
+            lw.show()
+
+        rect = lw.visualItemRect(lw.item(_row_of(lw, "a")))
+        _, down_rect = ChannelOrderDelegate._arrow_rects(rect)
+        QTest.mouseClick(lw.viewport(), Qt.LeftButton, Qt.NoModifier, down_rect.center())
+
+        assert ctrl.ordered_selected_names() == ["b", "a", "c"]  # "a" moved later
+        selected = [lw.item(i).text() for i in range(lw.count()) if lw.item(i).isSelected()]
+        assert "a" in selected  # the arrow click must NOT have deselected "a"


### PR DESCRIPTION
## Summary

Lets the user define the **channel acquisition order** in the three multipoint widgets (Flexible, Wellplate, Fluidics):

- Selecting a channel includes it and floats it into an **ordered block at the top** of the list; the acquisition runs in that top-to-bottom order.
- Each selected row shows a `[N]` position badge and per-row **▲/▼ reorder controls** (gray, dimmed at the sequence ends).
- Click toggles inclusion; **click-drag range-select is disabled** so a stray drag can't select a swath of channels.
- The order **persists** to a per-widget local cache (`cache/channel_sequence.yaml`) and **round-trips through the acquisition YAML** — dropping a saved acquisition onto the widget restores its channel order.
- Fluidics now refreshes its channel list on config change (it previously didn't).

## Implementation

- New focused module `control/channel_sequence.py`; `control/widgets.py` + `control/gui_hcs.py` keep only thin wiring.
- `ChannelSequenceController` keeps `included_order` as the single source of truth (updated synchronously; the visual rebuild is deferred via a controller-owned single-shot `QTimer`, so it can't fire on a torn-down widget).
- `ChannelOrderDelegate` paints the badge/name/arrows and routes **left-clicks** on the arrows to `move_up`/`move_down` via `editorEvent` (consuming the click so it doesn't also toggle selection).
- Cache writes are atomic (temp file + `os.replace`).

## Test plan

- [x] `pytest software/tests/control/test_channel_sequence.py` — 32 tests: pure ordering + cache I/O, delegate badge / paint / arrow geometry, controller select/move/refresh/persistence, `editorEvent` + real-mouse-click integration (reorders without deselecting; right-click ignored), drag-select-disabled filter.
- [x] Manual (simulation): select channels out of order → group at top with `[N]` badges; ▲/▼ reorder (dimmed at ends); click-drag doesn't range-select; restart restores order; drag-drop an acquisition YAML restores its channel order; run a short acquisition and confirm channels image in the chosen order.

Note: a one-time wellplate selection reset is expected for users upgrading from the old `multipoint_widget_config.yaml` channel cache (no migration, by decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)