### PR TITLE
fix(channel-config): persist settings for channels added via the channel configurator

### DIFF
--- a/software/control/core/config/repository.py
+++ b/software/control/core/config/repository.py
@@ -15,12 +15,13 @@ Organization:
 - Cache Management: cache control
 """
 
-import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Type, TypeVar, Union
 
 import yaml
 from pydantic import BaseModel, ValidationError
+
+import squid.logging
 
 from control.models import (
     AcquisitionChannel,
@@ -47,9 +48,34 @@ from control.models.hardware_bindings import (
     FILTER_WHEEL_SOURCE_STANDALONE,
 )
 
-logger = logging.getLogger(__name__)
+logger = squid.logging.get_logger(__name__)
 
 T = TypeVar("T", bound=BaseModel)
+
+
+def _objective_channel_from_general(ch: AcquisitionChannel) -> AcquisitionChannel:
+    """Build a per-objective channel entry seeded from a general.yaml channel.
+
+    Objective files only carry per-objective settings; channel identity fields
+    (illumination_channel, filter wheel/position) stay in general.yaml.
+    """
+    return AcquisitionChannel(
+        name=ch.name,
+        display_color=ch.display_color,
+        camera=ch.camera,
+        camera_settings=CameraSettings(
+            exposure_time_ms=ch.camera_settings.exposure_time_ms,
+            gain_mode=ch.camera_settings.gain_mode,
+            pixel_format=ch.camera_settings.pixel_format,
+        ),
+        filter_wheel=None,
+        filter_position=None,
+        z_offset_um=ch.z_offset_um,
+        illumination_settings=IlluminationSettings(
+            illumination_channel=None,
+            intensity=ch.illumination_settings.intensity,
+        ),
+    )
 
 
 class ConfigRepository:
@@ -656,6 +682,38 @@ class ConfigRepository:
             path = self.user_profiles_path / profile / "channel_configs" / f"{objective}.yaml"
             self._save_yaml(path, config)
 
+    def sync_general_channels_to_objectives(self, profile: Optional[str] = None) -> None:
+        """
+        Ensure every channel in general.yaml has an entry in each objective config.
+
+        Channels added to general.yaml after the objective files were created (e.g. via
+        the channel configurator) are seeded into each objective file from their general
+        settings, so per-objective edits to them can persist. Existing objective entries
+        are left untouched.
+        """
+        profile = profile or self._current_profile
+        if not profile:
+            logger.warning("Cannot sync channels: no profile set")
+            return
+
+        general_config = self.get_general_config(profile)
+        if general_config is None:
+            return
+
+        for objective in self.get_available_objectives(profile):
+            obj_config = self.get_objective_config(objective, profile)
+            if obj_config is None:
+                continue
+            missing = [ch for ch in general_config.channels if obj_config.get_channel_by_name(ch.name) is None]
+            if not missing:
+                continue
+            obj_config.channels.extend(_objective_channel_from_general(ch) for ch in missing)
+            self.save_objective_config(profile, objective, obj_config)
+            logger.info(
+                f"Added {len(missing)} channel(s) from general.yaml to objective '{objective}': "
+                + ", ".join(ch.name for ch in missing)
+            )
+
     # ═══════════════════════════════════════════════════════════════════════════
     # CHANNEL CONFIG CONVENIENCE METHODS
     # Higher-level helpers for common channel config operations
@@ -762,33 +820,21 @@ class ConfigRepository:
             # Create objective config from general config (v1.1 schema)
             obj_config = ObjectiveChannelConfig(
                 version=1.1,
-                channels=[
-                    AcquisitionChannel(
-                        name=ch.name,
-                        display_color=ch.display_color,
-                        camera=ch.camera,
-                        camera_settings=CameraSettings(
-                            exposure_time_ms=ch.camera_settings.exposure_time_ms,
-                            gain_mode=ch.camera_settings.gain_mode,
-                            pixel_format=ch.camera_settings.pixel_format,
-                        ),
-                        filter_wheel=None,  # Objective files don't include filter wheel
-                        filter_position=None,
-                        z_offset_um=ch.z_offset_um,
-                        illumination_settings=IlluminationSettings(
-                            illumination_channel=None,  # From general.yaml
-                            intensity=ch.illumination_settings.intensity,
-                        ),
-                    )
-                    for ch in general_config.channels
-                ],
+                channels=[_objective_channel_from_general(ch) for ch in general_config.channels],
             )
 
         # Find the channel
         acq_channel = obj_config.get_channel_by_name(channel_name)
         if not acq_channel:
-            logger.warning(f"Channel '{channel_name}' not found in objective config")
-            return False
+            # Channel exists in general.yaml but not in this objective config (e.g. it was
+            # added via the channel configurator after the objective file was created).
+            # Seed it from general so the edit persists instead of being dropped.
+            gen_channel = general_config.get_channel_by_name(channel_name) if general_config else None
+            if gen_channel is None:
+                logger.warning(f"Channel '{channel_name}' not found in objective or general config")
+                return False
+            acq_channel = _objective_channel_from_general(gen_channel)
+            obj_config.channels.append(acq_channel)
 
         # Iris settings go to confocal_hardware_settings (applies in both modes)
         if location == "confocal_hw":

--- a/software/control/core/config/repository.py
+++ b/software/control/core/config/repository.py
@@ -682,37 +682,60 @@ class ConfigRepository:
             path = self.user_profiles_path / profile / "channel_configs" / f"{objective}.yaml"
             self._save_yaml(path, config)
 
-    def sync_general_channels_to_objectives(self, profile: Optional[str] = None) -> None:
+    def save_general_config_with_sync(self, profile: str, config: GeneralChannelConfig) -> List[str]:
         """
-        Ensure every channel in general.yaml has an entry in each objective config.
+        Save general.yaml and propagate channel list changes to the objective configs.
 
-        Channels added to general.yaml after the objective files were created (e.g. via
-        the channel configurator) are seeded into each objective file from their general
-        settings, so per-objective edits to them can persist. Existing objective entries
-        are left untouched.
+        Compared to the previous on-disk general.yaml:
+        - Channels newly added to general are seeded into each objective file (from
+          their general settings), so per-objective edits to them can persist.
+        - Objective entries whose channel no longer exists in general are removed,
+          so a later channel reusing the name cannot resurrect stale settings.
+        - Channels present in both are left untouched: an objective entry the user
+          removed to fall back to general defaults is not re-materialized.
+
+        Raises if general.yaml cannot be saved. A failure writing one objective file
+        does not interrupt the sync of the others; the list of objectives that failed
+        to update is returned (empty on full success).
         """
-        profile = profile or self._current_profile
-        if not profile:
-            logger.warning("Cannot sync channels: no profile set")
-            return
+        # Read the previous general config from disk (not the cache — the caller may
+        # have mutated the cached object in place) to diff the channel lists.
+        old_general_path = self.user_profiles_path / profile / "channel_configs" / "general.yaml"
+        old_general = self._load_yaml(old_general_path, GeneralChannelConfig)
+        old_names = {ch.name for ch in old_general.channels} if old_general else set()
 
-        general_config = self.get_general_config(profile)
-        if general_config is None:
-            return
+        self.save_general_config(profile, config)
 
+        new_by_name = {ch.name: ch for ch in config.channels}
+        added_names = [name for name in new_by_name if name not in old_names]
+
+        failed_objectives: List[str] = []
         for objective in self.get_available_objectives(profile):
             obj_config = self.get_objective_config(objective, profile)
             if obj_config is None:
                 continue
-            missing = [ch for ch in general_config.channels if obj_config.get_channel_by_name(ch.name) is None]
-            if not missing:
+            existing_names = {ch.name for ch in obj_config.channels}
+            removed_names = [name for name in existing_names if name not in new_by_name]
+            to_seed = [name for name in added_names if name not in existing_names]
+            if not removed_names and not to_seed:
                 continue
-            obj_config.channels.extend(_objective_channel_from_general(ch) for ch in missing)
-            self.save_objective_config(profile, objective, obj_config)
-            logger.info(
-                f"Added {len(missing)} channel(s) from general.yaml to objective '{objective}': "
-                + ", ".join(ch.name for ch in missing)
-            )
+
+            # Mutate a copy so a failed save cannot leave unsaved changes in the cache.
+            updated = obj_config.model_copy(deep=True)
+            updated.channels = [ch for ch in updated.channels if ch.name in new_by_name]
+            updated.channels.extend(_objective_channel_from_general(new_by_name[name]) for name in to_seed)
+            try:
+                self.save_objective_config(profile, objective, updated)
+            except (OSError, yaml.YAMLError) as e:
+                logger.error(f"Failed to sync channel list to objective '{objective}': {e}")
+                failed_objectives.append(objective)
+                continue
+            if to_seed:
+                logger.info(f"Seeded channel(s) into objective '{objective}': " + ", ".join(to_seed))
+            if removed_names:
+                logger.info(f"Removed channel(s) from objective '{objective}': " + ", ".join(removed_names))
+
+        return failed_objectives
 
     # ═══════════════════════════════════════════════════════════════════════════
     # CHANNEL CONFIG CONVENIENCE METHODS
@@ -812,6 +835,11 @@ class ConfigRepository:
         # Get or create objective config
         obj_config = self.get_objective_config(objective, profile)
         general_config = self.get_general_config(profile)
+
+        if obj_config is not None:
+            # Mutate a copy so a failed save cannot leave unsaved changes in the cache;
+            # save_objective_config re-caches the copy on success.
+            obj_config = obj_config.model_copy(deep=True)
 
         if obj_config is None:
             if general_config is None:

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -15935,6 +15935,9 @@ class AcquisitionChannelConfiguratorDialog(QDialog):
         # Save to YAML file
         try:
             self.config_repo.save_general_config(self.config_repo.current_profile, self.general_config)
+            # Seed any newly added channels into the per-objective configs so that
+            # per-objective edits (exposure/gain/intensity) to them can persist.
+            self.config_repo.sync_general_channels_to_objectives(self.config_repo.current_profile)
         except (PermissionError, OSError) as e:
             self._log.error(f"Failed to save channel configuration: {e}")
             QMessageBox.critical(self, "Save Failed", f"Cannot write configuration file:\n{e}")

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -15932,12 +15932,12 @@ class AcquisitionChannelConfiguratorDialog(QDialog):
             if reply != QMessageBox.Yes:
                 return
 
-        # Save to YAML file
+        # Save to YAML file, seeding added channels into (and pruning removed channels
+        # from) the per-objective configs so per-objective edits to them can persist.
         try:
-            self.config_repo.save_general_config(self.config_repo.current_profile, self.general_config)
-            # Seed any newly added channels into the per-objective configs so that
-            # per-objective edits (exposure/gain/intensity) to them can persist.
-            self.config_repo.sync_general_channels_to_objectives(self.config_repo.current_profile)
+            failed_objectives = self.config_repo.save_general_config_with_sync(
+                self.config_repo.current_profile, self.general_config
+            )
         except (PermissionError, OSError) as e:
             self._log.error(f"Failed to save channel configuration: {e}")
             QMessageBox.critical(self, "Save Failed", f"Cannot write configuration file:\n{e}")
@@ -15946,6 +15946,16 @@ class AcquisitionChannelConfiguratorDialog(QDialog):
             self._log.error(f"Unexpected error saving channel configuration: {e}")
             QMessageBox.critical(self, "Save Failed", f"Failed to save configuration:\n{e}")
             return
+
+        if failed_objectives:
+            # general.yaml was saved; only some per-objective files could not be updated.
+            QMessageBox.warning(
+                self,
+                "Partial Save",
+                "The channel list was saved, but the settings files for these objectives "
+                f"could not be updated: {', '.join(failed_objectives)}.\n"
+                "Settings for added/removed channels may be stale for those objectives.",
+            )
 
         self.signal_channels_updated.emit()
         self.accept()

--- a/software/tests/control/core/config/test_repository.py
+++ b/software/tests/control/core/config/test_repository.py
@@ -1548,18 +1548,86 @@ class TestChannelMissingFromObjectiveConfig:
         """A channel in neither general nor objective config is still rejected."""
         assert repo_with_new_channel.update_channel_setting("20x", "no such channel", "ExposureTime", 10.0) is False
 
-    def test_sync_general_channels_to_objectives(self, repo_with_new_channel):
-        """Sync seeds missing channels into every objective file without touching existing entries."""
-        repo_with_new_channel.sync_general_channels_to_objectives()
+    @staticmethod
+    def _make_channel(name, exposure=15.0, intensity=33.0):
+        return AcquisitionChannel(
+            name=name,
+            display_color="#FFFFFF",
+            camera_settings=CameraSettings(exposure_time_ms=exposure, gain_mode=2.0),
+            illumination_settings=IlluminationSettings(illumination_channel="561nm", intensity=intensity),
+        )
+
+    def test_save_with_sync_seeds_only_added_channels(self, repo_with_new_channel):
+        """Channels added in this save are seeded into every objective file; channels that
+        were already in general.yaml but absent from an objective file are NOT re-added."""
+        general = repo_with_new_channel.get_general_config()
+        general.channels.append(self._make_channel("561nm - 2"))
+
+        failed = repo_with_new_channel.save_general_config_with_sync("default", general)
+        assert failed == []
 
         repo_with_new_channel.clear_profile_cache()
         for objective in ("20x", "4x"):
             obj = repo_with_new_channel.get_objective_config(objective)
-            ch = obj.get_channel_by_name("561nm - 1")
-            assert ch is not None, f"'561nm - 1' missing from {objective}"
-            assert ch.camera_settings.exposure_time_ms == 30.0
-            assert ch.illumination_settings.intensity == 44.0
+            ch = obj.get_channel_by_name("561nm - 2")
+            assert ch is not None, f"'561nm - 2' missing from {objective}"
+            assert ch.camera_settings.exposure_time_ms == 15.0
+            assert ch.illumination_settings.intensity == 33.0
+            # '561nm - 1' was already in general before this save: its absence from the
+            # objective file is preserved (a user's fallback-to-general is respected).
+            assert obj.get_channel_by_name("561nm - 1") is None
             # Existing entry untouched (keeps objective-specific values)
             ch488 = obj.get_channel_by_name("488nm")
             assert ch488.camera_settings.exposure_time_ms == 50.0
             assert ch488.illumination_settings.intensity == 75.0
+
+    def test_save_with_sync_prunes_removed_channels_and_prevents_resurrection(self, repo_with_new_channel):
+        """Removing a channel prunes its objective entries; re-adding the same name later
+        seeds fresh settings instead of resurrecting the stale ones."""
+        # Materialize '561nm - 1' in 20x.yaml with a distinctive value via the lazy seed path
+        assert repo_with_new_channel.update_channel_setting("20x", "561nm - 1", "ExposureTime", 123.0) is True
+
+        # Remove the channel in the configurator and save
+        general = repo_with_new_channel.get_general_config()
+        general.channels = [ch for ch in general.channels if ch.name != "561nm - 1"]
+        assert repo_with_new_channel.save_general_config_with_sync("default", general) == []
+
+        repo_with_new_channel.clear_profile_cache()
+        assert repo_with_new_channel.get_objective_config("20x").get_channel_by_name("561nm - 1") is None
+
+        # Re-add a channel with the same name but different settings
+        general = repo_with_new_channel.get_general_config()
+        general.channels.append(self._make_channel("561nm - 1", exposure=10.0, intensity=5.0))
+        assert repo_with_new_channel.save_general_config_with_sync("default", general) == []
+
+        repo_with_new_channel.clear_profile_cache()
+        ch = repo_with_new_channel.get_objective_config("20x").get_channel_by_name("561nm - 1")
+        assert ch is not None
+        assert ch.camera_settings.exposure_time_ms == 10.0  # not the stale 123.0
+        assert ch.illumination_settings.intensity == 5.0
+
+    def test_save_with_sync_objective_failure_is_isolated_and_does_not_poison_cache(self, repo_with_new_channel):
+        """A failing objective write is reported, does not block other objectives, and
+        leaves neither the cache nor the disk with the unsaved change."""
+        orig_save_yaml = repo_with_new_channel._save_yaml
+
+        def failing_save_yaml(path, model):
+            if path.name == "20x.yaml":
+                raise PermissionError(f"denied: {path}")
+            return orig_save_yaml(path, model)
+
+        repo_with_new_channel._save_yaml = failing_save_yaml
+
+        general = repo_with_new_channel.get_general_config()
+        general.channels.append(self._make_channel("561nm - 2"))
+        failed = repo_with_new_channel.save_general_config_with_sync("default", general)
+        assert failed == ["20x"]
+
+        # 4x still synced despite the 20x failure
+        assert repo_with_new_channel.get_objective_config("4x").get_channel_by_name("561nm - 2") is not None
+        # Cached 20x config does not contain the never-persisted channel...
+        assert repo_with_new_channel.get_objective_config("20x").get_channel_by_name("561nm - 2") is None
+        # ...and neither does the file on disk
+        repo_with_new_channel._save_yaml = orig_save_yaml
+        repo_with_new_channel.clear_profile_cache()
+        assert repo_with_new_channel.get_objective_config("20x").get_channel_by_name("561nm - 2") is None

--- a/software/tests/control/core/config/test_repository.py
+++ b/software/tests/control/core/config/test_repository.py
@@ -1465,3 +1465,101 @@ class TestUpdateChannelSettingPreservesZOffset:
         obj = repo_general_only.get_objective_config("20x")
         ch488 = next(c for c in obj.channels if c.name == "488nm")
         assert ch488.z_offset_um == 0.0
+
+
+class TestChannelMissingFromObjectiveConfig:
+    """Channels added to general.yaml after objective files exist (e.g. via the channel
+    configurator) must still be editable and persist per-objective."""
+
+    @pytest.fixture
+    def repo_with_new_channel(self, tmp_path):
+        """Profile where '561nm - 1' exists in general.yaml but not in the objective files."""
+        machine = tmp_path / "machine_configs"
+        machine.mkdir()
+        (machine / "illumination_channel_config.yaml").write_text(
+            "version: 1\n"
+            "channels:\n"
+            '  - name: "488nm"\n'
+            "    type: epi_illumination\n"
+            "    controller_port: D2\n"
+            "    wavelength_nm: 488\n"
+            '  - name: "561nm"\n'
+            "    type: epi_illumination\n"
+            "    controller_port: D3\n"
+            "    wavelength_nm: 561\n"
+        )
+        profile = tmp_path / "user_profiles" / "default"
+        (profile / "channel_configs").mkdir(parents=True)
+        (profile / "laser_af_configs").mkdir()
+        (profile / "channel_configs" / "general.yaml").write_text(
+            "version: 1.0\n"
+            "channels:\n"
+            '  - name: "488nm"\n'
+            '    display_color: "#1FFF00"\n'
+            "    camera_settings: {exposure_time_ms: 20.0, gain_mode: 10.0}\n"
+            '    illumination_settings: {illumination_channel: "488nm", intensity: 20.0}\n'
+            "    z_offset_um: 0.0\n"
+            '  - name: "561nm - 1"\n'
+            '    display_color: "#FF8000"\n'
+            "    camera_settings: {exposure_time_ms: 30.0, gain_mode: 5.0}\n"
+            '    illumination_settings: {illumination_channel: "561nm", intensity: 44.0}\n'
+            "    filter_position: 2\n"
+            "    z_offset_um: 1.5\n"
+        )
+        objective_yaml = (
+            "version: 1.0\n"
+            "channels:\n"
+            '  - name: "488nm"\n'
+            '    display_color: "#1FFF00"\n'
+            "    camera_settings: {exposure_time_ms: 50.0, gain_mode: 1.0}\n"
+            "    illumination_settings: {intensity: 75.0}\n"
+        )
+        (profile / "channel_configs" / "20x.yaml").write_text(objective_yaml)
+        (profile / "channel_configs" / "4x.yaml").write_text(objective_yaml)
+        repo = ConfigRepository(base_path=tmp_path)
+        repo.set_profile("default")
+        return repo
+
+    def test_update_seeds_missing_channel_and_persists(self, repo_with_new_channel):
+        """Editing a channel absent from the objective file seeds it there and saves the edit."""
+        result = repo_with_new_channel.update_channel_setting("20x", "561nm - 1", "ExposureTime", 123.0)
+        assert result is True
+
+        # Persisted to YAML — clear cache and reload
+        repo_with_new_channel.clear_profile_cache()
+        obj = repo_with_new_channel.get_objective_config("20x")
+        ch = obj.get_channel_by_name("561nm - 1")
+        assert ch is not None
+        assert ch.camera_settings.exposure_time_ms == 123.0
+        # Other per-objective settings seeded from general.yaml
+        assert ch.camera_settings.gain_mode == 5.0
+        assert ch.illumination_settings.intensity == 44.0
+        assert ch.z_offset_um == 1.5
+        # Channel identity stays in general.yaml, not in the objective file
+        assert ch.filter_position is None
+
+        # The merged view reflects the edit (and keeps identity from general)
+        merged = repo_with_new_channel.get_merged_channels("20x")
+        merged_ch = next(c for c in merged if c.name == "561nm - 1")
+        assert merged_ch.camera_settings.exposure_time_ms == 123.0
+        assert merged_ch.filter_position == 2
+
+    def test_update_unknown_channel_still_fails(self, repo_with_new_channel):
+        """A channel in neither general nor objective config is still rejected."""
+        assert repo_with_new_channel.update_channel_setting("20x", "no such channel", "ExposureTime", 10.0) is False
+
+    def test_sync_general_channels_to_objectives(self, repo_with_new_channel):
+        """Sync seeds missing channels into every objective file without touching existing entries."""
+        repo_with_new_channel.sync_general_channels_to_objectives()
+
+        repo_with_new_channel.clear_profile_cache()
+        for objective in ("20x", "4x"):
+            obj = repo_with_new_channel.get_objective_config(objective)
+            ch = obj.get_channel_by_name("561nm - 1")
+            assert ch is not None, f"'561nm - 1' missing from {objective}"
+            assert ch.camera_settings.exposure_time_ms == 30.0
+            assert ch.illumination_settings.intensity == 44.0
+            # Existing entry untouched (keeps objective-specific values)
+            ch488 = obj.get_channel_by_name("488nm")
+            assert ch488.camera_settings.exposure_time_ms == 50.0
+            assert ch488.illumination_settings.intensity == 75.0


### PR DESCRIPTION
## Problem

Channel settings for channels added via the Acquisition Channel Configurator (e.g. "Fluorescence 638 nm Ex - 1") silently reverted on every restart.

Root cause: the configurator saves new channels only to `general.yaml` and never adds them to the per-objective config files (`4x.yaml`, `20x.yaml`, ...). When the user then edits such a channel's exposure/gain/intensity in the live UI, `update_channel_setting()` looks the channel up in the objective config, doesn't find it, and returns `False` — the edit is dropped without any user-visible feedback. On restart, the merge falls back to the stale `general.yaml` values.

Confirmed on hardware: setting 123 ms on a configurator-added channel wrote nothing to disk, while the same edit on an original channel was persisted to the objective YAML immediately.

The failure was also invisible in the logs because `repository.py` used a plain `logging.getLogger`, which is outside the `squid` logger hierarchy that the file handler is attached to.

## Fix

- `update_channel_setting()`: when the channel exists in `general.yaml` but not in the objective config, seed it into the objective config from the general settings and apply the edit (mirrors the existing behavior when the whole objective file is missing). The seeding is factored into a shared `_objective_channel_from_general()` helper.
- New `ConfigRepository.save_general_config_with_sync()`, used by the configurator dialog's save. It diffs the new channel list against the previous on-disk `general.yaml` and propagates the changes to every objective file:
  - channels **added** in this save are seeded from their general settings;
  - objective entries whose channel was **removed** are pruned, so a later channel reusing the name cannot resurrect stale settings;
  - channels present in both are left untouched — an objective entry the user removed to fall back to general defaults is not re-materialized;
  - `general.yaml` save failures stay fatal; per-objective write failures are isolated, reported to the user as a partial save, and don't block the remaining objectives or the UI refresh.
- Config mutations happen on deep copies, so a failed save can't leave unsaved changes in the profile cache (`get_merged_channels()` can't report state that isn't on disk).
- `repository.py` now logs via `squid.logging.get_logger`, so its warnings reach `main_hcs.log`.

## Testing

- New regression tests: lazy seeding on edit (+persistence through cache clear/reload, merged view, identity fields staying in `general.yaml`), unknown-channel rejection, diff-aware sync (seed-only-added, prune-removed, resurrection prevention, no re-materialization of fallback-to-general entries), and failure isolation/cache cleanliness on a failed objective write.
- `tests/control/core/config/` + `test_acquisition_config_models.py` + `test_default_config_generator.py`: 191 passed.
- An adversarially-verified multi-agent code review at high effort was run on the first iteration; all four confirmed findings are addressed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
