### PR TITLE
fix: skip focus-map interpolation for single-FOV snap acquisitions

### DIFF
--- a/software/control/core/multi_point_controller.py
+++ b/software/control/core/multi_point_controller.py
@@ -754,7 +754,7 @@ class MultiPointController:
 
             # run the acquisition
             self.timestamp_acquisition_started = time.time()
-            if self.focus_map:
+            if self.focus_map and not acquire_current_fov:
                 self._log.info("Using focus surface for Z interpolation")
                 for region_id in scan_position_information.scan_region_names:
                     region_fov_coords = scan_position_information.scan_region_fov_coords_mm[region_id]


### PR DESCRIPTION
## Summary

Fixes a crash when clicking **Snap Images** in Wellplate Multipoint mode while a per-well focus map is loaded.

## Bug

```
File "control/widgets.py", line 8551, in on_snap_images
    self.multipointController.run_acquisition(acquire_current_fov=True)
File "control/core/multi_point_controller.py", line 781, in run_acquisition
    z = self.focus_map.interpolate(x, y, region_id)
File "control/core/core.py", line 1933, in interpolate
    raise ValueError(f"Region {region_id} not found")
ValueError: Region current not found
```

## Steps to reproduce (on master)

1. Launch the GUI (`main_hcs.py`), switch to **Wellplate Multipoint** mode.
2. Select one or more wells and set focus points, then enable the focus map (`fit_by_region=True` — one surface per well). The focus map ends up keyed by well ID (`B1`, `B2`, …).
3. Position the stage over any point on the plate.
4. Select an imaging channel and click **Snap Images**.
5. → crash: `ValueError: Region current not found`.

## Root cause

`run_acquisition(acquire_current_fov=True)` at `multi_point_controller.py:722-735` creates a *temporary* `ScanCoordinates` with a single region literally named `"current"` for the one-off snap. Immediately after, the focus-map block (`multi_point_controller.py:774-784`) runs unconditionally:

```python
if self.focus_map:
    for region_id in scan_position_information.scan_region_names:
        ...
        z = self.focus_map.interpolate(x, y, region_id)
```

With `fit_by_region=True`, `FocusMap.interpolate` requires `region_id ∈ region_surface_fits` (`core.py:1931-1933`). `"current"` is never in that dict, so the call raises.

## Fix

Gate the focus-map block on `not acquire_current_fov` so it applies only to real multi-region acquisitions:

```python
if self.focus_map and not acquire_current_fov:
```

Rationale: **Snap Images** is a manual snapshot. `on_snap_images` at `widgets.py:8547-8548` already sets `set_z_range(z, z)` from `stage.get_pos().z_mm` — the user's currently focused Z. Overriding that Z with a focus-map interpolation was never the intended behavior for the single-FOV path, so skipping the block is the correct semantics *and* resolves the region-name mismatch.

## How to verify the fix

1. On this branch, repeat steps 1-4 above → snap succeeds, image saved.
2. Regression check — **regular** wellplate multipoint acquisition (Start Acquisition, not Snap Images) with the focus map still applies Z interpolation per well as before. The log line `Using focus surface for Z interpolation` should still appear for full acquisitions, and NOT for Snap Images.
3. Snap Images without a focus map still works exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)