### PR TITLE
feat: hide Continuous Acquisition trigger mode unless ENABLE_RECORDING

### DIFF
--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -4048,7 +4048,10 @@ class LiveControlWidget(QFrame):
     def add_components(self, show_trigger_options, show_display_options, show_autolevel, autolevel, stretch):
         # line 0: trigger mode
         self.dropdown_triggerManu = QComboBox()
-        self.dropdown_triggerManu.addItems([TriggerMode.SOFTWARE, TriggerMode.HARDWARE, TriggerMode.CONTINUOUS])
+        trigger_modes = [TriggerMode.SOFTWARE, TriggerMode.HARDWARE]
+        if ENABLE_RECORDING:
+            trigger_modes.append(TriggerMode.CONTINUOUS)
+        self.dropdown_triggerManu.addItems(trigger_modes)
         self.dropdown_triggerManu.setCurrentText(self.camera.get_acquisition_mode().value)
         sizePolicy = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         self.dropdown_triggerManu.setSizePolicy(sizePolicy)


### PR DESCRIPTION
## Summary

Hides the **Continuous Acquisition** option from the live-control Trigger Mode dropdown unless the `ENABLE_RECORDING` config flag is `True`.

Continuous acquisition mode is only meaningful when recording is enabled, so the dropdown item is now gated on the same `ENABLE_RECORDING` flag that already controls the "Simple Recording" tab (`gui_hcs.py`). With the default `ENABLE_RECORDING = False`, the dropdown shows only Software Trigger and Hardware Trigger.

## Change

In `LiveControlWidget.add_components()` (`software/control/widgets.py`), the trigger-mode list is built conditionally:

```python
trigger_modes = [TriggerMode.SOFTWARE, TriggerMode.HARDWARE]
if ENABLE_RECORDING:
    trigger_modes.append(TriggerMode.CONTINUOUS)
self.dropdown_triggerManu.addItems(trigger_modes)
```

## Notes

- `MultiCameraLiveControlWidget` already omits `CONTINUOUS`, so no change there.
- `setCurrentText(...)` is safe — `QComboBox.setCurrentText` is a no-op when the text isn't an existing item, so it won't error if the camera's current mode happens to be Continuous while the flag is off.

## Test plan

- [x] Syntax check + `black --check` pass.
- [ ] With `ENABLE_RECORDING = False` (default): Continuous Acquisition is absent from the Trigger Mode dropdown.
- [ ] With `ENABLE_RECORDING = True`: Continuous Acquisition appears as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)