### PR TITLE
Laser AF: fix autofocus live-view freeze + add Restore Full FOV button

### DIFF
--- a/software/control/core_displacement_measurement.py
+++ b/software/control/core_displacement_measurement.py
@@ -34,6 +34,10 @@ class DisplacementMeasurementController(QObject):
         self.t_array = np.array([])
         self.x_array = np.array([])
         self.y_array = np.array([])
+        # Cache the coordinate grids across frames of the same size (see update_measurement).
+        self._grid_shape = None
+        self._xgrid = None
+        self._ygrid = None
 
     def update_measurement(self, image):
 
@@ -43,23 +47,36 @@ class DisplacementMeasurementController(QObject):
             image = cv2.cvtColor(image, cv2.COLOR_RGB2GRAY)
 
         h, w = image.shape
-        x, y = np.meshgrid(range(w), range(h))
+        # Recomputing the meshgrid every frame is the bulk of the per-frame CPU cost; on the main
+        # (UI) thread this is what froze the autofocus live view. Cache it across same-size frames.
+        if self._grid_shape != (h, w):
+            self._xgrid, self._ygrid = np.meshgrid(np.arange(w), np.arange(h))
+            self._grid_shape = (h, w)
+
         I = image.astype(float)
         I = I - np.amin(I)
-        I[I / np.amax(I) < 0.2] = 0
-        x = np.sum(x * I) / np.sum(I)
-        y = np.sum(y * I) / np.sum(I)
+        peak = np.amax(I)
+        if peak > 0:
+            I[I / peak < 0.2] = 0
+        total = np.sum(I)
+        if total > 0:
+            x = np.sum(self._xgrid * I) / total
+            y = np.sum(self._ygrid * I) / total
+        else:
+            x = y = 0.0  # blank/uniform frame: no spot -> avoid 0/0 nan spam
 
         x = x - self.x_offset
         y = y - self.y_offset
         x = x * self.x_scaling
         y = y * self.y_scaling
 
-        self.t_array = np.append(self.t_array, t)
-        self.x_array = np.append(self.x_array, x)
-        self.y_array = np.append(self.y_array, y)
+        # Keep only the last N samples. The original appended without trimming, so the arrays (and
+        # the plot data emitted every frame) grew without bound -> the UI thread eventually froze.
+        self.t_array = np.append(self.t_array, t)[-self.N :]
+        self.x_array = np.append(self.x_array, x)[-self.N :]
+        self.y_array = np.append(self.y_array, y)[-self.N :]
 
-        self.signal_plots.emit(self.t_array[-self.N :], np.vstack((self.x_array[-self.N :], self.y_array[-self.N :])))
+        self.signal_plots.emit(self.t_array, np.vstack((self.x_array, self.y_array)))
         self.signal_readings.emit([np.mean(self.x_array[-self.N_average :]), np.mean(self.y_array[-self.N_average :])])
 
     def update_settings(self, x_offset, y_offset, x_scaling, y_scaling, N_average, N):

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -2759,10 +2759,15 @@ class LaserAutofocusSettingWidget(QWidget):
         self.analog_gain_spinbox.setValue(self.laserAutofocusController.laser_af_properties.focus_camera_analog_gain)
         analog_gain_layout.addWidget(self.analog_gain_spinbox)
 
+        # Restore Full FOV button: undo the laser-AF spot crop so the whole focus-camera
+        # sensor is visible again (useful for re-locating the spot before re-initializing).
+        self.btn_restore_full_fov = QPushButton("Restore Full FOV")
+
         # Add to live group
         live_layout.addWidget(self.btn_live)
         live_layout.addLayout(exposure_layout)
         live_layout.addLayout(analog_gain_layout)
+        live_layout.addWidget(self.btn_restore_full_fov)
         live_group.setLayout(live_layout)
 
         # Non-threshold property group
@@ -2864,6 +2869,7 @@ class LaserAutofocusSettingWidget(QWidget):
         self.run_spot_detection_button.clicked.connect(self.run_spot_detection)
         self.initialize_button.clicked.connect(self.apply_and_initialize)
         self.characterization_checkbox.toggled.connect(self.toggle_characterization_mode)
+        self.btn_restore_full_fov.clicked.connect(self.restore_full_fov)
 
     def _add_spinbox(
         self,
@@ -2925,6 +2931,16 @@ class LaserAutofocusSettingWidget(QWidget):
 
     def update_analog_gain(self, value):
         self.signal_newAnalogGain.emit(value)
+
+    def restore_full_fov(self):
+        """Reset the focus camera ROI to the full sensor FOV (undo the laser-AF spot crop)."""
+        try:
+            camera = self.laserAutofocusController.camera
+            width, height = camera.get_resolution()
+            camera.set_region_of_interest(0, 0, width, height)
+            self._log.info(f"Restored focus camera to full FOV: {width} x {height}")
+        except Exception as e:
+            self._log.error(f"Failed to restore full FOV: {e}")
 
     def update_values(self):
         """Update all widget values from the controller properties"""


### PR DESCRIPTION
Two laser-autofocus live-view improvements (independent of the V-308 work in #569).

## 1. Fix autofocus live-view freeze (`core_displacement_measurement.py`)
`DisplacementMeasurementController.update_measurement` runs on the **main GUI thread** for every focus-camera frame. It:
- rebuilt the coordinate `meshgrid` on every frame (the bulk of the per-frame CPU), and
- appended to `t_array` / `x_array` / `y_array` **without ever trimming**, so both memory and the per-frame plot payload grew without bound.

After the focus camera streamed for a while (~10k frames), the UI thread saturated and the GUI **froze** whenever you sat in the autofocus live view. (Diagnosed with `py-spy`: MainThread stuck in `update_measurement`, all other threads idle.)

Fix:
- **Cache the meshgrid** across same-size frames.
- **Bound the arrays** to the last `N` samples.
- **Guard the centroid division** so a blank/uniform frame doesn't produce `0/0` NaNs.

Behaviour is otherwise unchanged (same centroid, offsets/scaling, plot of last `N`, readings averaged over `N_average`).

## 2. Add "Restore Full FOV" button (`LaserAutofocusSettingWidget`)
Adds a button to the laser-AF live-control group that resets the focus camera ROI to the full sensor via `camera.set_region_of_interest(0, 0, *camera.get_resolution())` — undoing the laser-AF spot crop so the whole sensor is visible again (handy for re-locating the spot before re-initializing). Portable (no hardcoded sensor size); failures are logged, not raised.

## Testing
- Verified on real hardware (Toupcam + focus camera): GUI launches with the button present and constructs without error; the fix compiles and preserves existing behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)