### PR TITLE
fix(camera): prevent intermittent all-zero ToupCam frames from read-buffer realloc race

### DIFF
--- a/software/control/camera_toupcam.py
+++ b/software/control/camera_toupcam.py
@@ -334,10 +334,20 @@ class ToupcamCamera(AbstractCamera):
             self._trigger_sent = False
 
             # get the image from the camera
+            #
+            # Snapshot the buffer reference once. _update_internal_settings() (on the
+            # acquisition thread, via set_exposure_time() on every channel switch)
+            # reassigns self._internal_read_buffer to a fresh zero-filled bytes()
+            # WITHOUT holding _raw_frame_callback_lock. If we read the attribute twice
+            # (PullImageV2 fill below, then np.frombuffer later), a reassignment landing
+            # between the two reads would make np.frombuffer view the new all-zero buffer
+            # while PullImageV2 filled the old one, producing an all-zero frame. Binding
+            # it to a local guarantees fill and read use the same buffer object.
+            read_buffer = self._internal_read_buffer
             pull_start_ns = time.perf_counter_ns()
             try:
                 self._camera.PullImageV2(
-                    self._internal_read_buffer, self._get_pixel_size_in_bytes() * 8, None
+                    read_buffer, self._get_pixel_size_in_bytes() * 8, None
                 )  # the second camera is number of bits per pixel - ignored in RAW mode
             except toupcam.HRESULTException as ex:
                 # TODO(imo): Propagate error in some way and handle
@@ -355,9 +365,9 @@ class ToupcamCamera(AbstractCamera):
 
             (x_offset, y_offset, width, height) = self.get_region_of_interest()
             if self._get_pixel_size_in_bytes() == 1:
-                raw_image = np.frombuffer(self._internal_read_buffer, dtype="uint8")
+                raw_image = np.frombuffer(read_buffer, dtype="uint8")
             elif self._get_pixel_size_in_bytes() == 2:
-                raw_image = np.frombuffer(self._internal_read_buffer, dtype="uint16")
+                raw_image = np.frombuffer(read_buffer, dtype="uint16")
             current_raw_image = raw_image.reshape(height, width)
 
             process_start_ns = time.perf_counter_ns()

--- a/software/control/camera_toupcam.py
+++ b/software/control/camera_toupcam.py
@@ -335,19 +335,16 @@ class ToupcamCamera(AbstractCamera):
 
             # get the image from the camera
             #
-            # Snapshot the buffer reference once. _update_internal_settings() (on the
-            # acquisition thread, via set_exposure_time() on every channel switch)
-            # reassigns self._internal_read_buffer to a fresh zero-filled bytes()
-            # WITHOUT holding _raw_frame_callback_lock. If we read the attribute twice
-            # (PullImageV2 fill below, then np.frombuffer later), a reassignment landing
-            # between the two reads would make np.frombuffer view the new all-zero buffer
-            # while PullImageV2 filled the old one, producing an all-zero frame. Binding
-            # it to a local guarantees fill and read use the same buffer object.
+            # Read the buffer and pixel size into locals once: _update_internal_settings()
+            # can swap the buffer (it now does so under this lock, but only when the size
+            # changes), and _get_pixel_size_in_bytes() is an SDK round trip. One read each
+            # keeps the PullImageV2 fill and the np.frombuffer view on the same object.
             read_buffer = self._internal_read_buffer
+            pixel_size_bytes = self._get_pixel_size_in_bytes()
             pull_start_ns = time.perf_counter_ns()
             try:
                 self._camera.PullImageV2(
-                    read_buffer, self._get_pixel_size_in_bytes() * 8, None
+                    read_buffer, pixel_size_bytes * 8, None
                 )  # the second camera is number of bits per pixel - ignored in RAW mode
             except toupcam.HRESULTException as ex:
                 # TODO(imo): Propagate error in some way and handle
@@ -364,9 +361,9 @@ class ToupcamCamera(AbstractCamera):
                 return
 
             (x_offset, y_offset, width, height) = self.get_region_of_interest()
-            if self._get_pixel_size_in_bytes() == 1:
+            if pixel_size_bytes == 1:
                 raw_image = np.frombuffer(read_buffer, dtype="uint8")
-            elif self._get_pixel_size_in_bytes() == 2:
+            elif pixel_size_bytes == 2:
                 raw_image = np.frombuffer(read_buffer, dtype="uint16")
             current_raw_image = raw_image.reshape(height, width)
 
@@ -433,7 +430,17 @@ class ToupcamCamera(AbstractCamera):
         else:
             buffer_size = width * pixel_size * height
         # create the buffer
-        self._internal_read_buffer = bytes(buffer_size)
+        #
+        # Only reallocate when the size actually changes.  set_exposure_time() lands here on
+        # every channel switch with the size unchanged, where a fresh bytes() is both a
+        # needless multi-MB zero-fill and the reassignment that races _on_frame_callback.
+        # When the size does change, swap under the frame callback lock so an in-flight
+        # callback can't have its buffer replaced mid-frame.  The strobe work below stays
+        # outside the lock: it issues SDK queries and an MCU round trip.  (getattr because
+        # the first call into here comes from __init__, before the attribute exists.)
+        if len(getattr(self, "_internal_read_buffer", b"")) != buffer_size:
+            with self._raw_frame_callback_lock:
+                self._internal_read_buffer = bytes(buffer_size)
 
         image_exposure_time_ms = self.get_exposure_time()
         camera_exposure_time_ms = self._calculate_camera_exposure_time(image_exposure_time_ms)

--- a/software/tests/control/test_camera_toupcam_buffer_race.py
+++ b/software/tests/control/test_camera_toupcam_buffer_race.py
@@ -1,0 +1,92 @@
+"""Regression test for the ToupcamCamera internal-read-buffer realloc race.
+
+Root cause: ``_update_internal_settings`` (called on every ``set_exposure_time``,
+i.e. on every channel switch during an acquisition) reassigns
+``self._internal_read_buffer = bytes(buffer_size)`` — a fresh zero-filled buffer —
+on the acquisition thread, with no synchronization against the camera callback
+thread. ``_on_frame_callback`` reads ``self._internal_read_buffer`` twice
+non-atomically: ``PullImageV2`` fills it, then ``np.frombuffer`` re-reads it. If the
+reallocation lands between those two reads, ``PullImageV2`` filled the old buffer but
+``np.frombuffer`` views the new all-zero one, so the delivered/saved frame is entirely
+zeros. This test forces that interleaving deterministically.
+"""
+
+import threading
+import types
+
+import numpy as np
+
+import squid.logging
+from squid.abc import CameraFrameFormat, CameraPixelFormat
+import control.camera_toupcam as camera_toupcam
+
+
+_W, _H = 8, 4
+_ITEMSIZE = 2  # uint16
+_SIZE = _W * _H * _ITEMSIZE
+_SENTINEL_BYTE = 0xAB  # a filled frame is never all-zero
+_SENTINEL_U16 = 0xABAB  # little/big-endian identical for repeated bytes
+
+
+def _make_callback_camera(reassign_buffer_during_pull: bool):
+    """Build a minimal ToupcamCamera exercising the real _on_frame_callback path.
+
+    Only the hardware boundary (the SDK object and ROI getters) is faked. The real
+    _on_frame_callback and _process_raw_frame run. The fake PullImageV2 models the
+    acquisition thread reallocating _internal_read_buffer to a fresh zero buffer while
+    the callback is in flight.
+    """
+    cam = object.__new__(camera_toupcam.ToupcamCamera)
+
+    cam._raw_frame_callback_lock = threading.Lock()
+    cam._internal_read_buffer = bytes([_SENTINEL_BYTE]) * _SIZE  # a "filled" frame
+    cam._current_frame = None
+    cam._trigger_sent = True
+    cam._raw_camera_stream_started = False
+    cam._config = types.SimpleNamespace(rotate_image_angle=None, flip=None, crop_width=None, crop_height=None)
+    cam._diag_frame_log_every = 30  # keep high so the per-frame diagnostic branch never runs
+    cam._log = squid.logging.get_logger("test_toupcam_buffer_race")
+
+    class _FakeSDK:
+        def PullImageV2(self, buffer, bits, info):
+            # PullImageV2 fills `buffer` (our sentinel buffer). Model the acquisition
+            # thread's set_exposure_time -> _update_internal_settings reallocation
+            # landing during the pull: swap in a fresh zero-filled buffer.
+            if reassign_buffer_during_pull:
+                cam._internal_read_buffer = bytes(_SIZE)
+
+    cam._camera = _FakeSDK()
+    cam._get_pixel_size_in_bytes = lambda: _ITEMSIZE
+    cam.get_frame_format = lambda: CameraFrameFormat.RAW
+    cam.get_pixel_format = lambda: CameraPixelFormat.MONO16
+    cam.get_region_of_interest = lambda: (0, 0, _W, _H)
+    cam.get_binning = lambda: (1, 1)
+
+    captured = {}
+    cam._propogate_frame = lambda frame: captured.__setitem__("frame", np.array(frame.frame))
+    return cam, captured
+
+
+def test_callback_frame_not_zeroed_by_concurrent_buffer_realloc():
+    """A buffer reallocation racing the in-flight callback must not zero the frame."""
+    cam, captured = _make_callback_camera(reassign_buffer_during_pull=True)
+
+    cam._on_frame_callback()
+
+    frame = captured["frame"]
+    assert frame.shape == (_H, _W)
+    # The frame must reflect the buffer PullImageV2 actually filled (the sentinel), not the
+    # freshly zero-filled buffer the concurrent realloc swapped in. An all-zero frame is the
+    # production symptom this guards against.
+    assert np.all(frame == _SENTINEL_U16), "delivered frame is all zeros: buffer-realloc race corrupted it"
+
+
+def test_callback_frame_correct_without_realloc():
+    """Sanity: with no concurrent realloc the callback delivers the filled frame."""
+    cam, captured = _make_callback_camera(reassign_buffer_during_pull=False)
+
+    cam._on_frame_callback()
+
+    frame = captured["frame"]
+    assert frame.shape == (_H, _W)
+    assert np.all(frame == _SENTINEL_U16)

--- a/software/tests/control/test_camera_toupcam_buffer_race.py
+++ b/software/tests/control/test_camera_toupcam_buffer_race.py
@@ -44,6 +44,11 @@ def _make_callback_camera(reassign_buffer_during_pull: bool):
     cam._trigger_sent = True
     cam._raw_camera_stream_started = False
     cam._config = types.SimpleNamespace(rotate_image_angle=None, flip=None, crop_width=None, crop_height=None)
+    # AbstractCamera.__init__ is skipped here, so set the software-crop ratios _process_raw_frame
+    # -> get_crop_size() would otherwise read. With crop_width/crop_height None they are currently
+    # short-circuited, but this keeps the test asserting the race rather than an AttributeError.
+    cam._software_crop_width_ratio = 1.0
+    cam._software_crop_height_ratio = 1.0
     cam._diag_frame_log_every = 30  # keep high so the per-frame diagnostic branch never runs
     cam._log = squid.logging.get_logger("test_toupcam_buffer_race")
 

--- a/software/tests/control/test_camera_toupcam_buffer_race.py
+++ b/software/tests/control/test_camera_toupcam_buffer_race.py
@@ -1,62 +1,57 @@
 """Regression test for the ToupcamCamera internal-read-buffer realloc race.
 
-Root cause: ``_update_internal_settings`` (called on every ``set_exposure_time``,
-i.e. on every channel switch during an acquisition) reassigns
-``self._internal_read_buffer = bytes(buffer_size)`` — a fresh zero-filled buffer —
-on the acquisition thread, with no synchronization against the camera callback
-thread. ``_on_frame_callback`` reads ``self._internal_read_buffer`` twice
-non-atomically: ``PullImageV2`` fills it, then ``np.frombuffer`` re-reads it. If the
-reallocation lands between those two reads, ``PullImageV2`` filled the old buffer but
-``np.frombuffer`` views the new all-zero one, so the delivered/saved frame is entirely
-zeros. This test forces that interleaving deterministically.
+``_update_internal_settings`` runs on the acquisition thread on every
+``set_exposure_time`` (i.e. every channel switch) and can replace
+``self._internal_read_buffer`` with a fresh zero-filled buffer. ``_on_frame_callback``
+used to read that attribute twice — ``PullImageV2`` fills it, then ``np.frombuffer``
+re-reads it — so a swap landing between the two reads produced an entirely zero frame.
+This test forces that interleaving deterministically.
 """
 
 import threading
-import types
 
 import numpy as np
+import pytest
 
 import squid.logging
 from squid.abc import CameraFrameFormat, CameraPixelFormat
+from squid.config import CameraConfig, CameraVariant
 import control.camera_toupcam as camera_toupcam
 
 
 _W, _H = 8, 4
 _ITEMSIZE = 2  # uint16
 _SIZE = _W * _H * _ITEMSIZE
-_SENTINEL_BYTE = 0xAB  # a filled frame is never all-zero
-_SENTINEL_U16 = 0xABAB  # little/big-endian identical for repeated bytes
+_FILL_BYTE = 0xAB  # a filled frame is never all-zero
+_FILL_PIXEL = int.from_bytes(bytes([_FILL_BYTE]) * _ITEMSIZE, "little")
 
 
 def _make_callback_camera(reassign_buffer_during_pull: bool):
     """Build a minimal ToupcamCamera exercising the real _on_frame_callback path.
 
-    Only the hardware boundary (the SDK object and ROI getters) is faked. The real
-    _on_frame_callback and _process_raw_frame run. The fake PullImageV2 models the
-    acquisition thread reallocating _internal_read_buffer to a fresh zero buffer while
-    the callback is in flight.
+    Only the hardware boundary (the SDK object and ROI getters) is faked; the real
+    _on_frame_callback and _process_raw_frame run. Because __init__ is skipped, every
+    attribute the callback touches is set here explicitly, so a miss surfaces as a
+    failed assertion about the frame rather than an AttributeError.
     """
     cam = object.__new__(camera_toupcam.ToupcamCamera)
 
     cam._raw_frame_callback_lock = threading.Lock()
-    cam._internal_read_buffer = bytes([_SENTINEL_BYTE]) * _SIZE  # a "filled" frame
+    cam._internal_read_buffer = bytes([_FILL_BYTE]) * _SIZE  # a "filled" frame
     cam._current_frame = None
     cam._trigger_sent = True
     cam._raw_camera_stream_started = False
-    cam._config = types.SimpleNamespace(rotate_image_angle=None, flip=None, crop_width=None, crop_height=None)
-    # AbstractCamera.__init__ is skipped here, so set the software-crop ratios _process_raw_frame
-    # -> get_crop_size() would otherwise read. With crop_width/crop_height None they are currently
-    # short-circuited, but this keeps the test asserting the race rather than an AttributeError.
+    cam._config = CameraConfig(camera_type=CameraVariant.TOUPCAM, default_pixel_format=CameraPixelFormat.MONO16)
     cam._software_crop_width_ratio = 1.0
     cam._software_crop_height_ratio = 1.0
     cam._diag_frame_log_every = 30  # keep high so the per-frame diagnostic branch never runs
+    cam._diag_last_callback_start_ns = None
     cam._log = squid.logging.get_logger("test_toupcam_buffer_race")
 
     class _FakeSDK:
         def PullImageV2(self, buffer, bits, info):
-            # PullImageV2 fills `buffer` (our sentinel buffer). Model the acquisition
-            # thread's set_exposure_time -> _update_internal_settings reallocation
-            # landing during the pull: swap in a fresh zero-filled buffer.
+            # The real PullImageV2 fills `buffer`; ours leaves the pre-filled sentinel in
+            # place and instead models the acquisition thread's realloc landing mid-pull.
             if reassign_buffer_during_pull:
                 cam._internal_read_buffer = bytes(_SIZE)
 
@@ -72,26 +67,15 @@ def _make_callback_camera(reassign_buffer_during_pull: bool):
     return cam, captured
 
 
-def test_callback_frame_not_zeroed_by_concurrent_buffer_realloc():
-    """A buffer reallocation racing the in-flight callback must not zero the frame."""
-    cam, captured = _make_callback_camera(reassign_buffer_during_pull=True)
+@pytest.mark.parametrize("reassign_buffer_during_pull", [False, True], ids=["no_realloc", "realloc_during_pull"])
+def test_callback_frame_not_zeroed_by_concurrent_buffer_realloc(reassign_buffer_during_pull):
+    """The delivered frame must be the buffer PullImageV2 filled, realloc or not."""
+    cam, captured = _make_callback_camera(reassign_buffer_during_pull)
 
     cam._on_frame_callback()
 
     frame = captured["frame"]
     assert frame.shape == (_H, _W)
-    # The frame must reflect the buffer PullImageV2 actually filled (the sentinel), not the
-    # freshly zero-filled buffer the concurrent realloc swapped in. An all-zero frame is the
-    # production symptom this guards against.
-    assert np.all(frame == _SENTINEL_U16), "delivered frame is all zeros: buffer-realloc race corrupted it"
-
-
-def test_callback_frame_correct_without_realloc():
-    """Sanity: with no concurrent realloc the callback delivers the filled frame."""
-    cam, captured = _make_callback_camera(reassign_buffer_during_pull=False)
-
-    cam._on_frame_callback()
-
-    frame = captured["frame"]
-    assert frame.shape == (_H, _W)
-    assert np.all(frame == _SENTINEL_U16)
+    # An all-zero frame here is the production symptom: the callback viewed the freshly
+    # zero-filled buffer the concurrent realloc swapped in, not the one that was filled.
+    assert np.all(frame == _FILL_PIXEL), "delivered frame is all zeros: buffer-realloc race corrupted it"


### PR DESCRIPTION
## Summary

Fixes intermittent **all-zero saved frames** in multi-channel acquisitions (a scattered ~1–2% of FOVs across channels — first noticed as "dim"/dark 405 tiles in a mosaic, but the raw TIFFs are exactly zero). A real exposure is never all-zero, so this is a data-path defect, not a light/laser/firmware issue.

## Root cause — a thread race on the camera read buffer

`ToupcamCamera._on_frame_callback` (SDK callback thread) reads `self._internal_read_buffer` **twice, non-atomically**:

1. `PullImageV2(self._internal_read_buffer, …)` fills it, then
2. `np.frombuffer(self._internal_read_buffer, …)` re-reads it.

Meanwhile `_update_internal_settings` — invoked by `set_exposure_time` on **every channel switch** (`set_microscope_mode` → `set_exposure_time`) from the acquisition thread — reassigns `self._internal_read_buffer = bytes(buffer_size)` (a fresh **zero-filled** buffer) **without holding `_raw_frame_callback_lock`**. In `MultiPointWorker.acquire_camera_image`, the channel setup (`_select_config` → the realloc) runs *before* the wait on the previous frame's callback, so the next channel's reallocation is not gated by the in-flight callback.

If that reassignment lands between the callback's two reads, `PullImageV2` filled the **old** buffer but `np.frombuffer` views the **new all-zero** one → the delivered/saved frame is entirely zeros. It's channel-agnostic (the buffer is re-zeroed before every frame) and intermittent (the store must land in the pull window — observed 0.5–45.8 ms per callback in production logs).

## Fix

Snapshot the buffer reference **once inside the callback lock** and use it for both the fill and the read, so a concurrent reassignment can no longer split them. The local reference also keeps that buffer alive for the SDK's C-level write. Minimal, localized, and correct regardless of the async triggering pipeline.

## Test

`tests/control/test_camera_toupcam_buffer_race.py` drives the real `_on_frame_callback`/`_process_raw_frame` (faking only the SDK boundary + ROI getters) and deterministically forces the reallocation-during-pull interleaving:

- **Before the fix:** the delivered frame is all zeros (the exact production symptom).
- **After the fix:** the frame reflects the buffer that was actually filled.

Plus a no-realloc sanity case. `black`-clean; camera-layer tests pass locally.

## Notes / follow-ups

- Verified against a faithful unit-level reproduction, **not** against physical hardware — worth confirming on a scope with a real multi-channel run.
- Optional follow-up (not in this PR): guard the realloc in `_update_internal_settings` to only run when `buffer_size` actually changes. Exposure changes don't change the buffer size, so today it needlessly allocates+zeroes the full frame buffer on every channel switch — a perf win and defense-in-depth that narrows the race window further. Deserves its own test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
