### PR TITLE
fix(laser-engine): bound serial write_timeout so a stuck engine can't hang startup

### DIFF
--- a/software/control/squid_laser_engine.py
+++ b/software/control/squid_laser_engine.py
@@ -489,6 +489,7 @@ class SquidLaserEngine(SquidLaserEngineBase):
     """USB-serial controller. Background query thread + receive thread."""
 
     BAUDRATE = 115200
+    WRITE_TIMEOUT_S = 2.0
 
     def __init__(
         self,
@@ -572,7 +573,7 @@ class SquidLaserEngine(SquidLaserEngineBase):
                 raise RuntimeError(f"SquidLaserEngine: no USB device found with serial number {self.sn!r}")
         elif port_path is None:
             raise RuntimeError("SquidLaserEngine: must provide either sn or device")
-        return serial.Serial(port_path, baudrate=self.BAUDRATE, timeout=0.1)
+        return serial.Serial(port_path, baudrate=self.BAUDRATE, timeout=0.1, write_timeout=self.WRITE_TIMEOUT_S)
 
     def _write_packet(self, packet: bytes) -> None:
         if self._serial is None or self.is_connection_lost():

--- a/software/tests/control/test_squid_laser_engine.py
+++ b/software/tests/control/test_squid_laser_engine.py
@@ -498,3 +498,41 @@ class TestSquidLaserEngineRealClass:
         qtbot.wait(50)
         assert engine.is_connection_lost() is True
         assert any("simulated drop" in s for s in signals)
+
+    def test_open_serial_sets_write_timeout(self, monkeypatch):
+        # Regression: unbounded write_timeout let a stuck write hang GUI startup.
+        import control.squid_laser_engine as sle
+
+        captured = {}
+
+        class _RecordingSerial:
+            def __init__(self, port, write_timeout=None, **kwargs):
+                captured["port"] = port
+                captured["write_timeout"] = write_timeout
+
+        monkeypatch.setattr(sle.serial, "Serial", _RecordingSerial)
+        SquidLaserEngine(device="/dev/fake-laser")._open_serial()
+
+        assert captured["port"] == "/dev/fake-laser"
+        assert captured["write_timeout"] == SquidLaserEngine.WRITE_TIMEOUT_S
+
+    def test_write_timeout_does_not_block_startup(self, qtbot):
+        # Regression: a bounded write_timeout must surface as connection-lost, not a hang.
+        import serial
+
+        engine, fake = self._make_engine()
+
+        def raise_timeout(_data):
+            raise serial.SerialTimeoutException("simulated write timeout")
+
+        fake.write = raise_timeout
+        signals = []
+        engine.connection_lost.connect(lambda msg: signals.append(msg))
+        # Mark started without launching threads so _write_packet takes the running path.
+        engine._running.set()
+
+        t0 = time.time()
+        engine.wake_up_all()
+        assert time.time() - t0 < 1.0
+        assert engine.is_connection_lost() is True
+        assert any("simulated write timeout" in s for s in signals)


### PR DESCRIPTION
## Problem

Starting the software with `USE_SQUID_LASER_ENGINE = True` hangs at startup: the GUI never appears and the Toupcam driver thread keeps logging `frame N (CONTINUOUS): ...` indefinitely. Setting `USE_SQUID_LASER_ENGINE = False` (all else equal) starts normally.

## Root cause

`SquidLaserEngine._open_serial()` opened the port with pyserial's default **`write_timeout=None` (block forever)**:

```python
return serial.Serial(port_path, baudrate=self.BAUDRATE, timeout=0.1)
```

`MicroscopeAddons.prepare_for_use()` calls `wake_up_all()` **synchronously on the main thread** during startup (`microscope.py:281`). If the engine device doesn't drain its USB buffer, that `write()` blocks forever, wedging the entire GUI launch. The camera's driver callback thread is independent, so it keeps streaming frames — and because the main thread is parked in a C-level `write()`, a single Ctrl+C can't unstick it.

Confirmed on hardware: opening `/dev/ttyACM1` succeeds instantly, but the first `serial.write()` to it blocks. (The SN→port mapping was correct — this is a robustness gap, not a misconfiguration.)

## Fix

Give the port a bounded `write_timeout`. A stuck write now raises `SerialTimeoutException`, which `_write_packet()` already routes into the existing graceful connection-lost path (`_signal_connection_lost()` + `_running.clear()`). The GUI comes up with the engine marked disconnected instead of hanging; a healthy engine (drains in <1 ms) is unaffected.

## Tests

Added to `tests/control/test_squid_laser_engine.py`:
- `test_open_serial_sets_write_timeout` — `_open_serial()` passes `write_timeout` to `serial.Serial`.
- `test_write_timeout_does_not_block_startup` — a write that raises `SerialTimeoutException` makes `wake_up_all()` return promptly and signal connection-lost, rather than blocking.

`python3 -m pytest tests/control/test_squid_laser_engine.py` → 43 passed. Black clean.

## Note (not addressed here)

The write blocking on the first packet means the device wasn't draining as a healthy laser engine would (firmware/power/wrong-device). This PR stops the hang; it does not make an unresponsive engine functional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)