### PR TITLE
feat(turret): per-machine objective turret pulse offset

### DIFF
--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -1221,6 +1221,11 @@ OBJECTIVE_TURRET_SLAVE_ID = 1
 OBJECTIVE_TURRET_BAUDRATE = 115200
 # Objective name -> turret slot index (1..4). Override per machine in .ini.
 OBJECTIVE_TURRET_POSITIONS = {"4x": 1, "10x": 2, "20x": 3, "40x": 4}
+# Global pulse offset added to every turret slot target, shifting the whole slot
+# frame relative to the homing switch (pulse 0). Corrects units whose limit switch
+# does not sit exactly at slot 1. 0 on all normal units; set per machine (may be
+# negative).
+OBJECTIVE_TURRET_OFFSET_PULSES = 0
 
 
 def _validate_objective_changer_flags(use_xeryon: bool, use_turret: bool) -> None:

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -156,6 +156,7 @@ class MicroscopeAddons:
                 slave_id=control._def.OBJECTIVE_TURRET_SLAVE_ID,
                 baudrate=control._def.OBJECTIVE_TURRET_BAUDRATE,
                 positions=control._def.OBJECTIVE_TURRET_POSITIONS,
+                offset_pulses=control._def.OBJECTIVE_TURRET_OFFSET_PULSES,
                 stage=stage,
             )
             objective_changer = (

--- a/software/control/objective_turret_controller.py
+++ b/software/control/objective_turret_controller.py
@@ -80,9 +80,11 @@ EXPECTED_MIN_SPEED = 150
 # this firmware (motion is identical at 0 or 1). Set to 0 for documented-disabled.
 DRIVE_PARAM = 0
 
-# Homing defaults (auto-calibrated on first connect). Slot 1 sits at the limit
-# on this turret, so counter=0 lands at the switch — HOMING_ORIGIN_OFFSET=0
-# enforces that against any tool that may have written a non-zero offset.
+# Homing defaults (auto-calibrated on first connect). counter=0 is established at
+# the limit switch by the SET_ZERO in home(); HOMING_ORIGIN_OFFSET=0 keeps the
+# NiMotion's own homing-offset register out of the picture (SET_ZERO cancels it
+# anyway). On units where slot 1 does not sit exactly at the switch, the
+# correction is applied in software instead — see OBJECTIVE_TURRET_OFFSET_PULSES.
 HOMING_METHOD = 17
 HOMING_ORIGIN_OFFSET = 0
 HOMING_SEARCH_SPEED = 1000
@@ -161,12 +163,14 @@ class ObjectiveTurret4PosControllerSimulation:
         timeout: float = 0.5,
         positions: Optional[dict] = None,
         stage: Optional[squid.abc.AbstractStage] = None,
+        offset_pulses: Optional[int] = None,  # accepted for constructor parity with the real controller
     ):
         from control._def import OBJECTIVE_TURRET_POSITIONS
 
         self._is_open = True
         self._current_objective: Optional[str] = None
         self._positions = dict(positions) if positions is not None else dict(OBJECTIVE_TURRET_POSITIONS)
+        # offset_pulses is unused here: the simulation tracks objectives by name and never computes pulses.
         self._stage = stage
         logger.info("Simulated turret opened (sn=%s)", serial_number)
 
@@ -254,11 +258,18 @@ class ObjectiveTurret4PosController:
         timeout: float = 0.5,
         positions: Optional[dict] = None,
         stage: Optional[squid.abc.AbstractStage] = None,
+        offset_pulses: Optional[int] = None,
     ) -> None:
-        from control._def import OBJECTIVE_TURRET_POSITIONS
+        from control._def import OBJECTIVE_TURRET_POSITIONS, OBJECTIVE_TURRET_OFFSET_PULSES
 
         self._slave_id = slave_id
         self._positions = dict(positions) if positions is not None else dict(OBJECTIVE_TURRET_POSITIONS)
+        offset = offset_pulses if offset_pulses is not None else OBJECTIVE_TURRET_OFFSET_PULSES
+        # Comes from per-machine .ini parsing; reject non-int so misconfiguration fails
+        # fast here instead of deep in the signed Modbus write (bool is an int subclass).
+        if isinstance(offset, bool) or not isinstance(offset, int):
+            raise ValueError(f"OBJECTIVE_TURRET_OFFSET_PULSES must be an integer number of pulses, got {offset!r}")
+        self._offset_pulses = offset
         self._stage = stage
         self._current_objective: Optional[str] = None
         self._is_open = False
@@ -387,7 +398,7 @@ class ObjectiveTurret4PosController:
 
     def _rotate_to(self, objective_name: str, timeout_s: float) -> None:
         position_index = _resolve_position(objective_name, self._positions)
-        target_pulses = (position_index - 1) * self._pulses_per_position
+        target_pulses = (position_index - 1) * self._pulses_per_position + self._offset_pulses
 
         logger.info(
             "Rotating to %s: start=%d, target=%d",

--- a/software/control/objective_turret_controller.py
+++ b/software/control/objective_turret_controller.py
@@ -291,6 +291,15 @@ class ObjectiveTurret4PosController:
             self._microstep = 2**microstep_raw
             self._pulses_per_position = int(MOTOR_STEPS_PER_REV * self._microstep * GEAR_RATIO / POSITIONS_PER_REV)
 
+            # A real slot-1 misalignment is always smaller than the 90-degree slot spacing;
+            # a larger value means the slot mapping itself is wrong, not that slot 1 is off.
+            # Bounding it also keeps every target inside the signed 32-bit register (no wrap).
+            if abs(self._offset_pulses) > self._pulses_per_position:
+                raise ValueError(
+                    f"OBJECTIVE_TURRET_OFFSET_PULSES={self._offset_pulses} exceeds one slot "
+                    f"(±{self._pulses_per_position} pulses ≈ 90°); check the machine .ini"
+                )
+
             changed = [self._calibrate_motion_params(), self._calibrate_homing_config()]
             if any(changed):
                 self._save_to_eeprom()

--- a/software/tests/control/test_objective_turret_controller.py
+++ b/software/tests/control/test_objective_turret_controller.py
@@ -244,12 +244,16 @@ class _FakeModbus:
         return [value for (address, value) in self.writes if address == REG_CONTROL_WORD]
 
 
-def _make_real_controller(monkeypatch):
+def _make_real_controller(monkeypatch, **controller_kwargs):
     fake = _FakeModbus()
     monkeypatch.setattr(otc, "_find_port", lambda serial_number: "FAKE_PORT")
     monkeypatch.setattr(otc, "ModbusRTUClient", lambda **kwargs: fake)
-    controller = ObjectiveTurret4PosController(serial_number="SIM", stage=None)
+    controller = ObjectiveTurret4PosController(serial_number="SIM", stage=None, **controller_kwargs)
     return controller, fake
+
+
+def _target_position_writes(fake):
+    return [value for (address, value) in fake.writes if address == REG_TARGET_POSITION]
 
 
 def test_init_leaves_motor_deenergized(monkeypatch):
@@ -289,3 +293,75 @@ def test_deenergize_is_best_effort(monkeypatch):
     monkeypatch.setattr(fake, "write_register", failing_write)
     controller._deenergize()  # must not raise despite the failing control-word write
     controller.close()
+
+
+def test_move_targets_have_no_offset_by_default(monkeypatch):
+    # Default (offset 0): slot N targets the bare (N-1)*pulses_per_position.
+    controller, fake = _make_real_controller(monkeypatch)
+    pp = controller.pulses_per_position
+    for name, index in OBJECTIVE_TURRET_POSITIONS.items():
+        fake.writes.clear()
+        controller.move_to_objective(name)
+        assert _target_position_writes(fake)[-1] == (index - 1) * pp
+    controller.close()
+
+
+def test_move_targets_include_offset(monkeypatch):
+    # A configured offset is added to every slot target.
+    offset = 37
+    controller, fake = _make_real_controller(monkeypatch, offset_pulses=offset)
+    pp = controller.pulses_per_position
+    for name, index in OBJECTIVE_TURRET_POSITIONS.items():
+        fake.writes.clear()
+        controller.move_to_objective(name)
+        assert _target_position_writes(fake)[-1] == (index - 1) * pp + offset
+    controller.close()
+
+
+def test_move_targets_handle_negative_offset(monkeypatch):
+    # The offset may be negative (limit switch on the far side of slot 1); the
+    # signed 32-bit write and the tolerance check must handle a negative target.
+    offset = -30
+    controller, fake = _make_real_controller(monkeypatch, offset_pulses=offset)
+    pp = controller.pulses_per_position
+    fake.writes.clear()
+    controller.move_to_objective("4x")  # slot 1 -> negative absolute target
+    assert _target_position_writes(fake)[-1] == offset
+    fake.writes.clear()
+    controller.move_to_objective("40x")  # slot 4
+    assert _target_position_writes(fake)[-1] == 3 * pp + offset
+    controller.close()
+
+
+def test_offset_falls_back_to_def_when_not_passed(monkeypatch):
+    # With no explicit kwarg, the controller picks up the per-machine _def value.
+    monkeypatch.setattr(control._def, "OBJECTIVE_TURRET_OFFSET_PULSES", 25)
+    controller, fake = _make_real_controller(monkeypatch)
+    pp = controller.pulses_per_position
+    fake.writes.clear()
+    controller.move_to_objective("40x")  # slot index 4
+    assert _target_position_writes(fake)[-1] == 3 * pp + 25
+    controller.close()
+
+
+@pytest.mark.parametrize("bad_offset", [37.5, "30", True])
+def test_non_int_offset_raises(monkeypatch, bad_offset):
+    # .ini parsing can yield a float/str/bool; a non-int offset must fail fast at init
+    # rather than deep in the signed Modbus write.
+    monkeypatch.setattr(otc, "_find_port", lambda serial_number: "FAKE_PORT")
+    monkeypatch.setattr(otc, "ModbusRTUClient", lambda **kwargs: _FakeModbus())
+    with pytest.raises(ValueError):
+        ObjectiveTurret4PosController(serial_number="SIM", stage=None, offset_pulses=bad_offset)
+
+
+def test_sim_accepts_offset_kwarg():
+    # The simulation twin must accept the same kwarg (built from the same turret_kwargs).
+    sim = ObjectiveTurret4PosControllerSimulation(
+        serial_number="SIM-001",
+        positions=OBJECTIVE_TURRET_POSITIONS,
+        offset_pulses=42,
+    )
+    assert sim.is_open
+    sim.move_to_objective("20x")
+    assert sim.current_objective == "20x"
+    sim.close()

--- a/software/tests/control/test_objective_turret_controller.py
+++ b/software/tests/control/test_objective_turret_controller.py
@@ -243,6 +243,9 @@ class _FakeModbus:
     def control_word_writes(self):
         return [value for (address, value) in self.writes if address == REG_CONTROL_WORD]
 
+    def target_position_writes(self):
+        return [value for (address, value) in self.writes if address == REG_TARGET_POSITION]
+
 
 def _make_real_controller(monkeypatch, **controller_kwargs):
     fake = _FakeModbus()
@@ -250,10 +253,6 @@ def _make_real_controller(monkeypatch, **controller_kwargs):
     monkeypatch.setattr(otc, "ModbusRTUClient", lambda **kwargs: fake)
     controller = ObjectiveTurret4PosController(serial_number="SIM", stage=None, **controller_kwargs)
     return controller, fake
-
-
-def _target_position_writes(fake):
-    return [value for (address, value) in fake.writes if address == REG_TARGET_POSITION]
 
 
 def test_init_leaves_motor_deenergized(monkeypatch):
@@ -295,41 +294,17 @@ def test_deenergize_is_best_effort(monkeypatch):
     controller.close()
 
 
-def test_move_targets_have_no_offset_by_default(monkeypatch):
-    # Default (offset 0): slot N targets the bare (N-1)*pulses_per_position.
-    controller, fake = _make_real_controller(monkeypatch)
-    pp = controller.pulses_per_position
-    for name, index in OBJECTIVE_TURRET_POSITIONS.items():
-        fake.writes.clear()
-        controller.move_to_objective(name)
-        assert _target_position_writes(fake)[-1] == (index - 1) * pp
-    controller.close()
-
-
-def test_move_targets_include_offset(monkeypatch):
-    # A configured offset is added to every slot target.
-    offset = 37
+@pytest.mark.parametrize("offset", [0, 37, -30], ids=["default", "positive", "negative"])
+def test_move_targets_apply_offset(monkeypatch, offset):
+    # Every slot N targets (N-1)*pulses_per_position + offset. offset=0 proves default
+    # behavior is unchanged; the negative case drives slot 1 to a negative absolute
+    # target, exercising the signed 32-bit write and the tolerance check.
     controller, fake = _make_real_controller(monkeypatch, offset_pulses=offset)
     pp = controller.pulses_per_position
     for name, index in OBJECTIVE_TURRET_POSITIONS.items():
         fake.writes.clear()
         controller.move_to_objective(name)
-        assert _target_position_writes(fake)[-1] == (index - 1) * pp + offset
-    controller.close()
-
-
-def test_move_targets_handle_negative_offset(monkeypatch):
-    # The offset may be negative (limit switch on the far side of slot 1); the
-    # signed 32-bit write and the tolerance check must handle a negative target.
-    offset = -30
-    controller, fake = _make_real_controller(monkeypatch, offset_pulses=offset)
-    pp = controller.pulses_per_position
-    fake.writes.clear()
-    controller.move_to_objective("4x")  # slot 1 -> negative absolute target
-    assert _target_position_writes(fake)[-1] == offset
-    fake.writes.clear()
-    controller.move_to_objective("40x")  # slot 4
-    assert _target_position_writes(fake)[-1] == 3 * pp + offset
+        assert fake.target_position_writes()[-1] == (index - 1) * pp + offset
     controller.close()
 
 
@@ -340,7 +315,7 @@ def test_offset_falls_back_to_def_when_not_passed(monkeypatch):
     pp = controller.pulses_per_position
     fake.writes.clear()
     controller.move_to_objective("40x")  # slot index 4
-    assert _target_position_writes(fake)[-1] == 3 * pp + 25
+    assert fake.target_position_writes()[-1] == 3 * pp + 25
     controller.close()
 
 

--- a/software/tests/control/test_objective_turret_controller.py
+++ b/software/tests/control/test_objective_turret_controller.py
@@ -354,6 +354,16 @@ def test_non_int_offset_raises(monkeypatch, bad_offset):
         ObjectiveTurret4PosController(serial_number="SIM", stage=None, offset_pulses=bad_offset)
 
 
+def test_out_of_range_offset_raises(monkeypatch):
+    # An offset beyond one slot (the 90-degree spacing) is a misconfiguration and must be
+    # rejected. With the fake's microstep 4 -> 16 microsteps, pulses/position = 2200, so
+    # 5000 is over one slot (but under a full rev) — it must still be rejected.
+    monkeypatch.setattr(otc, "_find_port", lambda serial_number: "FAKE_PORT")
+    monkeypatch.setattr(otc, "ModbusRTUClient", lambda **kwargs: _FakeModbus())
+    with pytest.raises(ValueError):
+        ObjectiveTurret4PosController(serial_number="SIM", stage=None, offset_pulses=5_000)
+
+
 def test_sim_accepts_offset_kwarg():
     # The simulation twin must accept the same kwarg (built from the same turret_kwargs).
     sim = ObjectiveTurret4PosControllerSimulation(


### PR DESCRIPTION
## Problem

Normally the objective turret's homing limit switch coincides with slot 1: after `home()` seeks the switch and zeroes the position counter there, every objective lands at the correct angle. On **one** unit the switch does not sit exactly at slot 1, so all four objectives are rotated by the same small constant.

## Change

Adds a per-machine config knob **`OBJECTIVE_TURRET_OFFSET_PULSES`** (default `0`, may be negative) — a single global offset added to every slot target in `_rotate_to`, shifting the whole turret frame uniformly relative to the homing zero:

```python
target_pulses = (position_index - 1) * self._pulses_per_position + self._offset_pulses
```

Set it per machine in that unit's `configuration*.ini`:

```ini
[GENERAL]
objective_turret_offset_pulses = <measured, may be negative>
```

Every other machine keeps `0` → unchanged behavior.

### Why software, not the hardware homing register

The NiMotion's own `REG_HOMING_OFFSET` (0x0069) can't carry this correction:
- `home()` unconditionally issues `SET_ZERO` after the limit-switch seek, re-zeroing the counter at the physical stop — cancelling any homing-register offset.
- `_HOMING_PARAMS` actively forces `REG_HOMING_OFFSET` back to `0` on every connect (and saves to EEPROM).

`_rotate_to` is the single place a slot index becomes an absolute pulse target, so it's the right seam to apply the correction. `home()` is untouched — the counter still zeros at the switch.

### Naming

Named `OBJECTIVE_TURRET_OFFSET_PULSES` (not `HOME_OFFSET` or `SLOT1_OFFSET`) because it's a single **global** offset applied uniformly to all slots, acting at move time rather than home time — and to avoid colliding with the file's hardware-homing terms (`HOMING_ORIGIN_OFFSET`, `REG_HOMING_OFFSET`) that this value deliberately does *not* touch.

### Validation

The value is parsed from the machine `.ini` (via `json.loads`), so it can come back as a float/string/bool. The controller validates the resolved offset is an `int` at init and raises `ValueError` otherwise, so misconfiguration fails fast with a clear message rather than deep in the signed Modbus write.

## Plumbing

Threaded through the controller constructor mirroring the existing `positions` fallback, wired from `microscope.py`'s shared `turret_kwargs`. The simulation twin accepts the kwarg for constructor parity (it tracks objectives by name and never computes pulses).

## Tests

`tests/control/test_objective_turret_controller.py` (29 pass, black clean):
- default (no offset) → slot N targets `(N−1)·pulses_per_position`
- explicit offset → added to every slot target across all 4 slots
- negative offset → verified through the signed 32-bit write / tolerance path
- non-int offset (`37.5`, `"30"`, `True`) → raises `ValueError` at init
- `_def` fallback when the kwarg isn't passed
- simulation twin accepts the kwarg

🤖 Generated with [Claude Code](https://claude.com/claude-code)