### PR TITLE
fix: AttributeError when selecting Simple Recording/Tracking tab

### DIFF
--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -2347,8 +2347,10 @@ class HighContentScreeningGui(QMainWindow):
             self.flexibleMultiPointWidget.update_fov_positions()
 
         self.toggleWellSelector(is_wellplate_acquisition and self.wellSelectionWidget.format != "glass slide")
+        # Non-multipoint tabs (Simple Recording, Tracking) don't have channel selection.
         acquisitionWidget = self.recordTabWidget.widget(index)
-        acquisitionWidget.emit_selected_channels()
+        if hasattr(acquisitionWidget, "emit_selected_channels"):
+            acquisitionWidget.emit_selected_channels()
 
     def resizeCurrentTab(self, tabWidget):
         current_widget = tabWidget.currentWidget()
@@ -2526,8 +2528,11 @@ class HighContentScreeningGui(QMainWindow):
         else:
             self.toggleWellSelector(False)
 
-        # display acquisition progress bar during acquisition
-        self.recordTabWidget.currentWidget().display_progress_bar(acquisition_started)
+        # display acquisition progress bar during acquisition (non-multipoint tabs
+        # like Simple Recording can be current when a workflow/TCP acquisition starts)
+        current_widget = self.recordTabWidget.currentWidget()
+        if hasattr(current_widget, "display_progress_bar"):
+            current_widget.display_progress_bar(acquisition_started)
 
     def _update_ram_monitor_visibility(self):
         """Update RAM monitor widget visibility based on setting."""

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -2347,10 +2347,6 @@ class HighContentScreeningGui(QMainWindow):
             self.flexibleMultiPointWidget.update_fov_positions()
 
         self.toggleWellSelector(is_wellplate_acquisition and self.wellSelectionWidget.format != "glass slide")
-        # Non-multipoint tabs (Simple Recording, Tracking) don't have channel selection.
-        acquisitionWidget = self.recordTabWidget.widget(index)
-        if hasattr(acquisitionWidget, "emit_selected_channels"):
-            acquisitionWidget.emit_selected_channels()
 
     def resizeCurrentTab(self, tabWidget):
         current_widget = tabWidget.currentWidget()
@@ -2527,12 +2523,6 @@ class HighContentScreeningGui(QMainWindow):
             self.toggleWellSelector(not acquisition_started, remember_state=False)
         else:
             self.toggleWellSelector(False)
-
-        # display acquisition progress bar during acquisition (non-multipoint tabs
-        # like Simple Recording can be current when a workflow/TCP acquisition starts)
-        current_widget = self.recordTabWidget.currentWidget()
-        if hasattr(current_widget, "display_progress_bar"):
-            current_widget.display_progress_bar(acquisition_started)
 
     def _update_ram_monitor_visibility(self):
         """Update RAM monitor widget visibility based on setting."""

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -6524,6 +6524,7 @@ class FlexibleMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMixi
             # emit signals
             self.signal_acquisition_started.emit(True)
             self.signal_acquisition_shape.emit(self.entry_NZ.value(), self.entry_deltaZ.value())
+            self.emit_selected_channels()
 
             # Start coordinate-based acquisition
             self.multipointController.run_acquisition()
@@ -8907,6 +8908,7 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMix
         # Emit signals to notify other components
         self.signal_acquisition_started.emit(True)
         self.signal_acquisition_shape.emit(nz, delta_z_um)
+        self.emit_selected_channels()
 
     @Slot(bool, int, float)
     def set_acquisition_running_state(self, is_running: bool, nz: int = 1, delta_z_um: float = 1.0) -> None:
@@ -9633,6 +9635,7 @@ class MultiPointWithFluidicsWidget(_ApplyChannelOffsetMixin, QFrame):
             # Emit signals
             self.signal_acquisition_started.emit(True)
             self.signal_acquisition_shape.emit(self.entry_NZ.value(), self.entry_deltaZ.value())
+            self.emit_selected_channels()
 
             # Start acquisition
             self.multipointController.run_acquisition()

--- a/software/tests/control/test_HighContentScreeningGui.py
+++ b/software/tests/control/test_HighContentScreeningGui.py
@@ -29,6 +29,39 @@ def test_create_simulated_hcs_with_or_without_piezo(qtbot, monkeypatch):
     qtbot.add_widget(without_piezo)
 
 
+def test_tab_change_to_simple_recording_does_not_raise(qtbot, monkeypatch):
+    """Regression: onTabChanged called emit_selected_channels() on every record tab,
+    but RecordingWidget (Simple Recording) doesn't have that method, so selecting
+    the tab raised AttributeError on machines with ENABLE_RECORDING on."""
+
+    def confirm_exit(parent, title, text, *args, **kwargs):
+        if title == "Confirm Exit":
+            return QMessageBox.Yes
+        raise RuntimeError(f"Unexpected QMessageBox: {title} - {text}")
+
+    monkeypatch.setattr(QMessageBox, "question", confirm_exit)
+
+    # gui_hcs star-imports _def, so patch its module-level binding before construction
+    # to get the "Simple Recording" tab added.
+    monkeypatch.setattr(control.gui_hcs, "ENABLE_RECORDING", True)
+
+    scope = control.microscope.Microscope.build_from_global_config(True)
+    win = control.gui_hcs.HighContentScreeningGui(microscope=scope, is_simulation=True)
+    qtbot.add_widget(win)
+
+    recording_index = win.recordTabWidget.indexOf(win.recordingControlWidget)
+    assert recording_index >= 0, "Simple Recording tab was not added despite ENABLE_RECORDING"
+
+    # Selecting the tab fires currentChanged -> onTabChanged; must not raise.
+    win.recordTabWidget.setCurrentIndex(recording_index)
+    win.onTabChanged(recording_index)
+
+    # The same widget must also survive an acquisition start/stop notification
+    # (workflow/TCP acquisitions can start while a non-multipoint tab is current).
+    win.toggleAcquisitionStart(True)
+    win.toggleAcquisitionStart(False)
+
+
 def test_image_display_signals_connected_once(qtbot, monkeypatch):
     """Regression: make_connections and makeNapariConnections both used to wire the
     non-Napari image-display signals, causing slots to fire twice per click/scroll."""

--- a/software/tests/control/test_HighContentScreeningGui.py
+++ b/software/tests/control/test_HighContentScreeningGui.py
@@ -30,9 +30,10 @@ def test_create_simulated_hcs_with_or_without_piezo(qtbot, monkeypatch):
 
 
 def test_tab_change_to_simple_recording_does_not_raise(qtbot, monkeypatch):
-    """Regression: onTabChanged called emit_selected_channels() on every record tab,
-    but RecordingWidget (Simple Recording) doesn't have that method, so selecting
-    the tab raised AttributeError on machines with ENABLE_RECORDING on."""
+    """Regression: onTabChanged used to call emit_selected_channels() on every record
+    tab and toggleAcquisitionStart called display_progress_bar() on the current tab,
+    but RecordingWidget (Simple Recording) has neither method, so selecting the tab
+    raised AttributeError on machines with ENABLE_RECORDING on."""
 
     def confirm_exit(parent, title, text, *args, **kwargs):
         if title == "Confirm Exit":
@@ -60,6 +61,37 @@ def test_tab_change_to_simple_recording_does_not_raise(qtbot, monkeypatch):
     # (workflow/TCP acquisitions can start while a non-multipoint tab is current).
     win.toggleAcquisitionStart(True)
     win.toggleAcquisitionStart(False)
+
+
+def test_acquisition_start_emits_selected_channels(qtbot, monkeypatch):
+    """The napari multichannel viewer is initialized from signal_acquisition_channels.
+    That signal must be emitted when the acquisition starts (alongside
+    signal_acquisition_shape), for both the button path and the TCP path."""
+
+    def confirm_exit(parent, title, text, *args, **kwargs):
+        if title == "Confirm Exit":
+            return QMessageBox.Yes
+        raise RuntimeError(f"Unexpected QMessageBox: {title} - {text}")
+
+    monkeypatch.setattr(QMessageBox, "question", confirm_exit)
+
+    scope = control.microscope.Microscope.build_from_global_config(True)
+    win = control.gui_hcs.HighContentScreeningGui(microscope=scope, is_simulation=True)
+    qtbot.add_widget(win)
+
+    widget = win.wellplateMultiPointWidget
+    emitted = []
+    widget.signal_acquisition_channels.connect(emitted.append)
+
+    # _set_ui_acquisition_running is the shared start path (button + TCP/invokeMethod).
+    widget._set_ui_acquisition_running(nz=1, delta_z_um=1.0)
+    try:
+        assert emitted, "signal_acquisition_channels was not emitted at acquisition start"
+        assert emitted[-1] == widget.channel_sequence.ordered_selected_names()
+    finally:
+        # Unwind the acquisition-running UI state (signal_acquisition_started=True
+        # disabled the other tabs via toggleAcquisitionStart).
+        win.toggleAcquisitionStart(False)
 
 
 def test_image_display_signals_connected_once(qtbot, monkeypatch):


### PR DESCRIPTION
## Summary

Selecting the **Simple Recording** tab (or Tracking tab) crashes with:

```
File "control/gui_hcs.py", line 2360, in onTabChanged
    acquisitionWidget.emit_selected_channels()
AttributeError: 'RecordingWidget' object has no attribute 'emit_selected_channels'
```

`onTabChanged` called `emit_selected_channels()` on whatever record tab was selected, but only the multipoint widgets (Flexible, Wellplate, Fluidics) define that method. Most machine configs have `ENABLE_RECORDING` off, which is why this went unnoticed. `toggleAcquisitionStart` had the same latent bug with `display_progress_bar()`.

## Fix (structural, no hasattr guards)

The first commit guarded both calls with `hasattr`; the second commit replaces that with a structural fix:

**Channels: emit at acquisition start, not tab change.** The napari multichannel viewer needs two inputs: shape and channels. Shape was already emitted at acquisition start (next to `signal_acquisition_started`); channels rode on tab change. Now `emit_selected_channels()` is called at the same acquisition-start point in all three multipoint widgets — Wellplate's `_set_ui_acquisition_running` covers both the button path and the TCP/`invokeMethod` path. `onTabChanged` no longer calls anything on the selected tab, so tabs without channel selections are never asked. Timing is safe: the only consumer of the channel set (`updateLayers`) runs exclusively during an acquisition, and the per-tab `itemSelectionChanged` connections still keep it fresh in between.

**Progress bar: delete the gui_hcs call.** Every widget with a progress bar already connects its own `signal_acquisition_started` to its own `display_progress_bar`, and `toggleAcquisitionStart` is only ever invoked via that same signal — the call in gui_hcs was redundant for multipoint tabs and a crash for the rest.

## Testing

- Regression test: builds the simulated GUI with `ENABLE_RECORDING` patched on, switches to the Simple Recording tab, and cycles `toggleAcquisitionStart` — reproduced the exact AttributeError before the fix, passes after.
- New test: `signal_acquisition_channels` is emitted at acquisition start with the selected channel names.
- All 4 tests in `tests/control/test_HighContentScreeningGui.py` pass locally with `QT_API=pyqt5` (this file is skipped in CI).
- `black` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)