### PR TITLE
fix(filter-wheel): reset W/W2 range to full after home (rotary axis) — fixes intermittent post-home CMD_EXECUTION_ERROR

### DIFF
--- a/firmware/controller/src/constants.h
+++ b/firmware/controller/src/constants.h
@@ -12,8 +12,11 @@
 // Version 1.2 = CMD_EXECUTION_ERROR reported on failed moves + MOVETO_W2 command
 // Version 1.3 = strobe ISR latches illumination source at start (race fix when
 //               channel switched during live HW-triggered acquisition)
+// Version 1.4 = filter-wheel (W/W2) home resets xmin/xmax to full range (rotary
+//               axis has no travel end-stop); fixes intermittent post-home
+//               MOVETO_W CMD_EXECUTION_ERROR (home left xmin = L - C > offset)
 #define FIRMWARE_VERSION_MAJOR 1
-#define FIRMWARE_VERSION_MINOR 3
+#define FIRMWARE_VERSION_MINOR 4
 
 #include "def/def_v1.h"
 

--- a/firmware/controller/src/operations.cpp
+++ b/firmware/controller/src/operations.cpp
@@ -375,6 +375,17 @@ void finalize_homing_w()
       tmc4361A_write_encoder(&tmc4361[w], 0);
       if (stage_PID_enabled[w])
         tmc4361A_set_PID(&tmc4361[w], PID_BPG0);
+      // The filter wheel is ROTARY (no travel end-stop) -- the linear-stage
+      // [xmin,xmax] range gate in tmc4361A_moveTo does not apply to it. Homing
+      // leaves xmin = L - C (L = press-latch position, C = release-detect
+      // position); a stale/mis-ordered latch makes xmin exceed the small absolute
+      // post-home offset target, so MOVETO_W is wrongly rejected with
+      // CMD_EXECUTION_ERROR. Reset to full range so valid rotary moves are never
+      // range-rejected. Safe: W xmin/xmax are written only in check_homing_w and
+      // consumed only by the moveTo range check (check_limits acts on X/Y/Z only,
+      // stopping them on a limit-switch event, and never touches W/W2).
+      tmc4361[w].xmin = INT32_MIN;
+      tmc4361[w].xmax = INT32_MAX;
     }
     W_pos = 0;
     is_homing_W = false;
@@ -393,6 +404,9 @@ void finalize_homing_w2()
       tmc4361A_write_encoder(&tmc4361[w2], 0);
       if (stage_PID_enabled[w2])
         tmc4361A_set_PID(&tmc4361[w2], PID_BPG0);
+      // Rotary wheel: no travel end-stop -> full range (see finalize_homing_w).
+      tmc4361[w2].xmin = INT32_MIN;
+      tmc4361[w2].xmax = INT32_MAX;
     }
     W2_pos = 0;
     is_homing_W2 = false;


### PR DESCRIPTION
## Problem

Intermittently, a filter-wheel home **succeeds** but the immediate post-home offset move (`MOVETO_W`, an absolute `+102` ustep target) is rejected with `CMD_EXECUTION_ERROR`, crashing startup. Observed across runs; ~1 in N power-ups.

## Root cause

The home anchors its coordinate frame from the limit-switch **PRESS** latch (`X_LATCH_RD`) but declares "home found" on the switch **RELEASE**, leaving final `xmin = L − C` (L = press-latch position, C = release position). `tmc4361A_moveTo` is the **sole** rejection gate (`x_pos < xmin || x_pos > xmax`; no transient path; `enable_filterwheel == false` ruled out post-INITFILTERWHEEL). So the abort is exactly `xmin > 102`, which happens whenever a home reaches release without a fresh, correctly-ordered in-cycle press (stale/mis-ordered latch). It's intermittent because `L − C` depends on the wheel's resting/switch state at power-up.

(Confirmed by a multi-agent adversarial root-cause analysis: `xmin = L − C`, absolute `+102` target, sole gate — all verified against source.)

## Fix

The `[xmin,xmax]` range check is **linear-stage infrastructure** (physical end-stops, `SET_LIM`, `moveToExtreme`). The filter wheel is **rotary** — no travel end-stop; the home switch is a reference mark. So `finalize_homing_w/_w2` now reset the wheel's range to full int32 after anchoring home, and a latch-derived `xmin` can never reject a valid rotary move — on every home entry path.

**Safe:** W/W2 `xmin/xmax` are written only in `check_homing_w/w2` and consumed only by the `moveTo` range gate; `check_limits` acts on X/Y/Z only and never touches W/W2; `SET_LIM` targets the stage.

`FIRMWARE_VERSION` 1.3 → 1.4 so logs (`Detected firmware version`) confirm the flashed build.

## Changes
- `firmware/controller/src/operations.cpp` — `finalize_homing_w/_w2` reset `xmin/xmax` to full range
- `firmware/controller/src/constants.h` — version 1.4 + changelog

## Note
An earlier iteration tried a "back-off, then re-approach" homing phase to force a fresh press-latch. Hardware testing showed it only fixed the *pressed-at-entry* subcase — a *released-at-entry* home still failed — so it was dropped in favor of this version-independent, root-cause fix.

## Testing
- `pio run -e teensy41` builds clean.
- Hardware validation pending: reflash, confirm `Detected firmware version: (1, 4)`, then power-cycle ~10+ times (varying the wheel's resting position) and confirm every home completes with no `CMD_EXECUTION_ERROR`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)