### PR TITLE
fix(turret): prevent Z-restore timeout at startup; de-energize when idle

### DIFF
--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -552,10 +552,8 @@ class Microscope:
                     # working soft floor), so don't restore Z to it after rotating — the cached-Z
                     # restore at GUI startup positions Z. Later objective changes (Z not freshly
                     # homed) restore the live focus position as before.
-                    z_just_homed = (not skip_init) and control._def.HOMING_ENABLED_Z
-                    self.addons.objective_changer.move_to_objective(
-                        control._def.DEFAULT_OBJECTIVE, restore_z=not z_just_homed
-                    )
+                    restore_z = skip_init or not control._def.HOMING_ENABLED_Z
+                    self.addons.objective_changer.move_to_objective(control._def.DEFAULT_OBJECTIVE, restore_z=restore_z)
             except KeyError as e:
                 raise RuntimeError(
                     f"DEFAULT_OBJECTIVE={control._def.DEFAULT_OBJECTIVE!r} "

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -537,14 +537,25 @@ class Microscope:
 
         if self.addons.objective_changer:
             # Xeryon always re-homes (findIndex is fast and required). The turret skips
-            # homing on a software restart: the motor stays powered across close()/re-init
-            # and retains its position register, so a re-home would just be wasted motion.
+            # homing on a software restart: the controller retains its position counter
+            # across close()/re-init (the motor is de-energized but the drive stays
+            # powered), so a re-home would just be wasted motion.
             if control._def.USE_XERYON or not skip_init:
                 self.addons.objective_changer.home()
             if control._def.USE_XERYON:
                 self.addons.objective_changer.setSpeed(control._def.XERYON_SPEED)
             try:
-                self.addons.objective_changer.move_to_objective(control._def.DEFAULT_OBJECTIVE)
+                if control._def.USE_XERYON:
+                    self.addons.objective_changer.move_to_objective(control._def.DEFAULT_OBJECTIVE)
+                else:
+                    # Turret: when Z was just homed it sits at the home reference (0.0, below the
+                    # working soft floor), so don't restore Z to it after rotating — the cached-Z
+                    # restore at GUI startup positions Z. Later objective changes (Z not freshly
+                    # homed) restore the live focus position as before.
+                    z_just_homed = (not skip_init) and control._def.HOMING_ENABLED_Z
+                    self.addons.objective_changer.move_to_objective(
+                        control._def.DEFAULT_OBJECTIVE, restore_z=not z_just_homed
+                    )
             except KeyError as e:
                 raise RuntimeError(
                     f"DEFAULT_OBJECTIVE={control._def.DEFAULT_OBJECTIVE!r} "

--- a/software/control/objective_turret_controller.py
+++ b/software/control/objective_turret_controller.py
@@ -470,8 +470,15 @@ class ObjectiveTurret4PosController:
 
     def _deenergize(self) -> None:
         """Remove holding current so the motor idles cold. The turret holds its slot
-        mechanically and the controller retains its position counter while powered."""
-        self._write_control(CW_DISABLE)
+        mechanically and the controller retains its position counter while powered.
+
+        Best-effort: this runs from finally blocks after a move/home, so a failed disable
+        must not replace the real timeout/fault that triggered the cleanup.
+        """
+        try:
+            self._write_control(CW_DISABLE)
+        except Exception as exc:
+            logger.warning("Failed to de-energize turret motor: %s", exc)
 
     def _write_holding(self, address: int, value: int) -> None:
         self._modbus.write_register(self._slave_id, address, value)

--- a/software/control/objective_turret_controller.py
+++ b/software/control/objective_turret_controller.py
@@ -180,7 +180,9 @@ class ObjectiveTurret4PosControllerSimulation:
         self._require_open()
         logger.info("Simulated turret enabled")
 
-    def move_to_objective(self, objective_name: str, timeout_s: float = DEFAULT_MOVE_TIMEOUT_S) -> None:
+    def move_to_objective(
+        self, objective_name: str, timeout_s: float = DEFAULT_MOVE_TIMEOUT_S, restore_z: bool = True
+    ) -> None:
         self._require_open()
         if _is_alias_for_current(self._current_objective, objective_name, self._positions):
             self._current_objective = objective_name
@@ -189,7 +191,8 @@ class ObjectiveTurret4PosControllerSimulation:
 
         captured_z = self._retract_z_if_possible()
         self._current_objective = objective_name
-        self._restore_z_if_captured(captured_z)
+        if restore_z:
+            self._restore_z_if_captured(captured_z)
 
         logger.info(
             "Simulated turret moved to %s (position %d)",
@@ -289,7 +292,10 @@ class ObjectiveTurret4PosController:
                 any(changed),
             )
 
-            self.enable()
+            # Leave the motor de-energized; home() and move_to_objective() energize on
+            # demand and de-energize again when idle. The turret holds its slot
+            # mechanically and the controller retains its position counter while powered.
+            self._write_control(CW_DISABLE)
             self._is_open = True
         except Exception:
             self._modbus.disconnect()
@@ -303,13 +309,17 @@ class ObjectiveTurret4PosController:
         self._write_control(CW_ENABLE)
         self._write_control(CW_RUN_ABSOLUTE)
         self._write_control(CW_TRIGGER_ABSOLUTE)
-        self._wait_until_idle(timeout_s)
-        # Reset counter to 0 at the post-homing position so absolute slot targets
-        # land at the correct physical angle.
-        pre = self.current_position_pulses
-        self._write_holding(REG_SET_ZERO, SET_ZERO_MAGIC)
-        time.sleep(0.05)
-        post = self.current_position_pulses
+        try:
+            self._wait_until_idle(timeout_s)
+            # Reset counter to 0 at the post-homing position so absolute slot targets
+            # land at the correct physical angle.
+            pre = self.current_position_pulses
+            self._write_holding(REG_SET_ZERO, SET_ZERO_MAGIC)
+            time.sleep(0.05)
+            post = self.current_position_pulses
+        finally:
+            # De-energize when idle: the turret holds its slot mechanically.
+            self._write_control(CW_DISABLE)
         self._current_objective = None
         logger.info("Homed: pre_set_zero=%d, post_set_zero=%d", pre, post)
 
@@ -319,7 +329,9 @@ class ObjectiveTurret4PosController:
         self._write_control(CW_STARTUP)
         self._write_control(CW_ENABLE)
 
-    def move_to_objective(self, objective_name: str, timeout_s: float = DEFAULT_MOVE_TIMEOUT_S) -> None:
+    def move_to_objective(
+        self, objective_name: str, timeout_s: float = DEFAULT_MOVE_TIMEOUT_S, restore_z: bool = True
+    ) -> None:
         self._require_open()
         if _is_alias_for_current(self._current_objective, objective_name, self._positions):
             self._current_objective = objective_name
@@ -330,7 +342,8 @@ class ObjectiveTurret4PosController:
             self._rotate_to(objective_name, timeout_s)
             self._current_objective = objective_name
         finally:
-            self._restore_z_if_captured(captured_z)
+            if restore_z:
+                self._restore_z_if_captured(captured_z)
 
     def clear_alarm(self) -> None:
         self._write_control(CW_CLEAR_FAULT)
@@ -393,7 +406,11 @@ class ObjectiveTurret4PosController:
         self._write_control(CW_ENABLE)
         self._write_control(CW_RUN_ABSOLUTE)
         self._write_control(CW_TRIGGER_ABSOLUTE)
-        self._wait_for_position(target_pulses, timeout_s)
+        try:
+            self._wait_for_position(target_pulses, timeout_s)
+        finally:
+            # De-energize when idle: the turret holds its slot mechanically.
+            self._write_control(CW_DISABLE)
         logger.info(
             "Rotated to %s: target=%d, actual=%d",
             objective_name,

--- a/software/control/objective_turret_controller.py
+++ b/software/control/objective_turret_controller.py
@@ -292,10 +292,8 @@ class ObjectiveTurret4PosController:
                 any(changed),
             )
 
-            # Leave the motor de-energized; home() and move_to_objective() energize on
-            # demand and de-energize again when idle. The turret holds its slot
-            # mechanically and the controller retains its position counter while powered.
-            self._write_control(CW_DISABLE)
+            # Leave the motor de-energized; home()/move_to_objective() energize on demand.
+            self._deenergize()
             self._is_open = True
         except Exception:
             self._modbus.disconnect()
@@ -318,8 +316,7 @@ class ObjectiveTurret4PosController:
             time.sleep(0.05)
             post = self.current_position_pulses
         finally:
-            # De-energize when idle: the turret holds its slot mechanically.
-            self._write_control(CW_DISABLE)
+            self._deenergize()
         self._current_objective = None
         logger.info("Homed: pre_set_zero=%d, post_set_zero=%d", pre, post)
 
@@ -409,8 +406,7 @@ class ObjectiveTurret4PosController:
         try:
             self._wait_for_position(target_pulses, timeout_s)
         finally:
-            # De-energize when idle: the turret holds its slot mechanically.
-            self._write_control(CW_DISABLE)
+            self._deenergize()
         logger.info(
             "Rotated to %s: target=%d, actual=%d",
             objective_name,
@@ -471,6 +467,11 @@ class ObjectiveTurret4PosController:
 
     def _write_control(self, value: int) -> None:
         self._modbus.write_register(self._slave_id, REG_CONTROL_WORD, value)
+
+    def _deenergize(self) -> None:
+        """Remove holding current so the motor idles cold. The turret holds its slot
+        mechanically and the controller retains its position counter while powered."""
+        self._write_control(CW_DISABLE)
 
     def _write_holding(self, address: int, value: int) -> None:
         self._modbus.write_register(self._slave_id, address, value)

--- a/software/squid/config.py
+++ b/software/squid/config.py
@@ -201,6 +201,10 @@ class AxisConfig(pydantic.BaseModel):
             / (self.MOVEMENT_SIGN.value * self.SCREW_PITCH / (self.MICROSTEPS_PER_STEP * self.FULL_STEPS_PER_REV))
         )
 
+    def clamp_position(self, value: float) -> float:
+        """Clamp a position (native units) into this axis's [MIN_POSITION, MAX_POSITION] range."""
+        return min(max(value, self.MIN_POSITION), self.MAX_POSITION)
+
 
 class StageConfig(pydantic.BaseModel):
     X_AXIS: AxisConfig

--- a/software/squid/stage/cephla.py
+++ b/software/squid/stage/cephla.py
@@ -111,6 +111,17 @@ class CephlaStage(AbstractStage):
             )
 
     def move_z_to(self, abs_mm: float, blocking: bool = True):
+        # Clamp to the configured Z soft limits before commanding the move. The firmware's
+        # absolute MOVETO_Z records the requested target unclamped but parks the motor at the
+        # soft limit, so an out-of-range target never reports complete and the move times out.
+        # (e.g. the objective-turret retract/restore commanding the post-home Z=0.0, which is
+        # below MIN_POSITION). This mirrors the MIN_POSITION clamp on the backlash pre-move below.
+        z_config = self.get_config().Z_AXIS
+        clamped_abs_mm = min(max(abs_mm, z_config.MIN_POSITION), z_config.MAX_POSITION)
+        if clamped_abs_mm != abs_mm:
+            self._log.debug(f"Clamped Z move target {abs_mm} mm to soft limit {clamped_abs_mm} mm.")
+        abs_mm = clamped_abs_mm
+
         # From Hongquan, we want the z axis to rest on the "up" (wrt gravity) direction of gravity. So if we
         # are moving in the negative (down) z direction, we need to move past our mark a bit then
         # back up.  If we are already moving in the "up" position, we can move straight there.

--- a/software/squid/stage/cephla.py
+++ b/software/squid/stage/cephla.py
@@ -116,8 +116,7 @@ class CephlaStage(AbstractStage):
         # soft limit, so an out-of-range target never reports complete and the move times out.
         # (e.g. the objective-turret retract/restore commanding the post-home Z=0.0, which is
         # below MIN_POSITION). This mirrors the MIN_POSITION clamp on the backlash pre-move below.
-        z_config = self.get_config().Z_AXIS
-        clamped_abs_mm = min(max(abs_mm, z_config.MIN_POSITION), z_config.MAX_POSITION)
+        clamped_abs_mm = self.get_config().Z_AXIS.clamp_position(abs_mm)
         if clamped_abs_mm != abs_mm:
             self._log.debug(f"Clamped Z move target {abs_mm} mm to soft limit {clamped_abs_mm} mm.")
         abs_mm = clamped_abs_mm

--- a/software/tests/control/test_objective_turret_controller.py
+++ b/software/tests/control/test_objective_turret_controller.py
@@ -5,9 +5,18 @@ from __future__ import annotations
 import pytest
 
 import control._def
+import control.objective_turret_controller as otc
 from control._def import OBJECTIVE_TURRET_POSITIONS, OBJECTIVE_RETRACTED_POS_MM
 from control.objective_turret_controller import (
+    ObjectiveTurret4PosController,
     ObjectiveTurret4PosControllerSimulation,
+    CW_DISABLE,
+    CW_ENABLE,
+    REG_CONTROL_WORD,
+    REG_CURRENT_POSITION,
+    REG_MICROSTEP,
+    REG_STATUS_WORD,
+    REG_TARGET_POSITION,
 )
 
 
@@ -167,3 +176,101 @@ def test_move_between_aliased_objectives_skips_z_retract(monkeypatch):
     assert sim.current_objective == "4x_B"
 
     sim.close()
+
+
+def test_move_to_objective_skips_restore_when_restore_z_false(monkeypatch):
+    # At startup Z was just homed to 0 (below the working floor), so the turret
+    # retracts and rotates but must NOT restore Z; the cached-Z restore handles it.
+    monkeypatch.setattr(control._def, "HOMING_ENABLED_Z", True)
+    stage = FakeStage(z_mm=3.5)
+    sim = _make_sim(stage=stage)
+
+    sim.move_to_objective("40x", restore_z=False)
+
+    # Retract happened; the restore back to the captured Z did not.
+    assert stage.z_moves == [OBJECTIVE_RETRACTED_POS_MM]
+    assert sim.current_objective == "40x"
+    sim.close()
+
+
+class _FakeModbus:
+    """Minimal ModbusRTUClient stand-in that records register writes.
+
+    Reads return values that drive the controller's wait loops straight to a
+    completed/idle state; writes are recorded so tests can assert the control-word
+    sequence (in particular, that the motor ends de-energized).
+    """
+
+    def __init__(self):
+        self.connected = False
+        self.writes = []  # (address, value) in order
+        self._position = 0
+
+    def connect(self, port=None, baudrate=None):
+        self.connected = True
+
+    def disconnect(self):
+        self.connected = False
+
+    @property
+    def is_connected(self):
+        return self.connected
+
+    def read_register(self, slave_id, address):
+        # Microstep register must be 0..7; 4 -> 16 microsteps.
+        return 4 if address == REG_MICROSTEP else 0
+
+    def read_register_32bit(self, slave_id, address, signed=False):
+        return 0
+
+    def read_input_register(self, slave_id, address):
+        # Status word: neither RUNNING nor FAULT -> wait loops see "idle".
+        return 0
+
+    def read_input_register_32bit(self, slave_id, address, signed=False):
+        # Report the commanded target as the live position so the move-complete
+        # tolerance check passes immediately.
+        return self._position if address == REG_CURRENT_POSITION else 0
+
+    def write_register(self, slave_id, address, value):
+        self.writes.append((address, value))
+
+    def write_register_32bit(self, slave_id, address, value, signed=False):
+        self.writes.append((address, value))
+        if address == REG_TARGET_POSITION:
+            self._position = value
+
+    def control_word_writes(self):
+        return [value for (address, value) in self.writes if address == REG_CONTROL_WORD]
+
+
+def _make_real_controller(monkeypatch):
+    fake = _FakeModbus()
+    monkeypatch.setattr(otc, "_find_port", lambda serial_number: "FAKE_PORT")
+    monkeypatch.setattr(otc, "ModbusRTUClient", lambda **kwargs: fake)
+    controller = ObjectiveTurret4PosController(serial_number="SIM", stage=None)
+    return controller, fake
+
+
+def test_init_leaves_motor_deenergized(monkeypatch):
+    controller, fake = _make_real_controller(monkeypatch)
+    assert fake.control_word_writes()[-1] == CW_DISABLE
+    controller.close()
+
+
+def test_move_to_objective_deenergizes_when_idle(monkeypatch):
+    controller, fake = _make_real_controller(monkeypatch)
+    fake.writes.clear()
+    controller.move_to_objective("40x")
+    # The motor energizes to rotate but is de-energized once the move completes.
+    assert fake.control_word_writes()[-1] == CW_DISABLE
+    assert CW_ENABLE in fake.control_word_writes()  # it did energize to move
+    controller.close()
+
+
+def test_home_deenergizes_when_idle(monkeypatch):
+    controller, fake = _make_real_controller(monkeypatch)
+    fake.writes.clear()
+    controller.home()
+    assert fake.control_word_writes()[-1] == CW_DISABLE
+    controller.close()

--- a/software/tests/control/test_objective_turret_controller.py
+++ b/software/tests/control/test_objective_turret_controller.py
@@ -274,3 +274,18 @@ def test_home_deenergizes_when_idle(monkeypatch):
     controller.home()
     assert fake.control_word_writes()[-1] == CW_DISABLE
     controller.close()
+
+
+def test_deenergize_is_best_effort(monkeypatch):
+    # _deenergize() runs from finally blocks after a move/home, so a failed disable
+    # write must not raise and mask the real timeout/fault that triggered the cleanup.
+    controller, fake = _make_real_controller(monkeypatch)
+
+    def failing_write(slave_id, address, value):
+        if address == REG_CONTROL_WORD:
+            raise IOError("modbus link down")
+        fake.writes.append((address, value))
+
+    monkeypatch.setattr(fake, "write_register", failing_write)
+    controller._deenergize()  # must not raise despite the failing control-word write
+    controller.close()

--- a/software/tests/squid/test_stage_z_limit.py
+++ b/software/tests/squid/test_stage_z_limit.py
@@ -1,0 +1,124 @@
+"""Z soft-limit clamping for CephlaStage.move_z_to.
+
+Regression tests for the objective-turret startup TimeoutError: after homing the
+firmware reports Z=0.0, which is below the configured Z soft floor (MIN_POSITION,
+0.05mm by default). The turret's retract/restore dance then commands an absolute
+move back to 0.0. The firmware's absolute MOVETO_Z stores that target unclamped
+while parking the motor at the clamped limit, so the move never reports complete
+and wait_till_operation_is_completed times out.
+
+The host-side fix clamps the final absolute Z target to [MIN_POSITION,
+MAX_POSITION] in CephlaStage.move_z_to, mirroring the clamp already applied to the
+backlash pre-move. Relative MOVE_Z is already clamped firmware-side, so only the
+absolute path needs this guard.
+"""
+
+import pytest
+
+import squid.config
+import squid.stage.cephla
+from control._def import CMD_EXECUTION_STATUS, CMD_SET
+from control.microcontroller import Microcontroller, SimSerial
+
+
+class _ZSoftLimitDeadlockSerial(SimSerial):
+    """SimSerial that reproduces the firmware's below-soft-limit Z deadlock.
+
+    The stock SimSerial accepts any absolute MOVETO_Z and immediately reports
+    COMPLETED at the commanded position, so it cannot reproduce the hang. This
+    subclass models the real Teensy behavior: do_focus_control drives the motor
+    to the clamped soft limit, but check_position compares the live position
+    against the *unclamped* commanded target, so a below-limit target never
+    matches and the command stays IN_PROGRESS forever.
+    """
+
+    def __init__(self, z_axis_config):
+        super().__init__()
+        lo = z_axis_config.convert_real_units_to_ustep(z_axis_config.MIN_POSITION)
+        hi = z_axis_config.convert_real_units_to_ustep(z_axis_config.MAX_POSITION)
+        # MOVEMENT_SIGN can invert ustep ordering, so sort to get the reachable range.
+        self._z_lo_ust, self._z_hi_ust = sorted((lo, hi))
+
+    def _respond_to(self, write_bytes):
+        if write_bytes[1] == CMD_SET.MOVETO_Z:
+            target = self.unpack_position(write_bytes[2:6])
+            if not (self._z_lo_ust <= target <= self._z_hi_ust):
+                # Park at the clamped limit but never acknowledge the unclamped
+                # target -> perpetual IN_PROGRESS, exactly as the firmware wedges.
+                self.z = min(max(target, self._z_lo_ust), self._z_hi_ust)
+                self.response_buffer.extend(
+                    SimSerial.response_bytes_for(
+                        write_bytes[0],
+                        CMD_EXECUTION_STATUS.IN_PROGRESS,
+                        self.x,
+                        self.y,
+                        self.z,
+                        self.theta,
+                        self.joystick_button,
+                        self.switch,
+                        firmware_version=(SimSerial.FIRMWARE_VERSION_MAJOR, SimSerial.FIRMWARE_VERSION_MINOR),
+                    )
+                )
+                self._update_internal_state()
+                return
+        super()._respond_to(write_bytes)
+
+
+@pytest.fixture
+def make_stage():
+    """Build a CephlaStage on a given SimSerial, closing the microcontroller at teardown.
+
+    tests/squid/ has no autouse Microcontroller-cleanup fixture (that lives in
+    tests/control/conftest.py), so close it here to stop the background
+    serial-read thread, per the CLAUDE.md segfault note.
+    """
+    created = []
+
+    def _make(serial=None):
+        mc = Microcontroller(serial if serial is not None else SimSerial(), True)
+        created.append(mc)
+        return squid.stage.cephla.CephlaStage(mc, squid.config.get_stage_config())
+
+    yield _make
+
+    for mc in created:
+        mc.close()
+
+
+def test_move_z_to_below_min_clamps_to_min(make_stage):
+    stage = make_stage()
+    z_min = stage.get_config().Z_AXIS.MIN_POSITION
+    # Mirror the turret restore: retract up, then attempt to restore below the floor.
+    stage.move_z_to(0.1)
+    stage.move_z_to(0.0)
+    assert stage.get_pos().z_mm == pytest.approx(z_min, abs=1e-3)
+
+
+def test_move_z_to_above_max_clamps_to_max(make_stage):
+    stage = make_stage()
+    z_max = stage.get_config().Z_AXIS.MAX_POSITION
+    stage.move_z_to(z_max + 5.0)
+    assert stage.get_pos().z_mm == pytest.approx(z_max, abs=1e-3)
+
+
+def test_move_z_to_in_range_is_not_clamped(make_stage):
+    stage = make_stage()
+    stage.move_z_to(1.0)
+    assert stage.get_pos().z_mm == pytest.approx(1.0, abs=1e-3)
+
+
+def test_move_z_to_below_soft_limit_does_not_deadlock(make_stage, monkeypatch):
+    # Keep the pre-fix failing path fast: a below-limit move would otherwise wait
+    # the full computed timeout before raising.
+    monkeypatch.setattr(
+        squid.stage.cephla.CephlaStage,
+        "_calc_move_timeout",
+        staticmethod(lambda distance, max_speed: 0.5),
+    )
+    cfg = squid.config.get_stage_config()
+    stage = make_stage(_ZSoftLimitDeadlockSerial(cfg.Z_AXIS))
+    z_min = cfg.Z_AXIS.MIN_POSITION
+    # Reproduce the turret startup sequence against firmware-faithful limits.
+    stage.move_z_to(0.1)
+    stage.move_z_to(0.0)  # pre-fix: TimeoutError; post-fix: clamped to the floor
+    assert stage.get_pos().z_mm == pytest.approx(z_min, abs=1e-3)


### PR DESCRIPTION
## Problem

With the objective turret enabled, startup crashed with:

```
TimeoutError: Current mcu operation timed out after 3 [s].
  ... objective_turret_controller._restore_z_if_captured
  ... squid/stage/cephla.py move_z_to
  ... microcontroller.wait_till_operation_is_completed
```

**Root cause:** `move_to_objective` runs in `_prepare_for_use` immediately after homing. The firmware's `finalize_homing_z` sets Z = **0.0**, but the config's Z soft floor is **0.05 mm**. The turret captures `z=0.0`, retracts up to `OBJECTIVE_RETRACTED_POS_MM` (fine), then restores **back to 0.0** — below the floor. The firmware's absolute `MOVETO_Z` stores `Z_commanded_target_position` *unclamped* while `do_focus_control` parks the motor at the clamped `Z_NEG_LIMIT`, so `check_position` (which compares against the unclamped target) never matches, `mcu_cmd_execution_in_progress` never clears, and the host times out after exactly 3 s (`30 × 0.1 mm`). The relative `MOVE_Z` path is already clamped firmware-side, so only the absolute path is affected — which is why this only appeared with the turret (the one startup path issuing a below-floor absolute Z).

## Changes

1. **Z soft-limit clamp** (`squid/stage/cephla.py`) — `move_z_to` clamps its target to `[MIN_POSITION, MAX_POSITION]` before commanding, mirroring the existing backlash pre-move clamp. Defense-in-depth: closes the latent firmware deadlock for *every* below-floor absolute-Z caller (scanning-position restore, multipoint return-to-start, focus-map gotos, `goto_z_min`). Clamping only ever moves Z toward the retracted/safe direction, so it can't crash the objective into the sample.

2. **Turret de-energizes when idle** (`control/objective_turret_controller.py`) — energizes only to home/rotate and `CW_DISABLE`s in a `finally` (even on timeout/error). `__init__` ends de-energized. The turret holds its slot mechanically and the controller retains its position counter while powered, so absolute targeting still works and the skip-re-home-on-restart optimization is preserved. `move_to_objective()` gains `restore_z` (default `True`).

3. **No startup restore to 0** (`control/microscope.py`) — at startup the turret passes `restore_z=False` when Z was just homed, so it no longer restores to the meaningless post-home 0.0; the existing cached-Z restore at GUI startup positions Z to the last focus. Mid-session objective changes still restore the live focus.

## Tests

- **`tests/squid/test_stage_z_limit.py`** (new) — a firmware-faithful `SimSerial` that wedges on a below-limit `MOVETO_Z` **reproduces the exact `TimeoutError`**; the clamp resolves it. Plus below-min/above-max/in-range clamp assertions.
- **`tests/control/test_objective_turret_controller.py`** — `restore_z=False` skips the restore; `init`/`move`/`home` all end de-energized (first real-controller coverage, via a fake-Modbus harness).
- Full run: **1285 passed, 8 skipped** across `tests/squid` + `tests/control`; black clean.

## Follow-up (firmware, optional)

The host clamp neutralizes the deadlock without a reflash. The authoritative firmware fix is a one-liner mirroring the relative path — clamp `Z_commanded_target_position` in `callback_move_to_z` — and can land separately on the firmware tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
