### PR TITLE
Add ASI LS50 Z-only focus stage (USE_ASI_Z_STAGE)

### DIFF
--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -1133,7 +1133,10 @@ ASI_Z_INVERT = True
 # set_limits from StageConfig.Z_AXIS at microscope init. 0 leaves controller limits untouched.
 ASI_Z_TRAVEL_MM = 0.0
 # Squid-frame retract target home() drives Z to; 0.0 = native 0, the retracted end. Power the
-# controller on with the stage retracted (or re-establish the frame) so this holds.
+# controller on with the stage retracted (or re-establish the frame) so this holds. NOTE the
+# power-on-retracted convention is load-bearing beyond home(): the shared retract flows
+# (loading/shutdown/safety-position) drive Z to OBJECTIVE_RETRACTED_POS_MM in this same squid
+# frame and assume it is near-retracted.
 ASI_Z_HOME_MM = 0.0
 # Retract Z to ASI_Z_HOME_MM once at bring-up. MOVES the stage. Default off: no uncommanded
 # motion until the machine's frame convention is verified.
@@ -1148,7 +1151,7 @@ def uses_external_z_stage() -> bool:
     are defined, so a derived constant would capture the pre-override defaults. Policy sites use
     this instead of OR-ing vendor flags.
     """
-    return bool(USE_PI_FOCUS_STAGE) or bool(USE_ASI_Z_STAGE)
+    return bool(USE_PI_FOCUS_STAGE or USE_ASI_Z_STAGE)
 
 
 def _validate_external_z_stage_flags(use_pi: bool, use_asi: bool) -> None:

--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -1119,7 +1119,6 @@ PI_FOCUS_Z_TRAVEL_MM = 0.0
 # ASI LS50 Z-only linear stage on its own MS-2000-family controller, used as the main Z (wraps
 # the configured XY stage via CombinedStage). CR-terminated text protocol, 1/10 um native units.
 USE_ASI_Z_STAGE = False
-SIMULATE_ASI_Z_STAGE = False
 ASI_Z_STAGE_SN = ""  # USB serial number -> resolved to a port
 ASI_Z_SERIAL_PORT = ""  # explicit port fallback (e.g. /dev/ttyUSB0, COM7)
 ASI_Z_BAUDRATE = 115200

--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -1123,6 +1123,9 @@ SIMULATE_ASI_Z_STAGE = False
 ASI_Z_STAGE_SN = ""  # USB serial number -> resolved to a port
 ASI_Z_SERIAL_PORT = ""  # explicit port fallback (e.g. /dev/ttyUSB0, COM7)
 ASI_Z_BAUDRATE = 115200
+# Axis letter of the LS50 on its controller. Single-axis MS-2000 builds sometimes label
+# their lone axis X; the driver uses this letter in every command (M/R/W/SL/SU/H).
+ASI_Z_AXIS_LETTER = "Z"
 # The LS50 has no absolute reference: native 0 is the power-on position (the retracted end by
 # convention) and native POSITIVE is away from the sample. True (the standard wiring) shows the
 # negation (squid_z = -native_z), so squid 0 = retracted and squid Z+ is toward the sample.

--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -1126,36 +1126,29 @@ ASI_Z_BAUDRATE = 115200
 # Axis letter of the LS50 on its controller. Single-axis MS-2000 builds sometimes label
 # their lone axis X; the driver uses this letter in every command (M/R/W/SL/SU/H).
 ASI_Z_AXIS_LETTER = "Z"
-# The LS50 has no absolute reference: native 0 is the power-on position (the retracted end by
-# convention) and native POSITIVE is away from the sample. True (the standard wiring) shows the
-# negation (squid_z = -native_z), so squid 0 = retracted and squid Z+ is toward the sample.
+# Native POSITIVE is away from the sample. True (the standard wiring) shows the negation
+# (squid_z = -native_z), so squid 0 is the away end and squid Z+ is toward the sample.
 ASI_Z_INVERT = True
-# Coarse sanity fence: >0 sets controller soft limits (SL/SU) and a software clamp to
-# [-travel, +travel] native mm around the power-on zero. +/- full travel (50 for the LS50) can
-# never exclude a reachable position but stops absurd targets; the real fence arrives via
-# set_limits from StageConfig.Z_AXIS at microscope init. 0 leaves controller limits untouched.
+# Physical travel of the stage (LS-50 = 50). REQUIRED when find-zero is on: it sets the
+# overdrive distance. Also sets a coarse sanity fence of native [-travel, +travel] (controller
+# SL/SU + software clamp) -- full travel can never exclude a reachable position but stops
+# absurd targets. 0 leaves the controller limits untouched (and is invalid with find-zero).
 ASI_Z_TRAVEL_MM = 0.0
-# Squid-frame retract target home() drives Z to; 0.0 = native 0, the retracted end. Power the
-# controller on with the stage retracted (or re-establish the frame) so this holds. NOTE the
-# power-on-retracted convention is load-bearing beyond home(): the shared retract flows
-# (loading/shutdown/safety-position) drive Z to OBJECTIVE_RETRACTED_POS_MM in this same squid
-# frame and assume it is near-retracted.
+# Squid-frame retract target home() drives Z to; 0.0 = native 0, the away end that find-zero
+# anchors at the limit switch. The shared retract flows (loading/shutdown/safety-position)
+# drive Z to OBJECTIVE_RETRACTED_POS_MM in this same frame.
 ASI_Z_HOME_MM = 0.0
-# Retract Z to ASI_Z_HOME_MM once at bring-up. MOVES the stage. Default off: no uncommanded
-# motion until the machine's frame convention is verified.
-ASI_Z_HOME_ON_STARTUP = False
 # Establish the Z frame at startup: drive to the away-from-sample limit switch (native +,
 # the safe direction) and define native 0 there ('H Z=0'), so squid 0 is ALWAYS the true
-# farthest-from-sample position, never a random power-on point. MOVES the stage at startup.
-# The rest of the config (ASI_Z_HOME_MM=0, retract flows) assumes this frame; with it
-# established, ASI_Z_APPLY_SOFTWARE_LIMITS becomes meaningful again if wanted. Stale
-# controller-side soft limits are always cleared first (unconditional).
+# farthest-from-sample position, never a random power-on point. MOVES the stage at startup
+# (away only; up to ~90 s for full travel at the MFC-2000's 0.6 mm/s). Stale controller-side
+# soft limits are always cleared first (unconditional; they persist across power cycles).
 ASI_Z_FIND_ZERO_ON_STARTUP = True
 
-# Apply StageConfig.Z_AXIS MIN/MAX as a software fence on the LS50. Default off: the frame
-# is power-on-relative (native 0 = wherever the controller woke up), so fixed squid-frame
-# limits fence arbitrary positions unless the power-on-retracted convention is guaranteed.
-# The coarse ASI_Z_TRAVEL_MM fence (physical-travel-sized, frame-independent) still applies.
+# Apply StageConfig.Z_AXIS MIN/MAX as a software fence on the LS50. Off by operator choice on
+# the reference machine (full manual range wanted); with find-zero anchoring the frame, turning
+# this on gives a meaningful anti-collision fence at Z_AXIS MAX_POSITION. The coarse
+# ASI_Z_TRAVEL_MM fence applies regardless.
 ASI_Z_APPLY_SOFTWARE_LIMITS = False
 
 
@@ -1175,6 +1168,15 @@ def _validate_external_z_stage_flags(use_pi: bool, use_asi: bool) -> None:
         raise ValueError(
             "USE_PI_FOCUS_STAGE and USE_ASI_Z_STAGE are mutually exclusive "
             "(the microscope has exactly one external Z focus stage; set only one in the machine config)"
+        )
+
+
+def _validate_asi_z_flags(use_asi: bool, find_zero: bool, travel_mm: float) -> None:
+    # Fail at config load, next to the other flag validators, rather than mid-bring-up.
+    if use_asi and find_zero and not travel_mm:
+        raise ValueError(
+            "USE_ASI_Z_STAGE with ASI_Z_FIND_ZERO_ON_STARTUP requires ASI_Z_TRAVEL_MM: "
+            "the physical travel sets the find-zero overdrive distance (LS-50 = 50)"
         )
 
 
@@ -1422,6 +1424,7 @@ if config_files:
 
     _validate_objective_changer_flags(USE_XERYON, USE_OBJECTIVE_TURRET)
     _validate_external_z_stage_flags(USE_PI_FOCUS_STAGE, USE_ASI_Z_STAGE)
+    _validate_asi_z_flags(USE_ASI_Z_STAGE, ASI_Z_FIND_ZERO_ON_STARTUP, ASI_Z_TRAVEL_MM)
 
     with open("cache/config_file_path.txt", "w") as file:
         file.write(config_files[0])
@@ -1437,6 +1440,7 @@ else:
         exec(open(config_files[0]).read())
         _validate_objective_changer_flags(USE_XERYON, USE_OBJECTIVE_TURRET)
         _validate_external_z_stage_flags(USE_PI_FOCUS_STAGE, USE_ASI_Z_STAGE)
+        _validate_asi_z_flags(USE_ASI_Z_STAGE, ASI_Z_FIND_ZERO_ON_STARTUP, ASI_Z_TRAVEL_MM)
     else:
         log.error("machine-specific configuration not present, the program will exit")
         sys.exit(1)

--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -1116,6 +1116,49 @@ PI_FOCUS_Z_TRAVEL_MM = 0.0
 # When neither of the above applies, Z retracts to OBJECTIVE_RETRACTED_POS_MM (the existing Squid
 # retract constant) on home() and before XY homing -- set that for the objective-clear position.
 
+# ASI LS50 Z-only linear stage on its own MS-2000-family controller, used as the main Z (wraps
+# the configured XY stage via CombinedStage). CR-terminated text protocol, 1/10 um native units.
+USE_ASI_Z_STAGE = False
+SIMULATE_ASI_Z_STAGE = False
+ASI_Z_STAGE_SN = ""  # USB serial number -> resolved to a port
+ASI_Z_SERIAL_PORT = ""  # explicit port fallback (e.g. /dev/ttyUSB0, COM7)
+ASI_Z_BAUDRATE = 115200
+# The LS50 has no absolute reference: native 0 is the power-on position (the retracted end by
+# convention) and native POSITIVE is away from the sample. True (the standard wiring) shows the
+# negation (squid_z = -native_z), so squid 0 = retracted and squid Z+ is toward the sample.
+ASI_Z_INVERT = True
+# Coarse sanity fence: >0 sets controller soft limits (SL/SU) and a software clamp to
+# [-travel, +travel] native mm around the power-on zero. +/- full travel (50 for the LS50) can
+# never exclude a reachable position but stops absurd targets; the real fence arrives via
+# set_limits from StageConfig.Z_AXIS at microscope init. 0 leaves controller limits untouched.
+ASI_Z_TRAVEL_MM = 0.0
+# Squid-frame retract target home() drives Z to; 0.0 = native 0, the retracted end. Power the
+# controller on with the stage retracted (or re-establish the frame) so this holds.
+ASI_Z_HOME_MM = 0.0
+# Retract Z to ASI_Z_HOME_MM once at bring-up. MOVES the stage. Default off: no uncommanded
+# motion until the machine's frame convention is verified.
+ASI_Z_HOME_ON_STARTUP = False
+
+
+def uses_external_z_stage() -> bool:
+    """True when an external Z-only focus stage (PI V-308 or ASI LS50) provides the Z axis and
+    the XY stage is wrapped in a CombinedStage.
+
+    Must stay a function: the machine-config loader below overrides the flag globals AFTER they
+    are defined, so a derived constant would capture the pre-override defaults. Policy sites use
+    this instead of OR-ing vendor flags.
+    """
+    return bool(USE_PI_FOCUS_STAGE) or bool(USE_ASI_Z_STAGE)
+
+
+def _validate_external_z_stage_flags(use_pi: bool, use_asi: bool) -> None:
+    if use_pi and use_asi:
+        raise ValueError(
+            "USE_PI_FOCUS_STAGE and USE_ASI_Z_STAGE are mutually exclusive "
+            "(the microscope has exactly one external Z focus stage; set only one in the machine config)"
+        )
+
+
 # camera blacklevel settings
 DISPLAY_TOUPCAMER_BLACKLEVEL_SETTINGS = False
 
@@ -1359,6 +1402,7 @@ if config_files:
         populate_class_from_dict(myclass, pop_items)
 
     _validate_objective_changer_flags(USE_XERYON, USE_OBJECTIVE_TURRET)
+    _validate_external_z_stage_flags(USE_PI_FOCUS_STAGE, USE_ASI_Z_STAGE)
 
     with open("cache/config_file_path.txt", "w") as file:
         file.write(config_files[0])
@@ -1373,6 +1417,7 @@ else:
         log.info("load machine-specific configuration")
         exec(open(config_files[0]).read())
         _validate_objective_changer_flags(USE_XERYON, USE_OBJECTIVE_TURRET)
+        _validate_external_z_stage_flags(USE_PI_FOCUS_STAGE, USE_ASI_Z_STAGE)
     else:
         log.error("machine-specific configuration not present, the program will exit")
         sys.exit(1)

--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -1144,6 +1144,11 @@ ASI_Z_HOME_MM = 0.0
 # Retract Z to ASI_Z_HOME_MM once at bring-up. MOVES the stage. Default off: no uncommanded
 # motion until the machine's frame convention is verified.
 ASI_Z_HOME_ON_STARTUP = False
+# Apply StageConfig.Z_AXIS MIN/MAX as a software fence on the LS50. Default off: the frame
+# is power-on-relative (native 0 = wherever the controller woke up), so fixed squid-frame
+# limits fence arbitrary positions unless the power-on-retracted convention is guaranteed.
+# The coarse ASI_Z_TRAVEL_MM fence (physical-travel-sized, frame-independent) still applies.
+ASI_Z_APPLY_SOFTWARE_LIMITS = False
 
 
 def uses_external_z_stage() -> bool:

--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -1309,11 +1309,32 @@ OBJECTIVE_TURRET_BAUDRATE = 115200
 # Objective name -> turret slot index (1..4). Override per machine in .ini.
 OBJECTIVE_TURRET_POSITIONS = {"4x": 1, "10x": 2, "20x": 3, "40x": 4}
 
+# 6-position ASI objective turret on an MS-2000-family controller ('M F=<slot>' with a RAW
+# slot index 1..6 -- not scaled like linear-axis units). Typically the SAME controller as the
+# ASI LS50 Z stage (USE_ASI_Z_STAGE): when both are enabled the turret reuses the Z stage's
+# serial connection and the SN/port/baud below are ignored. They apply only when the turret
+# runs WITHOUT the ASI Z stage; empty/0 means "reuse the ASI_Z_* value" -- resolved at
+# construction time in microscope.py, NOT here, because the machine-config loader overrides
+# these globals after definition (same reasoning as uses_external_z_stage()).
+# The turret has NO homing: home() never moves; startup's move_to_objective(DEFAULT_OBJECTIVE)
+# establishes a known slot at every boot.
+USE_ASI_OBJECTIVE_TURRET = False
+# Axis letter of the turret on the controller ('M <letter>=<slot>' / 'W <letter>').
+# F on the MFC-2000 (hardware-confirmed).
+ASI_OBJECTIVE_TURRET_AXIS_LETTER = "F"
+# Objective name -> turret slot (1..6). Keys must match objectives.csv names. Override per machine .ini
+# (JSON with double-quoted keys, e.g. asi_objective_turret_positions = {"4x": 1, "20x": 2}).
+ASI_OBJECTIVE_TURRET_POSITIONS = {"2x": 1, "4x": 2, "10x": 3, "20x": 4, "40x": 5, "60x": 6}
+ASI_OBJECTIVE_TURRET_SN = ""  # "" = reuse ASI_Z_STAGE_SN (turret-without-Z-stage only)
+ASI_OBJECTIVE_TURRET_SERIAL_PORT = ""  # "" = reuse ASI_Z_SERIAL_PORT
+ASI_OBJECTIVE_TURRET_BAUDRATE = 0  # 0 = reuse ASI_Z_BAUDRATE
 
-def _validate_objective_changer_flags(use_xeryon: bool, use_turret: bool) -> None:
-    if use_xeryon and use_turret:
+
+def _validate_objective_changer_flags(use_xeryon: bool, use_turret: bool, use_asi_turret: bool = False) -> None:
+    if int(bool(use_xeryon)) + int(bool(use_turret)) + int(bool(use_asi_turret)) > 1:
         raise ValueError(
-            "USE_XERYON and USE_OBJECTIVE_TURRET are mutually exclusive " "(set only one to True in the machine .ini)"
+            "USE_XERYON, USE_OBJECTIVE_TURRET and USE_ASI_OBJECTIVE_TURRET are mutually exclusive "
+            "(set at most one to True in the machine .ini)"
         )
 
 
@@ -1422,7 +1443,7 @@ if config_files:
         myclass = locals()[classkey]
         populate_class_from_dict(myclass, pop_items)
 
-    _validate_objective_changer_flags(USE_XERYON, USE_OBJECTIVE_TURRET)
+    _validate_objective_changer_flags(USE_XERYON, USE_OBJECTIVE_TURRET, USE_ASI_OBJECTIVE_TURRET)
     _validate_external_z_stage_flags(USE_PI_FOCUS_STAGE, USE_ASI_Z_STAGE)
     _validate_asi_z_flags(USE_ASI_Z_STAGE, ASI_Z_FIND_ZERO_ON_STARTUP, ASI_Z_TRAVEL_MM)
 
@@ -1438,7 +1459,7 @@ else:
             sys.exit(1)
         log.info("load machine-specific configuration")
         exec(open(config_files[0]).read())
-        _validate_objective_changer_flags(USE_XERYON, USE_OBJECTIVE_TURRET)
+        _validate_objective_changer_flags(USE_XERYON, USE_OBJECTIVE_TURRET, USE_ASI_OBJECTIVE_TURRET)
         _validate_external_z_stage_flags(USE_PI_FOCUS_STAGE, USE_ASI_Z_STAGE)
         _validate_asi_z_flags(USE_ASI_Z_STAGE, ASI_Z_FIND_ZERO_ON_STARTUP, ASI_Z_TRAVEL_MM)
     else:

--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -1144,6 +1144,14 @@ ASI_Z_HOME_MM = 0.0
 # Retract Z to ASI_Z_HOME_MM once at bring-up. MOVES the stage. Default off: no uncommanded
 # motion until the machine's frame convention is verified.
 ASI_Z_HOME_ON_STARTUP = False
+# Establish the Z frame at startup: drive to the away-from-sample limit switch (native +,
+# the safe direction) and define native 0 there ('H Z=0'), so squid 0 is ALWAYS the true
+# farthest-from-sample position, never a random power-on point. MOVES the stage at startup.
+# The rest of the config (ASI_Z_HOME_MM=0, retract flows) assumes this frame; with it
+# established, ASI_Z_APPLY_SOFTWARE_LIMITS becomes meaningful again if wanted. Stale
+# controller-side soft limits are always cleared first (unconditional).
+ASI_Z_FIND_ZERO_ON_STARTUP = True
+
 # Apply StageConfig.Z_AXIS MIN/MAX as a software fence on the LS50. Default off: the frame
 # is power-on-relative (native 0 = wherever the controller woke up), so fixed squid-frame
 # limits fence arbitrary positions unless the power-on-retracted convention is guaranteed.

--- a/software/control/asi_objective_turret.py
+++ b/software/control/asi_objective_turret.py
@@ -1,0 +1,278 @@
+"""6-position ASI objective turret on an MS-2000-family controller.
+
+Shares the controller -- and, when USE_ASI_Z_STAGE is enabled, the serial connection -- with
+the LS50 Z stage (squid.stage.asi). Command set: ``M F=<slot>`` rotates to a RAW slot index
+1..6 (NOT scaled by the 0.1 um unit factor used for linear axes); ``W F`` presumably reads
+the slot back (UNVERIFIED on hardware -- treated as best-effort, degrading to software
+tracking of the last commanded slot); ``/`` is the controller-GLOBAL busy byte, shared with
+the Z axis. ``MS2000Serial``'s internal lock keeps turret and Z commands frame-safe when
+interleaved.
+
+The turret has NO homing: ``home()`` never moves; it only refreshes the tracked slot. The
+startup flow's ``move_to_objective(DEFAULT_OBJECTIVE)`` establishes a known slot at boot.
+"""
+
+from contextlib import suppress
+from typing import Dict, Optional
+
+import squid.abc
+import squid.logging
+from control.objective_turret_controller import (  # shared changer helpers (same KeyError the GUI dialog shows)
+    _resolve_position,
+    restore_z_if_captured,
+    retract_z_if_possible,
+)
+from squid.stage.asi import MS2000Serial, parse_ms2000_number
+
+_log = squid.logging.get_logger(__name__)
+
+TURRET_SLOT_COUNT = 6
+DEFAULT_MOVE_TIMEOUT_S = 30.0
+
+
+def _validate_positions(positions: Optional[dict]) -> Dict[str, int]:
+    if positions is None:
+        from control._def import ASI_OBJECTIVE_TURRET_POSITIONS
+
+        positions = ASI_OBJECTIVE_TURRET_POSITIONS
+    # Fail fast: a bad slot value would otherwise go straight to the hardware as 'M F=<junk>'.
+    for name, slot in positions.items():
+        if not isinstance(slot, int) or not 1 <= slot <= TURRET_SLOT_COUNT:
+            raise ValueError(
+                f"ASI turret position for {name!r} must be an integer slot 1..{TURRET_SLOT_COUNT}, got {slot!r}"
+            )
+    return dict(positions)
+
+
+class ASIObjectiveTurret:
+    """ObjectiveChangerProtocol implementation for the MS-2000 turret axis (F on the MFC-2000).
+
+    Pass ``shared_serial`` (the Z stage's transport, via squid.stage.asi.find_shared_ms2000)
+    when the LS50 Z stage runs on the same controller -- the turret then never closes it.
+    Without it, the turret opens (and owns) its own connection by serial number or port.
+    """
+
+    def __init__(
+        self,
+        shared_serial: Optional[MS2000Serial] = None,
+        serial_number: Optional[str] = None,
+        serial_port: Optional[str] = None,
+        baudrate: int = 115200,
+        axis: str = "F",
+        positions: Optional[Dict[str, int]] = None,
+        stage: Optional[squid.abc.AbstractStage] = None,
+    ):
+        self._positions = _validate_positions(positions)
+        self._axis = axis
+        self._stage = stage
+        self._current_objective: Optional[str] = None
+        self._is_open = False
+
+        if shared_serial is not None:
+            self._serial = shared_serial
+            self._owns_serial = False
+            _log.info("ASI turret reusing the Z stage's MS-2000 connection.")
+        else:
+            import squid.stage.utils
+
+            port = squid.stage.utils.resolve_port(
+                serial_port,
+                serial_number,
+                missing_hint="Verify the MS-2000 controller is powered and enumerates as a USB serial device.",
+                unset_message=(
+                    "Set ASI_OBJECTIVE_TURRET_SN/ASI_OBJECTIVE_TURRET_SERIAL_PORT (or the ASI_Z_* "
+                    "equivalents) to locate the MS-2000 controller."
+                ),
+            )
+            _log.info(f"ASI turret opening its own MS-2000 connection on {port} at {baudrate} baud.")
+            self._serial = MS2000Serial.open(port, baudrate=baudrate)
+            self._owns_serial = True
+
+        try:
+            # require_reply only when this is our own connection (then it doubles as the comms
+            # sanity check); on a shared connection the Z stage already proved the link.
+            self._current_slot = self._probe_slot(require_reply=self._owns_serial)
+        except Exception:
+            if self._owns_serial:
+                self._serial.close()  # no leaked handle on a failed bring-up
+            raise
+        self._is_open = True
+
+    # --- ObjectiveChangerProtocol ---------------------------------------------
+
+    def home(self, timeout_s: float = DEFAULT_MOVE_TIMEOUT_S) -> None:
+        """The ASI turret has no homing: refresh the tracked slot; NEVER moves."""
+        self._require_open()
+        self._current_objective = None
+        slot = self._probe_slot()
+        if slot is not None:
+            self._current_slot = slot
+        _log.info("ASI turret has no homing; home() refreshed the tracked slot without motion.")
+
+    def move_to_objective(
+        self, objective_name: str, timeout_s: float = DEFAULT_MOVE_TIMEOUT_S, restore_z: bool = True
+    ) -> None:
+        self._require_open()
+        target_slot = _resolve_position(objective_name, self._positions)
+        if self._current_slot == target_slot:
+            # Already at the slot (alias name, or the W-T-seeded position). An unknown slot
+            # (None) never equals an int, so uncertainty always rotates.
+            self._current_objective = objective_name
+            return
+        captured_z = self._retract_z_if_possible()
+        try:
+            self._rotate_to_slot(target_slot, timeout_s)
+            self._current_objective = objective_name
+        finally:
+            if restore_z:
+                self._restore_z_if_captured(captured_z)
+
+    def close(self) -> None:
+        if not self._is_open:
+            return
+        self._is_open = False
+        if self._owns_serial:
+            self._serial.close()
+        # A shared transport belongs to the Z stage and is released by stage.close().
+
+    def __enter__(self) -> "ASIObjectiveTurret":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()
+
+    # --- properties -------------------------------------------------------------
+
+    @property
+    def current_objective(self) -> Optional[str]:
+        return self._current_objective
+
+    @property
+    def current_slot(self) -> Optional[int]:
+        return self._current_slot
+
+    @property
+    def is_open(self) -> bool:
+        return self._is_open
+
+    @property
+    def owns_serial(self) -> bool:
+        return self._owns_serial
+
+    # --- internals ---------------------------------------------------------------
+
+    def _require_open(self) -> None:
+        if not self._is_open:
+            raise RuntimeError("ASI turret is closed")
+
+    def _probe_slot(self, require_reply: bool = False) -> Optional[int]:
+        """Best-effort 'W F' read. Returns the slot only for a plausible 1..N integer reply.
+
+        check_error=False: an ':N-...' ack still proves comms -- it just means 'W F' is
+        unsupported on this controller build, and we fall back to tracking the last
+        commanded slot.
+        """
+        reply = self._serial.command_with_settle_retry(f"W {self._axis}", check_error=False)
+        if require_reply and not reply:
+            # Our own connection: this probe doubles as the comms sanity check.
+            raise RuntimeError(
+                f"MS-2000 did not answer 'W {self._axis}'. Check the baud rate (ASI RS-232 "
+                f"DIP default is 9600), the port, and that the controller is powered."
+            )
+        _log.info(f"ASI turret 'W {self._axis}' reply: {reply!r}")
+        value = parse_ms2000_number(reply)
+        if value is not None and value == int(value) and 1 <= int(value) <= TURRET_SLOT_COUNT:
+            return int(value)
+        return None
+
+    def _rotate_to_slot(self, slot: int, timeout_s: float) -> None:
+        wt_was_supported = self._current_slot is not None
+        # RAW slot index -- turret positions are not scaled like linear-axis 0.1 um units.
+        self._serial.command(f"M {self._axis}={int(slot)}")
+        self._wait_idle(timeout_s)
+        self._current_slot = slot
+        if wt_was_supported:
+            # Verification only; tracked state stays authoritative.
+            with suppress(Exception):
+                readback = self._probe_slot()
+                if readback is not None and readback != slot:
+                    _log.warning(f"ASI turret readback disagrees: commanded slot {slot}, 'W' reports {readback}.")
+
+    def _wait_idle(self, timeout_s: float) -> None:
+        # '/' is controller-global: a concurrently moving Z also reads busy. Acceptable --
+        # objective changes and Z scans are not concurrent flows.
+        self._serial.wait_idle(timeout_s, "ASI turret")
+
+    def _retract_z_if_possible(self) -> Optional[float]:
+        return retract_z_if_possible(self._stage)
+
+    def _restore_z_if_captured(self, captured_z: Optional[float]) -> None:
+        restore_z_if_captured(self._stage, captured_z)
+
+
+class ASIObjectiveTurretSimulation:
+    """Hardware-free stand-in with the same public surface (SIMULATE_OBJECTIVE_CHANGER)."""
+
+    def __init__(
+        self,
+        positions: Optional[Dict[str, int]] = None,
+        stage: Optional[squid.abc.AbstractStage] = None,
+        axis: str = "F",
+    ):
+        self._positions = _validate_positions(positions)
+        self._axis = axis
+        self._stage = stage
+        self._current_objective: Optional[str] = None
+        self._current_slot: Optional[int] = None  # unknown until commanded, like power-on
+        self._is_open = True
+
+    def home(self, timeout_s: float = DEFAULT_MOVE_TIMEOUT_S) -> None:
+        self._require_open()
+        self._current_objective = None  # slot is retained: no homing, nothing moved
+
+    def move_to_objective(
+        self, objective_name: str, timeout_s: float = DEFAULT_MOVE_TIMEOUT_S, restore_z: bool = True
+    ) -> None:
+        self._require_open()
+        target_slot = _resolve_position(objective_name, self._positions)
+        if self._current_slot == target_slot:
+            self._current_objective = objective_name
+            return
+        captured_z = self._retract_z_if_possible()
+        try:
+            self._current_slot = target_slot
+            self._current_objective = objective_name
+        finally:
+            if restore_z:
+                self._restore_z_if_captured(captured_z)
+
+    def close(self) -> None:
+        self._is_open = False
+
+    def __enter__(self) -> "ASIObjectiveTurretSimulation":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()
+
+    @property
+    def current_objective(self) -> Optional[str]:
+        return self._current_objective
+
+    @property
+    def current_slot(self) -> Optional[int]:
+        return self._current_slot
+
+    @property
+    def is_open(self) -> bool:
+        return self._is_open
+
+    def _require_open(self) -> None:
+        if not self._is_open:
+            raise RuntimeError("ASI turret (simulated) is closed")
+
+    def _retract_z_if_possible(self) -> Optional[float]:
+        return retract_z_if_possible(self._stage)
+
+    def _restore_z_if_captured(self, captured_z: Optional[float]) -> None:
+        restore_z_if_captured(self._stage, captured_z)

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -85,6 +85,8 @@ else:
     import squid.stage.cephla
 if USE_PI_FOCUS_STAGE:
     import squid.stage.pi
+if USE_ASI_Z_STAGE:
+    import squid.stage.asi
 from control.piezo import PiezoStage
 
 if USE_XERYON:
@@ -774,10 +776,10 @@ class HighContentScreeningGui(QMainWindow):
                 self.stage.move_x_to(cached_pos.x_mm)
                 self.stage.move_y_to(cached_pos.y_mm)
 
-                if USE_PI_FOCUS_STAGE:
-                    # V-308: no Z_HOME_SAFETY_POINT floor; restore the cached absolute Z directly.
-                    # The PI driver clamps every move to the configured Z limits, so a stale
-                    # cached Z cannot command an out-of-range move.
+                if uses_external_z_stage():
+                    # External Z focus stage: no Z_HOME_SAFETY_POINT floor; restore the cached
+                    # absolute Z directly. The drivers clamp every move to the configured Z
+                    # limits, so a stale cached Z cannot command an out-of-range move.
                     self.stage.move_z_to(cached_pos.z_mm)
                 elif (int(Z_HOME_SAFETY_POINT) / 1000.0) < cached_pos.z_mm:
                     self.stage.move_z_to(cached_pos.z_mm)

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -2914,10 +2914,11 @@ class HighContentScreeningGui(QMainWindow):
                     else:
                         raise
 
-        # Turret close: always release the serial port so the new process (on restart)
-        # can acquire it, and so the motor is de-energized on full shutdown. Independent
-        # of Z-retract success — the close path must run even if Z retract failed.
-        if USE_OBJECTIVE_TURRET and self.objective_changer:
+        # Changer close: every ObjectiveChangerProtocol implementation provides close()
+        # (release serial ports for a restarted process, de-energize motors). Runs
+        # independent of Z-retract success. The ASI turret only closes a serial it
+        # opened itself; one shared with the Z stage is closed by stage.close().
+        if self.objective_changer:
             try:
                 self.objective_changer.close()
             except Exception:

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -85,8 +85,6 @@ else:
     import squid.stage.cephla
 if USE_PI_FOCUS_STAGE:
     import squid.stage.pi
-if USE_ASI_Z_STAGE:
-    import squid.stage.asi
 from control.piezo import PiezoStage
 
 if USE_XERYON:

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -30,6 +30,7 @@ import squid.filter_wheel_controller.utils
 import squid.logging
 import squid.stage.asi
 import squid.stage.cephla
+import squid.stage.composite
 import squid.stage.pi
 import squid.stage.utils
 
@@ -174,6 +175,32 @@ class MicroscopeAddons:
                 if not objective_changer_simulated
                 else ObjectiveTurret4PosControllerSimulation(**turret_kwargs)
             )
+        elif control._def.USE_ASI_OBJECTIVE_TURRET:
+            # Imported here (not at module level behind the flag) so tests can exercise this
+            # path by monkeypatching the flag alone.
+            from control.asi_objective_turret import ASIObjectiveTurret, ASIObjectiveTurretSimulation
+
+            if objective_changer_simulated:
+                objective_changer = ASIObjectiveTurretSimulation(
+                    positions=control._def.ASI_OBJECTIVE_TURRET_POSITIONS,
+                    stage=stage,
+                    axis=str(control._def.ASI_OBJECTIVE_TURRET_AXIS_LETTER),
+                )
+            else:
+                # Same MS-2000 controller as the LS50 Z stage when both are enabled: reuse its
+                # serial (the Z stage owns/closes it). None => turret-without-Z (or simulated
+                # Z): open our own connection, defaulting SN/port/baud to the ASI_Z_* values.
+                objective_changer = ASIObjectiveTurret(
+                    shared_serial=squid.stage.asi.find_shared_ms2000(stage),
+                    serial_number=_config_sn_to_str(control._def.ASI_OBJECTIVE_TURRET_SN)
+                    or _config_sn_to_str(control._def.ASI_Z_STAGE_SN),
+                    serial_port=(control._def.ASI_OBJECTIVE_TURRET_SERIAL_PORT or control._def.ASI_Z_SERIAL_PORT)
+                    or None,
+                    baudrate=int(control._def.ASI_OBJECTIVE_TURRET_BAUDRATE or control._def.ASI_Z_BAUDRATE),
+                    axis=str(control._def.ASI_OBJECTIVE_TURRET_AXIS_LETTER),
+                    positions=control._def.ASI_OBJECTIVE_TURRET_POSITIONS,
+                    stage=stage,
+                )
 
         camera_focus = None
         if control._def.SUPPORT_LASER_AUTOFOCUS:
@@ -381,7 +408,7 @@ class Microscope:
                 stage_config=stage_config,
             )
         if z_stage is not None:
-            stage = squid.stage.pi.CombinedStage(xy_stage=stage, z_stage=z_stage, stage_config=stage_config)
+            stage = squid.stage.composite.CombinedStage(xy_stage=stage, z_stage=z_stage, stage_config=stage_config)
 
         addons = MicroscopeAddons.build_from_global_config(
             stage, low_level_devices.microcontroller, simulated=simulated, skip_init=skip_init
@@ -591,7 +618,8 @@ class Microscope:
             # Xeryon always re-homes (findIndex is fast and required). The turret skips
             # homing on a software restart: the controller retains its position counter
             # across close()/re-init (the motor is de-energized but the drive stays
-            # powered), so a re-home would just be wasted motion.
+            # powered), so a re-home would just be wasted motion. The ASI turret has no
+            # homing at all: its home() only refreshes the tracked slot, never moves.
             if control._def.USE_XERYON or not skip_init:
                 self.addons.objective_changer.home()
             if control._def.USE_XERYON:

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -369,6 +369,7 @@ class Microscope:
                 serialnum=_config_sn_to_str(control._def.ASI_Z_STAGE_SN),
                 serial_port=control._def.ASI_Z_SERIAL_PORT or None,
                 baudrate=control._def.ASI_Z_BAUDRATE,
+                axis=str(control._def.ASI_Z_AXIS_LETTER),
                 # Separately configurable (not OBJECTIVE_RETRACTED_POS_MM): with no absolute
                 # reference, home retracts to the power-on end, native/squid 0 by convention.
                 home_mm=float(control._def.ASI_Z_HOME_MM),

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -28,6 +28,7 @@ import squid.camera.utils
 import squid.config
 import squid.filter_wheel_controller.utils
 import squid.logging
+import squid.stage.asi
 import squid.stage.cephla
 import squid.stage.pi
 import squid.stage.utils
@@ -332,6 +333,13 @@ class Microscope:
                 raise ValueError("For a cephla stage microscope, you must provide a microcontroller.")
             stage = CephlaStage(low_level_devices.microcontroller, stage_config)
 
+        if control._def.USE_PI_FOCUS_STAGE and control._def.USE_ASI_Z_STAGE:
+            # Also validated at machine-config load; this guard catches programmatic/test configs
+            # that would otherwise silently nest one CombinedStage inside the other.
+            raise ValueError(
+                "USE_PI_FOCUS_STAGE and USE_ASI_Z_STAGE are mutually exclusive; "
+                "the microscope has exactly one external Z focus stage."
+            )
         if control._def.USE_PI_FOCUS_STAGE:
             pi_simulated = _should_simulate(simulated, control._def.SIMULATE_PI_FOCUS_STAGE)
             # Normalise SN to a string (the config reader may coerce an all-digit serial to int);
@@ -350,6 +358,26 @@ class Microscope:
                 invert_z=control._def.PI_FOCUS_INVERT_Z,
                 home_to_positive_limit=control._def.PI_FOCUS_HOME_TO_POSITIVE_LIMIT,
                 z_travel_mm=control._def.PI_FOCUS_Z_TRAVEL_MM,
+                stage_config=stage_config,
+            )
+            stage = squid.stage.pi.CombinedStage(xy_stage=stage, z_stage=z_stage, stage_config=stage_config)
+        elif control._def.USE_ASI_Z_STAGE:
+            asi_simulated = _should_simulate(simulated, control._def.SIMULATE_ASI_Z_STAGE)
+            # Normalise SN to a string (the config reader may coerce an all-digit serial to int);
+            # treat only "" / None as "unset" so a numeric serial of 0 is not lost.
+            asi_sn = control._def.ASI_Z_STAGE_SN
+            asi_sn = str(asi_sn) if asi_sn not in (None, "") else None
+            z_stage = squid.stage.asi.connect_asi_z_stage(
+                simulated=asi_simulated,
+                serialnum=asi_sn,
+                serial_port=control._def.ASI_Z_SERIAL_PORT or None,
+                baudrate=control._def.ASI_Z_BAUDRATE,
+                # The LS50's retract position is native/squid 0 by definition (NOT
+                # OBJECTIVE_RETRACTED_POS_MM, which is an absolute-referenced-frame value).
+                home_mm=float(control._def.ASI_Z_HOME_MM),
+                invert_z=control._def.ASI_Z_INVERT,
+                home_on_startup=control._def.ASI_Z_HOME_ON_STARTUP and not skip_init,
+                z_travel_mm=control._def.ASI_Z_TRAVEL_MM,
                 stage_config=stage_config,
             )
             stage = squid.stage.pi.CombinedStage(xy_stage=stage, z_stage=z_stage, stage_config=stage_config)
@@ -893,21 +921,20 @@ class Microscope:
     def home_xyz(self) -> None:
         """Home the X, Y, and Z axes based on configuration settings.
 
-        Homes Z first if enabled, then (for a V-308 focus stage) ensures Z is referenced and
-        retracts it to the objective-clear end before moving XY, then performs a coordinated
-        X/Y homing sequence that avoids the plate clamp actuation post by moving Y first,
-        homing X, moving X clear, then homing Y.
+        Homes Z first if enabled, then (for an external Z focus stage) retracts Z to the
+        objective-clear end before moving XY, then performs a coordinated X/Y homing sequence
+        that avoids the plate clamp actuation post by moving Y first, homing X, moving X clear,
+        then homing Y.
         """
-        if control._def.HOMING_ENABLED_Z and not control._def.USE_PI_FOCUS_STAGE:
+        if control._def.HOMING_ENABLED_Z and not control._def.uses_external_z_stage():
             self.stage.home(x=False, y=False, z=True, theta=False)
 
-        # The V-308 voice coil has no self-locking, so before sweeping XY make sure the objective
-        # is clear: home(z) references-if-needed and drives Z to the retracted position
-        # (the positive travel limit when PI_FOCUS_HOME_TO_POSITIVE_LIMIT is set, e.g. an upright
-        # system; otherwise OBJECTIVE_RETRACTED_POS_MM). Gated on the PI stage so Cephla/Prior
-        # behaviour is unchanged.
-        if control._def.USE_PI_FOCUS_STAGE:
-            self._log.info("Homing Z (V-308) to the retracted position before XY homing.")
+        # Before sweeping XY, make sure the objective is clear: for an external Z focus stage
+        # home(z) drives Z to its retracted position (referencing first if the driver needs it --
+        # the V-308 voice coil has no self-locking, and the LS50 retracts to its native 0).
+        # Gated on the external stage so Cephla/Prior behaviour is unchanged.
+        if control._def.uses_external_z_stage():
+            self._log.info("Homing Z (external focus stage) to the retracted position before XY homing.")
             self.stage.home(x=False, y=False, z=True, theta=False)
 
         if control._def.HOMING_ENABLED_X and control._def.HOMING_ENABLED_Y:

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -72,6 +72,15 @@ else:
     NL5 = None
 
 
+def _config_sn_to_str(sn) -> Optional[str]:
+    """Normalise a config serial number to a string, or None when unset.
+
+    The config reader may coerce an all-digit serial to int; treat only "" / None as
+    "unset" so a numeric serial of 0 is not lost.
+    """
+    return str(sn) if sn not in (None, "") else None
+
+
 def _should_simulate(global_simulated: bool, component_override: bool) -> bool:
     """Determine if a component should be simulated.
 
@@ -333,22 +342,15 @@ class Microscope:
                 raise ValueError("For a cephla stage microscope, you must provide a microcontroller.")
             stage = CephlaStage(low_level_devices.microcontroller, stage_config)
 
-        if control._def.USE_PI_FOCUS_STAGE and control._def.USE_ASI_Z_STAGE:
-            # Also validated at machine-config load; this guard catches programmatic/test configs
-            # that would otherwise silently nest one CombinedStage inside the other.
-            raise ValueError(
-                "USE_PI_FOCUS_STAGE and USE_ASI_Z_STAGE are mutually exclusive; "
-                "the microscope has exactly one external Z focus stage."
-            )
+        # Also validated at machine-config load; re-checking here catches programmatic/test
+        # configs that would otherwise silently nest one CombinedStage inside the other.
+        control._def._validate_external_z_stage_flags(control._def.USE_PI_FOCUS_STAGE, control._def.USE_ASI_Z_STAGE)
+        z_stage = None
         if control._def.USE_PI_FOCUS_STAGE:
             pi_simulated = _should_simulate(simulated, control._def.SIMULATE_PI_FOCUS_STAGE)
-            # Normalise SN to a string (the config reader may coerce an all-digit serial to int);
-            # treat only "" / None as "unset" so a numeric serial of 0 is not lost.
-            pi_sn = control._def.PI_FOCUS_STAGE_SN
-            pi_sn = str(pi_sn) if pi_sn not in (None, "") else None
             z_stage = squid.stage.pi.connect_pi_focus_stage(
                 simulated=pi_simulated,
-                serialnum=pi_sn,
+                serialnum=_config_sn_to_str(control._def.PI_FOCUS_STAGE_SN),
                 serial_port=control._def.PI_FOCUS_SERIAL_PORT or None,
                 baudrate=control._def.PI_FOCUS_BAUDRATE,
                 axis=control._def.PI_FOCUS_AXIS,
@@ -360,26 +362,22 @@ class Microscope:
                 z_travel_mm=control._def.PI_FOCUS_Z_TRAVEL_MM,
                 stage_config=stage_config,
             )
-            stage = squid.stage.pi.CombinedStage(xy_stage=stage, z_stage=z_stage, stage_config=stage_config)
         elif control._def.USE_ASI_Z_STAGE:
             asi_simulated = _should_simulate(simulated, control._def.SIMULATE_ASI_Z_STAGE)
-            # Normalise SN to a string (the config reader may coerce an all-digit serial to int);
-            # treat only "" / None as "unset" so a numeric serial of 0 is not lost.
-            asi_sn = control._def.ASI_Z_STAGE_SN
-            asi_sn = str(asi_sn) if asi_sn not in (None, "") else None
             z_stage = squid.stage.asi.connect_asi_z_stage(
                 simulated=asi_simulated,
-                serialnum=asi_sn,
+                serialnum=_config_sn_to_str(control._def.ASI_Z_STAGE_SN),
                 serial_port=control._def.ASI_Z_SERIAL_PORT or None,
                 baudrate=control._def.ASI_Z_BAUDRATE,
-                # The LS50's retract position is native/squid 0 by definition (NOT
-                # OBJECTIVE_RETRACTED_POS_MM, which is an absolute-referenced-frame value).
+                # Separately configurable (not OBJECTIVE_RETRACTED_POS_MM): with no absolute
+                # reference, home retracts to the power-on end, native/squid 0 by convention.
                 home_mm=float(control._def.ASI_Z_HOME_MM),
                 invert_z=control._def.ASI_Z_INVERT,
                 home_on_startup=control._def.ASI_Z_HOME_ON_STARTUP and not skip_init,
                 z_travel_mm=control._def.ASI_Z_TRAVEL_MM,
                 stage_config=stage_config,
             )
+        if z_stage is not None:
             stage = squid.stage.pi.CombinedStage(xy_stage=stage, z_stage=z_stage, stage_config=stage_config)
 
         addons = MicroscopeAddons.build_from_global_config(

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -374,6 +374,7 @@ class Microscope:
                 # reference, home retracts to the power-on end, native/squid 0 by convention.
                 home_mm=float(control._def.ASI_Z_HOME_MM),
                 invert_z=control._def.ASI_Z_INVERT,
+                apply_software_limits=control._def.ASI_Z_APPLY_SOFTWARE_LIMITS,
                 home_on_startup=control._def.ASI_Z_HOME_ON_STARTUP and not skip_init,
                 z_travel_mm=control._def.ASI_Z_TRAVEL_MM,
                 stage_config=stage_config,

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -390,9 +390,8 @@ class Microscope:
                 stage_config=stage_config,
             )
         elif control._def.USE_ASI_Z_STAGE:
-            asi_simulated = _should_simulate(simulated, control._def.SIMULATE_ASI_Z_STAGE)
             z_stage = squid.stage.asi.connect_asi_z_stage(
-                simulated=asi_simulated,
+                simulated=simulated,
                 serialnum=_config_sn_to_str(control._def.ASI_Z_STAGE_SN),
                 serial_port=control._def.ASI_Z_SERIAL_PORT or None,
                 baudrate=control._def.ASI_Z_BAUDRATE,

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -370,14 +370,13 @@ class Microscope:
                 serial_port=control._def.ASI_Z_SERIAL_PORT or None,
                 baudrate=control._def.ASI_Z_BAUDRATE,
                 axis=str(control._def.ASI_Z_AXIS_LETTER),
-                # Separately configurable (not OBJECTIVE_RETRACTED_POS_MM): with no absolute
-                # reference, home retracts to the power-on end, native/squid 0 by convention.
+                # home retracts to squid 0, the find-zero-anchored away end (not
+                # OBJECTIVE_RETRACTED_POS_MM, which is a small offset above it).
                 home_mm=float(control._def.ASI_Z_HOME_MM),
                 invert_z=control._def.ASI_Z_INVERT,
                 apply_software_limits=control._def.ASI_Z_APPLY_SOFTWARE_LIMITS,
                 # Skip on in-place restart: the frame is already established, no surprise motion.
                 find_zero_on_startup=control._def.ASI_Z_FIND_ZERO_ON_STARTUP and not skip_init,
-                home_on_startup=control._def.ASI_Z_HOME_ON_STARTUP and not skip_init,
                 z_travel_mm=control._def.ASI_Z_TRAVEL_MM,
                 stage_config=stage_config,
             )

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -375,6 +375,8 @@ class Microscope:
                 home_mm=float(control._def.ASI_Z_HOME_MM),
                 invert_z=control._def.ASI_Z_INVERT,
                 apply_software_limits=control._def.ASI_Z_APPLY_SOFTWARE_LIMITS,
+                # Skip on in-place restart: the frame is already established, no surprise motion.
+                find_zero_on_startup=control._def.ASI_Z_FIND_ZERO_ON_STARTUP and not skip_init,
                 home_on_startup=control._def.ASI_Z_HOME_ON_STARTUP and not skip_init,
                 z_travel_mm=control._def.ASI_Z_TRAVEL_MM,
                 stage_config=stage_config,

--- a/software/control/objective_changer_2_pos_controller.py
+++ b/software/control/objective_changer_2_pos_controller.py
@@ -6,7 +6,10 @@ import serial
 from control.Xeryon import Xeryon, Stage
 from control._def import *  # to remove once we create ObjectiveChangerConfig
 import squid.abc
+import squid.logging
 from typing import Optional
+
+_log = squid.logging.get_logger(__name__)
 
 
 class ObjectiveChanger2PosController:
@@ -35,6 +38,15 @@ class ObjectiveChanger2PosController:
     def moveToZero(self):
         self.axisX.setDPOS(0)
         self.current_position = 0
+
+    def close(self):
+        # Xeryon.stop() sends STOP to the axis and shuts down the reader thread, which
+        # closes the serial port — required so a restarted process (spawned while this
+        # one is still alive) can re-acquire the device. Best-effort during teardown.
+        try:
+            self.controller.stop()
+        except Exception:
+            _log.exception("Error stopping the Xeryon controller during close()")
 
     def moveToPosition1(self, move_z=True):
         self.axisX.setDPOS(self.position1)
@@ -91,6 +103,9 @@ class ObjectiveChanger2PosController_Simulation:
         self.position2_offset = XERYON_OBJECTIVE_SWITCHER_POS_2_OFFSET_MM
 
     def home(self):
+        pass
+
+    def close(self):
         pass
 
     def moveToPosition1(self, move_z=True):

--- a/software/control/objective_turret_controller.py
+++ b/software/control/objective_turret_controller.py
@@ -118,6 +118,24 @@ _HOMING_PARAMS = [
 ]
 
 
+def retract_z_if_possible(stage) -> "Optional[float]":
+    """Shared objective-changer Z safety: if a stage with Z homing is usable, capture the
+    current Z and retract to OBJECTIVE_RETRACTED_POS_MM. Returns the captured Z, else None."""
+    from control._def import HOMING_ENABLED_Z, OBJECTIVE_RETRACTED_POS_MM
+
+    if stage is None or not HOMING_ENABLED_Z:
+        return None
+    z_mm = stage.get_pos().z_mm
+    stage.move_z_to(OBJECTIVE_RETRACTED_POS_MM)
+    return z_mm
+
+
+def restore_z_if_captured(stage, captured_z) -> None:
+    if captured_z is None or stage is None:
+        return
+    stage.move_z_to(captured_z)
+
+
 def _resolve_position(objective_name: str, positions: dict) -> int:
     try:
         return positions[objective_name]
@@ -228,19 +246,10 @@ class ObjectiveTurret4PosControllerSimulation:
             raise RuntimeError("Turret controller is closed")
 
     def _retract_z_if_possible(self) -> Optional[float]:
-        """If stage + Z homing are usable, capture Z and move to safe retract. Return captured z, else None."""
-        from control._def import HOMING_ENABLED_Z, OBJECTIVE_RETRACTED_POS_MM
-
-        if self._stage is None or not HOMING_ENABLED_Z:
-            return None
-        z_mm = self._stage.get_pos().z_mm
-        self._stage.move_z_to(OBJECTIVE_RETRACTED_POS_MM)
-        return z_mm
+        return retract_z_if_possible(self._stage)
 
     def _restore_z_if_captured(self, captured_z: Optional[float]) -> None:
-        if captured_z is None or self._stage is None:
-            return
-        self._stage.move_z_to(captured_z)
+        restore_z_if_captured(self._stage, captured_z)
 
 
 class ObjectiveTurret4PosController:
@@ -415,18 +424,10 @@ class ObjectiveTurret4PosController:
         )
 
     def _retract_z_if_possible(self) -> Optional[float]:
-        from control._def import HOMING_ENABLED_Z, OBJECTIVE_RETRACTED_POS_MM
-
-        if self._stage is None or not HOMING_ENABLED_Z:
-            return None
-        z_mm = self._stage.get_pos().z_mm
-        self._stage.move_z_to(OBJECTIVE_RETRACTED_POS_MM)
-        return z_mm
+        return retract_z_if_possible(self._stage)
 
     def _restore_z_if_captured(self, captured_z: Optional[float]) -> None:
-        if captured_z is None or self._stage is None:
-            return
-        self._stage.move_z_to(captured_z)
+        restore_z_if_captured(self._stage, captured_z)
 
     def _calibrate_one(
         self,

--- a/software/squid/stage/asi.py
+++ b/software/squid/stage/asi.py
@@ -34,6 +34,8 @@ _log = squid.logging.get_logger(__name__)
 
 STEPS_PER_MM = 10000  # ASI native unit = 0.1 um; also the finest addressable step (z_mm_to_usteps grid)
 _DEFAULT_MOVE_TIMEOUT_S = 30.0
+# Full-travel drive into the limit switch; sized for the slowest plausible traverse speed.
+_FIND_ZERO_TIMEOUT_S = 60.0
 _STATUS_POLL_PERIOD_S = 0.05
 
 
@@ -135,7 +137,7 @@ class _SimulatedLS50:
         self._pos_mm = 0.0
         self._zero_count += 1
 
-    def zero_at_away_limit(self, overdrive_mm: float, timeout: float = 60.0):
+    def zero_at_away_limit(self, overdrive_mm: float, timeout: float = _FIND_ZERO_TIMEOUT_S):
         # Drive past full travel toward the away end; the (simulated) limit switch stops
         # the stage; define native 0 there.
         self.move_relative(abs(float(overdrive_mm)), wait=True)
@@ -204,17 +206,19 @@ class LS50Controller:
         power cycle" (SETLOW manual), so a fence left by ANY previous session persists and
         silently clamps moves -- including the find-zero overdrive -- until overwritten.
         Uses the restore-defaults dash form ("SL Z-"), which also sidesteps the manual's
-        direction-dependent sign semantics for numeric limits; firmware too old for the
-        dash form (pre-~2013) error-acks it and gets a wide numeric window instead.
+        direction-dependent sign semantics for numeric limits. No numeric fallback: only
+        the controller knows its own defaults, so firmware without the dash form
+        (pre-~2013) fails loudly instead of getting an invented window.
         """
-        for dash, numeric in (
-            (f"SL {self._axis}-", f"SL {self._axis}=-1000"),
-            (f"SU {self._axis}-", f"SU {self._axis}=1000"),
-        ):
+        for cmd in (f"SL {self._axis}-", f"SU {self._axis}-"):
             try:
-                self._serial.command(dash)
-            except RuntimeError:
-                self._serial.command(numeric)
+                self._serial.command(cmd)
+            except RuntimeError as e:
+                raise RuntimeError(
+                    f"The controller rejected the restore-defaults limit command {cmd!r} "
+                    f"({e}). This firmware may predate the dash form (~2013); clear the "
+                    f"SL/SU limits manually (e.g. with ASI's tools) or update the firmware."
+                ) from e
         self._range_lo = self._range_hi = None
 
     def get_position_mm(self) -> float:
@@ -268,7 +272,7 @@ class LS50Controller:
         # Redefine the current position as native 0 (shifts the whole frame).
         self._serial.command(f"H {self._axis}=0")
 
-    def zero_at_away_limit(self, overdrive_mm: float, timeout: float = 60.0) -> None:
+    def zero_at_away_limit(self, overdrive_mm: float, timeout: float = _FIND_ZERO_TIMEOUT_S) -> None:
         """Establish the frame: drive PAST full travel toward the away-from-sample end
         (native +; the limit switch stops the stage safely), then define native 0 there.
 
@@ -487,6 +491,11 @@ def connect_asi_z_stage(
         backend = LS50Controller(axis=axis)
         _log.info(f"Connecting to the ASI Z stage on {port} at {baudrate} baud (axis {axis!r}).")
 
+    if find_zero_on_startup and not z_travel_mm:
+        # The overdrive distance is derived from the stage's physical travel; only the
+        # user knows that, so there is no default to invent.
+        raise ValueError("find_zero_on_startup requires the physical travel (ASI_Z_TRAVEL_MM) to be set.")
+
     try:
         backend.connect_serial(port, baudrate=baudrate)
         backend.initialize()
@@ -496,8 +505,9 @@ def connect_asi_z_stage(
         if find_zero_on_startup:
             # Anchor the frame: drive to the away-from-sample limit switch and define
             # native 0 there, so squid 0 is the true retracted end, never a random
-            # power-on position. Motion is in the safe (away) direction only.
-            backend.zero_at_away_limit(overdrive_mm=(z_travel_mm or 50.0) * 1.2)
+            # power-on position. Motion is in the safe (away) direction only. The 1.2
+            # margin guarantees reaching the switch from any position within travel.
+            backend.zero_at_away_limit(overdrive_mm=z_travel_mm * 1.2)
         if z_travel_mm:
             backend.set_travel_limits(-z_travel_mm, z_travel_mm)
     except Exception:

--- a/software/squid/stage/asi.py
+++ b/software/squid/stage/asi.py
@@ -198,14 +198,23 @@ class LS50Controller:
         self._range_lo, self._range_hi = float(min_mm), float(max_mm)
 
     def clear_travel_limits(self) -> None:
-        """Overwrite any controller-side SL/SU left by a previous session with a wide window.
+        """Restore the controller's factory-default travel limits, wiping stale SL/SU.
 
-        Stale soft limits persist in the controller across software restarts (and across
-        power cycles if they were ever saved); they would silently clamp moves -- including
-        the find-zero overdrive -- so startup clears them before anything else.
+        On the MS-2000, SL/SU limits are "automatically remembered and recalled through a
+        power cycle" (SETLOW manual), so a fence left by ANY previous session persists and
+        silently clamps moves -- including the find-zero overdrive -- until overwritten.
+        Uses the restore-defaults dash form ("SL Z-"), which also sidesteps the manual's
+        direction-dependent sign semantics for numeric limits; firmware too old for the
+        dash form (pre-~2013) error-acks it and gets a wide numeric window instead.
         """
-        self._serial.command(f"SL {self._axis}=-1000")
-        self._serial.command(f"SU {self._axis}=1000")
+        for dash, numeric in (
+            (f"SL {self._axis}-", f"SL {self._axis}=-1000"),
+            (f"SU {self._axis}-", f"SU {self._axis}=1000"),
+        ):
+            try:
+                self._serial.command(dash)
+            except RuntimeError:
+                self._serial.command(numeric)
         self._range_lo = self._range_hi = None
 
     def get_position_mm(self) -> float:

--- a/software/squid/stage/asi.py
+++ b/software/squid/stage/asi.py
@@ -278,6 +278,7 @@ class ASIZStage(AbstractStage):
 
         self._invert = invert_z
         self._home_mm = home_mm  # Squid-frame retract target; None = home(z) disabled
+        self._last_z_mm = 0.0  # last Squid-frame Z, served to pollers after close()
 
     def _flip(self, mm: float) -> float:
         # squid_z = -native_z (and vice versa) when inverted; identity otherwise.
@@ -285,22 +286,32 @@ class ASIZStage(AbstractStage):
 
     def move_z(self, rel_mm: float, blocking: bool = True):
         with self._lock:
-            self._backend.move_relative(self._flip(rel_mm), wait=blocking)
+            if self._closed:
+                self._log.warning("move_z ignored: the ASI Z stage is closed.")
+                return
+            self._last_z_mm = self._flip(self._backend.move_relative(self._flip(rel_mm), wait=blocking))
 
     def move_z_to(self, abs_mm: float, blocking: bool = True):
         with self._lock:
-            self._backend.move_to(self._flip(abs_mm), wait=blocking)
+            if self._closed:
+                self._log.warning("move_z_to ignored: the ASI Z stage is closed.")
+                return
+            self._last_z_mm = self._flip(self._backend.move_to(self._flip(abs_mm), wait=blocking))
 
     def get_pos(self) -> Pos:
+        # GUI pollers can fire after shutdown closes the port; serve the last-known Z then
+        # instead of touching the dead serial handle.
         with self._lock:
-            return Pos(x_mm=0.0, y_mm=0.0, z_mm=self._flip(self._backend.get_position_mm()), theta_rad=None)
+            if not self._closed:
+                self._last_z_mm = self._flip(self._backend.get_position_mm())
+            return Pos(x_mm=0.0, y_mm=0.0, z_mm=self._last_z_mm, theta_rad=None)
 
     def get_state(self) -> StageStage:
         # If an async home holds the lock, report busy without blocking on it.
         if self._busy:
             return StageStage(busy=True)
         with self._lock:
-            return StageStage(busy=self._backend.is_moving())
+            return StageStage(busy=False if self._closed else self._backend.is_moving())
 
     def is_referenced(self) -> bool:
         return True  # no referencing concept; the power-on frame is always valid

--- a/software/squid/stage/asi.py
+++ b/software/squid/stage/asi.py
@@ -53,7 +53,9 @@ class MS2000Serial:
     def open(cls, port: str, baudrate: int = 115200, timeout_s: float = 0.5) -> "MS2000Serial":
         import serial  # lazy: real-hardware path only
 
-        return cls(serial.Serial(port, baudrate=baudrate, timeout=timeout_s))
+        conn = serial.Serial(port, baudrate=baudrate, timeout=timeout_s)
+        conn.reset_input_buffer()  # drop any boot banner / stale bytes so the first reply parses
+        return cls(conn)
 
     def command(self, cmd: str, check_error: bool = True) -> str:
         """Send one command and return the stripped reply line.
@@ -135,7 +137,10 @@ class LS50Controller:
     writes no controller parameters.
     """
 
-    def __init__(self):
+    def __init__(self, axis: str = "Z"):
+        # Single-axis MS-2000 builds may label their lone axis X (or other) -- configurable
+        # via ASI_Z_AXIS_LETTER.
+        self._axis = axis
         self._serial: Optional[MS2000Serial] = None
         # Cached fence [lo, hi] in native mm so moves can clamp without a query each move;
         # None until set_travel_limits is called (limits are unknown at power-on).
@@ -147,19 +152,28 @@ class LS50Controller:
 
     def initialize(self) -> None:
         # Comms sanity only: prove the controller answers. NO motion, NO parameter writes.
-        self.get_position_mm()
+        try:
+            self.get_position_mm()
+        except RuntimeError as e:
+            raise RuntimeError(
+                f"LS50 controller did not answer a position query ({e}). Check the baud rate "
+                f"(ASI controllers often ship at 9600; Squid defaults to 115200 -- set "
+                f"ASI_Z_BAUDRATE in the machine config), that the resolved port really is the "
+                f"ASI controller, and that it is powered. "
+                f"`python3 tools/asi_z_bringup.py --sn <SN> --scan-bauds` can diagnose this."
+            ) from e
 
     def hardware_limits_mm(self) -> Tuple[Optional[float], Optional[float]]:
         return (self._range_lo, self._range_hi)
 
     def set_travel_limits(self, min_mm: float, max_mm: float) -> None:
         # SL (lower) / SU (upper) take mm, unlike M/R/W which take tenths of microns.
-        self._serial.command(f"SL Z={float(min_mm):.4f}")
-        self._serial.command(f"SU Z={float(max_mm):.4f}")
+        self._serial.command(f"SL {self._axis}={float(min_mm):.4f}")
+        self._serial.command(f"SU {self._axis}={float(max_mm):.4f}")
         self._range_lo, self._range_hi = float(min_mm), float(max_mm)
 
     def get_position_mm(self) -> float:
-        reply = self._serial.command("W Z")  # ':A -12345' or bare '-12345', in 0.1 um
+        reply = self._serial.command(f"W {self._axis}")  # ':A -12345' or bare '-12345', in 0.1 um
         match = re.search(r"-?\d+(?:\.\d+)?", reply.replace(":A", "", 1))
         if not match:
             raise RuntimeError(f"Could not parse LS50 position from reply {reply!r}")
@@ -186,7 +200,7 @@ class LS50Controller:
 
     def move_to(self, z_mm: float, wait: bool = True, timeout: float = _DEFAULT_MOVE_TIMEOUT_S) -> float:
         target = self._clamp_target(float(z_mm))
-        self._serial.command(f"M Z={round(target * STEPS_PER_MM)}")
+        self._serial.command(f"M {self._axis}={round(target * STEPS_PER_MM)}")
         if wait:
             self._wait_idle(timeout)
             return self.get_position_mm()
@@ -208,7 +222,7 @@ class LS50Controller:
     def zero_here(self) -> None:
         # Redefine the current position as native 0. Deliberately NOT wired to
         # AbstractStage.zero() -- see ASIZStage.zero().
-        self._serial.command("H Z=0")
+        self._serial.command(f"H {self._axis}=0")
 
     def stop(self) -> None:
         # HALT; the MS-2000 acks it with ':N-21', which is expected, not an error.
@@ -365,6 +379,7 @@ def connect_asi_z_stage(
     serialnum: Optional[str] = None,
     serial_port: Optional[str] = None,
     baudrate: int = 115200,
+    axis: str = "Z",
     home_mm: Optional[float] = None,
     invert_z: bool = False,
     home_on_startup: bool = False,
@@ -395,7 +410,7 @@ def connect_asi_z_stage(
             )
         else:
             raise RuntimeError("Set ASI_Z_STAGE_SN or ASI_Z_SERIAL_PORT to locate the LS50 controller.")
-        backend = LS50Controller()
+        backend = LS50Controller(axis=axis)
 
     try:
         backend.connect_serial(port, baudrate=baudrate)

--- a/software/squid/stage/asi.py
+++ b/software/squid/stage/asi.py
@@ -32,10 +32,7 @@ from squid.config import StageConfig
 
 _log = squid.logging.get_logger(__name__)
 
-STEPS_PER_MM = 10000  # ASI native unit = 0.1 um
-# The protocol grid is the finest addressable step; the GUI's ustep-based Z step snapping uses
-# this via z_mm_to_usteps (0.1 um is sub-slice for any real Z stack).
-_Z_RESOLUTION_MM = 1e-4
+STEPS_PER_MM = 10000  # ASI native unit = 0.1 um; also the finest addressable step (z_mm_to_usteps grid)
 _DEFAULT_MOVE_TIMEOUT_S = 30.0
 _STATUS_POLL_PERIOD_S = 0.05
 
@@ -91,16 +88,12 @@ class _SimulatedLS50:
         self._hi_mm: Optional[float] = None
         self._closed = False
         self._zero_count = 0
-        self._halt_count = 0
 
     def connect_serial(self, *args, **kwargs):
         pass
 
     def initialize(self):
         pass
-
-    def is_referenced(self) -> bool:
-        return True  # nothing to reference; position is always valid in the power-on frame
 
     def hardware_limits_mm(self) -> Tuple[Optional[float], Optional[float]]:
         return (self._lo_mm, self._hi_mm)
@@ -130,9 +123,6 @@ class _SimulatedLS50:
         self._pos_mm = 0.0
         self._zero_count += 1
 
-    def stop(self):
-        self._halt_count += 1
-
     def close(self):
         self._closed = True
 
@@ -158,9 +148,6 @@ class LS50Controller:
     def initialize(self) -> None:
         # Comms sanity only: prove the controller answers. NO motion, NO parameter writes.
         self.get_position_mm()
-
-    def is_referenced(self) -> bool:
-        return True  # nothing to reference; position is always valid in the power-on frame
 
     def hardware_limits_mm(self) -> Tuple[Optional[float], Optional[float]]:
         return (self._range_lo, self._range_hi)
@@ -267,8 +254,7 @@ class ASIZStage(AbstractStage):
         self._busy = False  # set while an async home holds the lock, so get_state needn't block
 
         self._invert = invert_z
-        # NATIVE home target (the flip is an involution, so it maps squid -> native too).
-        self._home_native_mm = self._flip(home_mm) if home_mm is not None else None
+        self._home_mm = home_mm  # Squid-frame retract target; None = home(z) disabled
 
     def _flip(self, mm: float) -> float:
         # squid_z = -native_z (and vice versa) when inverted; identity otherwise.
@@ -294,15 +280,14 @@ class ASIZStage(AbstractStage):
             return StageStage(busy=self._backend.is_moving())
 
     def is_referenced(self) -> bool:
-        with self._lock:
-            return self._backend.is_referenced()
+        return True  # no referencing concept; the power-on frame is always valid
 
     def home(self, x: bool, y: bool, z: bool, theta: bool, blocking: bool = True):
         # Home = retract to the configured target (native 0 by convention). There is no
         # hardware referencing routine on this stage.
         if not z:
             return
-        if self._home_native_mm is None:
+        if self._home_mm is None:
             self._log.warning("ASIZStage home(z=True) is a no-op: no home target configured (ASI_Z_HOME_MM).")
             return
         if blocking:
@@ -316,7 +301,7 @@ class ASIZStage(AbstractStage):
             with self._lock:
                 if self._closed:  # close() won the race; do not touch the torn-down handle
                     return
-                self._backend.move_to(self._home_native_mm, wait=True)
+                self._backend.move_to(self._flip(self._home_mm), wait=True)
         finally:
             self._busy = False
 
@@ -357,7 +342,7 @@ class ASIZStage(AbstractStage):
     def z_mm_to_usteps(self, mm: float) -> int:
         # The 0.1 um protocol grid is the finest addressable step; the GUI's Z step snapping
         # uses 1 / z_mm_to_usteps(1.0). Rounds to an integer like the stepper conversion.
-        return round(mm / _Z_RESOLUTION_MM)
+        return round(mm * STEPS_PER_MM)
 
     def move_x(self, rel_mm: float, blocking: bool = True):
         self._no_xy("move_x")
@@ -394,11 +379,7 @@ def connect_asi_z_stage(
     targets; the real fence arrives via set_limits from StageConfig.Z_AXIS at microscope init.
     """
     if simulated:
-        backend = _SimulatedLS50()
-        backend.initialize()
-        if z_travel_mm:
-            backend.set_travel_limits(-z_travel_mm, z_travel_mm)
-        stage = ASIZStage(backend, stage_config=stage_config, home_mm=home_mm, invert_z=invert_z)
+        backend, port = _SimulatedLS50(), None
     else:
         # Resolve the port BEFORE opening anything, so a missing controller never leaks a handle.
         if serial_port:
@@ -409,23 +390,22 @@ def connect_asi_z_stage(
             port = squid.stage.utils.resolve_serial_port_by_sn(
                 serialnum,
                 missing_hint=(
-                    "Verify the LS50 controller is powered and enumerates as a USB serial "
-                    "device (lsusb / dmesg)."
+                    "Verify the LS50 controller is powered and enumerates as a USB serial " "device (lsusb / dmesg)."
                 ),
             )
         else:
             raise RuntimeError("Set ASI_Z_STAGE_SN or ASI_Z_SERIAL_PORT to locate the LS50 controller.")
-
         backend = LS50Controller()
-        try:
-            backend.connect_serial(port, baudrate=baudrate)
-            backend.initialize()
-            if z_travel_mm:
-                backend.set_travel_limits(-z_travel_mm, z_travel_mm)
-        except Exception:
-            backend.close()  # release the serial handle on any connect/init failure
-            raise
-        stage = ASIZStage(backend, stage_config=stage_config, home_mm=home_mm, invert_z=invert_z)
+
+    try:
+        backend.connect_serial(port, baudrate=baudrate)
+        backend.initialize()
+        if z_travel_mm:
+            backend.set_travel_limits(-z_travel_mm, z_travel_mm)
+    except Exception:
+        backend.close()  # release the serial handle on any connect/init failure
+        raise
+    stage = ASIZStage(backend, stage_config=stage_config, home_mm=home_mm, invert_z=invert_z)
 
     if home_on_startup:
         if home_mm is None:

--- a/software/squid/stage/asi.py
+++ b/software/squid/stage/asi.py
@@ -152,7 +152,16 @@ class LS50Controller:
 
     def initialize(self) -> None:
         # Comms sanity only: prove the controller answers. NO motion, NO parameter writes.
+        # One retry after a settle+flush: a marginal RS-232 link or a just-opened adapter can
+        # drop/garble the very first exchange without being actually broken.
         try:
+            try:
+                self.get_position_mm()
+                return
+            except RuntimeError:
+                time.sleep(0.2)
+                with suppress(Exception):
+                    self._serial._serial.reset_input_buffer()
             self.get_position_mm()
         except RuntimeError as e:
             raise RuntimeError(
@@ -411,6 +420,7 @@ def connect_asi_z_stage(
         else:
             raise RuntimeError("Set ASI_Z_STAGE_SN or ASI_Z_SERIAL_PORT to locate the LS50 controller.")
         backend = LS50Controller(axis=axis)
+        _log.info(f"Connecting to the ASI Z stage on {port} at {baudrate} baud (axis {axis!r}).")
 
     try:
         backend.connect_serial(port, baudrate=baudrate)

--- a/software/squid/stage/asi.py
+++ b/software/squid/stage/asi.py
@@ -137,6 +137,107 @@ class _SimulatedLS50:
         self._closed = True
 
 
+class LS50Controller:
+    """ASI LS50 Z linear stage on an MS-2000-family controller (CR text protocol, 1/10 um units).
+
+    Native 0 is the power-on position (the retracted end by convention); native negative is
+    toward the sample. There is no referencing routine, and bring-up performs no motion and
+    writes no controller parameters.
+    """
+
+    def __init__(self):
+        self._serial: Optional[MS2000Serial] = None
+        # Cached fence [lo, hi] in native mm so moves can clamp without a query each move;
+        # None until set_travel_limits is called (limits are unknown at power-on).
+        self._range_lo: Optional[float] = None
+        self._range_hi: Optional[float] = None
+
+    def connect_serial(self, comport: str, baudrate: int = 115200) -> None:
+        self._serial = MS2000Serial.open(comport, baudrate=baudrate)
+
+    def initialize(self) -> None:
+        # Comms sanity only: prove the controller answers. NO motion, NO parameter writes.
+        self.get_position_mm()
+
+    def is_referenced(self) -> bool:
+        return True  # nothing to reference; position is always valid in the power-on frame
+
+    def hardware_limits_mm(self) -> Tuple[Optional[float], Optional[float]]:
+        return (self._range_lo, self._range_hi)
+
+    def set_travel_limits(self, min_mm: float, max_mm: float) -> None:
+        # SL (lower) / SU (upper) take mm, unlike M/R/W which take tenths of microns.
+        self._serial.command(f"SL Z={float(min_mm):.4f}")
+        self._serial.command(f"SU Z={float(max_mm):.4f}")
+        self._range_lo, self._range_hi = float(min_mm), float(max_mm)
+
+    def get_position_mm(self) -> float:
+        reply = self._serial.command("W Z")  # ':A -12345' or bare '-12345', in 0.1 um
+        match = re.search(r"-?\d+(?:\.\d+)?", reply.replace(":A", "", 1))
+        if not match:
+            raise RuntimeError(f"Could not parse LS50 position from reply {reply!r}")
+        return float(match.group(0)) / STEPS_PER_MM
+
+    def is_moving(self) -> bool:
+        return "B" in self._serial.command("/").upper()
+
+    def _clamp_target(self, z_mm: float) -> float:
+        """Clamp an absolute native target to the fence; pass through while unfenced."""
+        lo, hi = self._range_lo, self._range_hi
+        if lo is None:
+            return z_mm
+        clamped = min(max(z_mm, lo), hi)
+        if abs(clamped - z_mm) > 1e-9:
+            _log.warning(
+                "LS50 Z target %.5f mm is outside the travel fence [%.5f, %.5f]; clamped to %.5f mm.",
+                z_mm,
+                lo,
+                hi,
+                clamped,
+            )
+        return clamped
+
+    def move_to(self, z_mm: float, wait: bool = True, timeout: float = _DEFAULT_MOVE_TIMEOUT_S) -> float:
+        target = self._clamp_target(float(z_mm))
+        self._serial.command(f"M Z={round(target * STEPS_PER_MM)}")
+        if wait:
+            self._wait_idle(timeout)
+            return self.get_position_mm()
+        return target
+
+    def move_relative(self, dz_mm: float, wait: bool = True, timeout: float = _DEFAULT_MOVE_TIMEOUT_S) -> float:
+        # Resolve to an absolute target (M) rather than sending R Z=, so a jog past the fence
+        # clamps instead of erroring or overdriving.
+        return self.move_to(self.get_position_mm() + float(dz_mm), wait=wait, timeout=timeout)
+
+    def _wait_idle(self, timeout_s: float) -> None:
+        # '/' polling is the only settle signal (there is no on-target query in this command set).
+        deadline = time.monotonic() + timeout_s
+        while self.is_moving():
+            if time.monotonic() > deadline:
+                raise RuntimeError(f"LS50 did not reach idle within {timeout_s:.1f}s")
+            time.sleep(_STATUS_POLL_PERIOD_S)
+
+    def zero_here(self) -> None:
+        # Redefine the current position as native 0. Deliberately NOT wired to
+        # AbstractStage.zero() -- see ASIZStage.zero().
+        self._serial.command("H Z=0")
+
+    def stop(self) -> None:
+        # HALT; the MS-2000 acks it with ':N-21', which is expected, not an error.
+        self._serial.command("\\", check_error=False)
+
+    def close(self) -> None:
+        if self._serial:
+            self._serial.close()
+
+    def __enter__(self) -> "LS50Controller":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()
+
+
 class ASIZStage(AbstractStage):
     """Z-only AbstractStage backed by an ASI LS50. X / Y / theta are no-ops.
 
@@ -272,3 +373,63 @@ class ASIZStage(AbstractStage):
 
     def _no_xy(self, name: str):
         self._log.warning(f"{name} ignored: ASIZStage is a Z-only stage (pair via CombinedStage).")
+
+
+def connect_asi_z_stage(
+    simulated: bool = False,
+    serialnum: Optional[str] = None,
+    serial_port: Optional[str] = None,
+    baudrate: int = 115200,
+    home_mm: Optional[float] = None,
+    invert_z: bool = False,
+    home_on_startup: bool = False,
+    z_travel_mm: float = 0.0,
+    stage_config: Optional[StageConfig] = None,
+) -> ASIZStage:
+    """Open the LS50 controller over serial (or a simulated backend) and wrap it as an ASIZStage.
+
+    Bring-up performs NO motion unless home_on_startup=True (which requires home_mm and does one
+    blocking retract). z_travel_mm > 0 sets a coarse sanity fence of native [-travel, +travel]
+    around the power-on zero -- it can never exclude a reachable position, but stops absurd
+    targets; the real fence arrives via set_limits from StageConfig.Z_AXIS at microscope init.
+    """
+    if simulated:
+        backend = _SimulatedLS50()
+        backend.initialize()
+        if z_travel_mm:
+            backend.set_travel_limits(-z_travel_mm, z_travel_mm)
+        stage = ASIZStage(backend, stage_config=stage_config, home_mm=home_mm, invert_z=invert_z)
+    else:
+        # Resolve the port BEFORE opening anything, so a missing controller never leaks a handle.
+        if serial_port:
+            port = serial_port
+        elif serialnum:
+            import squid.stage.utils
+
+            port = squid.stage.utils.resolve_serial_port_by_sn(
+                serialnum,
+                missing_hint=(
+                    "Verify the LS50 controller is powered and enumerates as a USB serial "
+                    "device (lsusb / dmesg)."
+                ),
+            )
+        else:
+            raise RuntimeError("Set ASI_Z_STAGE_SN or ASI_Z_SERIAL_PORT to locate the LS50 controller.")
+
+        backend = LS50Controller()
+        try:
+            backend.connect_serial(port, baudrate=baudrate)
+            backend.initialize()
+            if z_travel_mm:
+                backend.set_travel_limits(-z_travel_mm, z_travel_mm)
+        except Exception:
+            backend.close()  # release the serial handle on any connect/init failure
+            raise
+        stage = ASIZStage(backend, stage_config=stage_config, home_mm=home_mm, invert_z=invert_z)
+
+    if home_on_startup:
+        if home_mm is None:
+            _log.warning("ASI_Z_HOME_ON_STARTUP is set but no home target is configured; skipping the retract.")
+        else:
+            stage.home(False, False, True, False, blocking=True)
+    return stage

--- a/software/squid/stage/asi.py
+++ b/software/squid/stage/asi.py
@@ -5,7 +5,7 @@ Squid stage support for the ASI LS50 Z-only linear stage on its own MS-2000-fami
 Provides (1) ``MS2000Serial``, the CR-terminated ASI command transport; (2) ``LS50Controller``,
 the single-axis driver; (3) ``_SimulatedLS50``, a pure-Python stand-in for hardware-free / CI
 use; and (4) ``ASIZStage``, the Z-only ``squid.abc.AbstractStage`` adapter (pair with an XY
-stage via ``squid.stage.pi.CombinedStage``).
+stage via ``squid.stage.composite.CombinedStage``).
 
 Frame and units: the controller's native unit is 1/10 um (10000 per mm). Native positive is
 away from the sample; the value goes negative as the stage approaches the sample. With
@@ -209,6 +209,11 @@ class LS50Controller:
         self._range_lo: Optional[float] = None
         self._range_hi: Optional[float] = None
 
+    @property
+    def serial(self) -> Optional[MS2000Serial]:
+        """The MS-2000 transport (public: shared with same-controller addons, e.g. the turret)."""
+        return self._serial
+
     def connect_serial(self, comport: str, baudrate: int = 115200) -> None:
         self._serial = MS2000Serial.open(comport, baudrate=baudrate)
 
@@ -362,6 +367,11 @@ class ASIZStage(AbstractStage):
         self._home_mm = home_mm  # Squid-frame retract target; None = home(z) disabled
         self._last_z_mm = 0.0  # last Squid-frame Z, served to pollers after close()
 
+    @property
+    def ms2000_serial(self) -> Optional[MS2000Serial]:
+        # getattr: _SimulatedLS50 has no `serial` property -> None (simulation-aware).
+        return getattr(self._backend, "serial", None)
+
     def _flip(self, mm: float) -> float:
         # squid_z = -native_z (and vice versa) when inverted; identity otherwise.
         return -mm if self._invert else mm
@@ -476,6 +486,22 @@ class ASIZStage(AbstractStage):
 
     def _no_xy(self, name: str):
         self._log.warning(f"{name} ignored: ASIZStage is a Z-only stage (pair via CombinedStage).")
+
+
+def find_shared_ms2000(stage) -> Optional[MS2000Serial]:
+    """Return the MS2000Serial of an ASI Z stage embedded in ``stage``, else None.
+
+    Accepts an ASIZStage directly or a CombinedStage wrapping one. Returns None for
+    simulated backends and non-ASI stages. Ownership stays with the Z stage: callers must
+    NOT close the returned transport -- it is released by stage.close().
+    """
+    from squid.stage.composite import CombinedStage  # here to keep module import light
+
+    if isinstance(stage, CombinedStage):
+        stage = stage.z_stage
+    if isinstance(stage, ASIZStage):
+        return stage.ms2000_serial
+    return None
 
 
 def connect_asi_z_stage(

--- a/software/squid/stage/asi.py
+++ b/software/squid/stage/asi.py
@@ -34,8 +34,10 @@ _log = squid.logging.get_logger(__name__)
 
 STEPS_PER_MM = 10000  # ASI native unit = 0.1 um; also the finest addressable step (z_mm_to_usteps grid)
 _DEFAULT_MOVE_TIMEOUT_S = 30.0
-# Full-travel drive into the limit switch; sized for the slowest plausible traverse speed.
-_FIND_ZERO_TIMEOUT_S = 60.0
+# MFC-2000 datasheet maximum Z velocity (0.6 mm/s). The find-zero timeout budgets a full
+# overdrive at this speed times a 2x margin, so drives tuned slower than spec still finish.
+_MFC2000_MAX_VELOCITY_MM_S = 0.6
+_FIND_ZERO_TIME_MARGIN = 2.0
 _STATUS_POLL_PERIOD_S = 0.05
 
 
@@ -137,7 +139,7 @@ class _SimulatedLS50:
         self._pos_mm = 0.0
         self._zero_count += 1
 
-    def zero_at_away_limit(self, overdrive_mm: float, timeout: float = _FIND_ZERO_TIMEOUT_S):
+    def zero_at_away_limit(self, overdrive_mm: float, timeout: Optional[float] = None):
         # Drive past full travel toward the away end; the (simulated) limit switch stops
         # the stage; define native 0 there.
         self.move_relative(abs(float(overdrive_mm)), wait=True)
@@ -272,14 +274,19 @@ class LS50Controller:
         # Redefine the current position as native 0 (shifts the whole frame).
         self._serial.command(f"H {self._axis}=0")
 
-    def zero_at_away_limit(self, overdrive_mm: float, timeout: float = _FIND_ZERO_TIMEOUT_S) -> None:
+    def zero_at_away_limit(self, overdrive_mm: float, timeout: Optional[float] = None) -> None:
         """Establish the frame: drive PAST full travel toward the away-from-sample end
         (native +; the limit switch stops the stage safely), then define native 0 there.
 
         Call AFTER clear_travel_limits and BEFORE set_travel_limits -- stale limits would
         clamp the overdrive, and the fresh fence must be expressed in the new frame.
+        The default timeout is derived from the overdrive distance at the MFC-2000's
+        datasheet velocity (a full 50 mm traverse takes ~80 s at 0.6 mm/s).
         """
-        self.move_relative(abs(float(overdrive_mm)), wait=True, timeout=timeout)
+        distance = abs(float(overdrive_mm))
+        if timeout is None:
+            timeout = distance / _MFC2000_MAX_VELOCITY_MM_S * _FIND_ZERO_TIME_MARGIN
+        self.move_relative(distance, wait=True, timeout=timeout)
         self.zero_here()
 
     def stop(self) -> None:

--- a/software/squid/stage/asi.py
+++ b/software/squid/stage/asi.py
@@ -1,0 +1,137 @@
+"""
+Squid stage support for the ASI LS50 Z-only linear stage on its own MS-2000-family controller.
+
+Provides (1) ``MS2000Serial``, the CR-terminated ASI command transport; (2) ``LS50Controller``,
+the single-axis driver; (3) ``_SimulatedLS50``, a pure-Python stand-in for hardware-free / CI
+use; and (4) ``ASIZStage``, the Z-only ``squid.abc.AbstractStage`` adapter (pair with an XY
+stage via ``squid.stage.pi.CombinedStage``).
+
+Frame and units: the controller's native unit is 1/10 um (10000 per mm). Native 0 is the
+power-on position, which by convention is the RETRACTED end; native positive is away from the
+sample and the value goes negative as the stage approaches the sample. There is no absolute
+reference or homing routine -- "home" simply retracts to native 0. Squid Z is the negation
+(``squid_z = -native_z`` with the default ``invert_z=True`` wiring), so squid 0 is retracted
+and squid Z increases toward the sample, matching the Cephla convention.
+
+NOTE: branch ``dragonfly-andor`` adds an XYZ ``ASIStage`` at this same path. When merging that
+branch, keep both: port ``ASIStage`` onto ``MS2000Serial`` below (its ``_send_command`` /
+port-by-SN / ``:N``-check code duplicates this core).
+"""
+
+from __future__ import annotations
+
+import re
+import threading
+import time
+from contextlib import suppress
+from typing import Optional, Tuple
+
+import squid.logging
+from squid.abc import AbstractStage, Pos, StageStage
+from squid.config import StageConfig
+
+_log = squid.logging.get_logger(__name__)
+
+STEPS_PER_MM = 10000  # ASI native unit = 0.1 um
+# The protocol grid is the finest addressable step; the GUI's ustep-based Z step snapping uses
+# this via z_mm_to_usteps (0.1 um is sub-slice for any real Z stack).
+_Z_RESOLUTION_MM = 1e-4
+_DEFAULT_MOVE_TIMEOUT_S = 30.0
+_STATUS_POLL_PERIOD_S = 0.05
+
+
+class MS2000Serial:
+    """CR-terminated MS-2000 command transport: locked write/read with ':N' error-ack checking.
+
+    Takes any pyserial-like object (write / read_until / close) so tests can inject a scripted
+    fake; ``open()`` constructs the real ``serial.Serial``. This class is the shared ASI command
+    core -- the dragonfly-andor ``ASIStage`` (XYZ) should adopt it when that branch merges.
+    """
+
+    def __init__(self, serial_conn):
+        self._serial = serial_conn
+        self._lock = threading.Lock()
+
+    @classmethod
+    def open(cls, port: str, baudrate: int = 115200, timeout_s: float = 0.5) -> "MS2000Serial":
+        import serial  # lazy: real-hardware path only
+
+        return cls(serial.Serial(port, baudrate=baudrate, timeout=timeout_s))
+
+    def command(self, cmd: str, check_error: bool = True) -> str:
+        """Send one command and return the stripped reply line.
+
+        Raises RuntimeError on an ':N-<code>' error ack unless check_error=False (e.g. HALT,
+        whose ':N-21' ack is expected).
+        """
+        with self._lock:
+            self._serial.write(f"{cmd}\r".encode("ascii"))
+            reply = self._serial.read_until(b"\n").decode("ascii", errors="ignore").strip()
+        if check_error and reply.startswith(":N"):
+            raise RuntimeError(f"MS-2000 error ack {reply!r} for command {cmd!r}")
+        return reply
+
+    def close(self):
+        with suppress(Exception):
+            self._serial.close()
+
+
+class _SimulatedLS50:
+    """In-memory stand-in for LS50Controller: instant moves, no serial.
+
+    Mirrors the real backend's contract: until a fence is set the travel limits are unknown
+    (native 0 is just the power-on position) and targets pass through unclamped; a fence set
+    via set_travel_limits clamps. There is no referencing concept -- the power-on frame is
+    always "valid".
+    """
+
+    def __init__(self):
+        self._pos_mm = 0.0  # power-on zero
+        self._lo_mm: Optional[float] = None
+        self._hi_mm: Optional[float] = None
+        self._closed = False
+        self._zero_count = 0
+        self._halt_count = 0
+
+    def connect_serial(self, *args, **kwargs):
+        pass
+
+    def initialize(self):
+        pass
+
+    def is_referenced(self) -> bool:
+        return True  # nothing to reference; position is always valid in the power-on frame
+
+    def hardware_limits_mm(self) -> Tuple[Optional[float], Optional[float]]:
+        return (self._lo_mm, self._hi_mm)
+
+    def set_travel_limits(self, min_mm: float, max_mm: float):
+        self._lo_mm, self._hi_mm = float(min_mm), float(max_mm)
+
+    def get_position_mm(self) -> float:
+        return self._pos_mm
+
+    def is_moving(self) -> bool:
+        return False
+
+    def move_to(self, z_mm: float, wait: bool = True, **kwargs) -> float:
+        target = float(z_mm)
+        if self._lo_mm is not None:
+            target = min(max(target, self._lo_mm), self._hi_mm)
+        self._pos_mm = target
+        return self._pos_mm
+
+    def move_relative(self, dz_mm: float, wait: bool = True, **kwargs) -> float:
+        return self.move_to(self._pos_mm + float(dz_mm), wait=wait)
+
+    def zero_here(self):
+        # 'H Z=0' capability: redefine the current position as native 0. Deliberately NOT
+        # wired to AbstractStage.zero() -- see ASIZStage.zero().
+        self._pos_mm = 0.0
+        self._zero_count += 1
+
+    def stop(self):
+        self._halt_count += 1
+
+    def close(self):
+        self._closed = True

--- a/software/squid/stage/asi.py
+++ b/software/squid/stage/asi.py
@@ -88,6 +88,7 @@ class _SimulatedLS50:
         self._pos_mm = 0.0  # power-on zero
         self._lo_mm: Optional[float] = None
         self._hi_mm: Optional[float] = None
+        self._hard_hi_mm: Optional[float] = None  # physical away-limit stop (set by frame tests)
         self._closed = False
         self._zero_count = 0
 
@@ -103,6 +104,9 @@ class _SimulatedLS50:
     def set_travel_limits(self, min_mm: float, max_mm: float):
         self._lo_mm, self._hi_mm = float(min_mm), float(max_mm)
 
+    def clear_travel_limits(self):
+        self._lo_mm = self._hi_mm = None
+
     def get_position_mm(self) -> float:
         return self._pos_mm
 
@@ -113,6 +117,8 @@ class _SimulatedLS50:
         target = float(z_mm)
         if self._lo_mm is not None:
             target = min(max(target, self._lo_mm), self._hi_mm)
+        if self._hard_hi_mm is not None:
+            target = min(target, self._hard_hi_mm)  # the limit switch stops the stage
         self._pos_mm = target
         return self._pos_mm
 
@@ -120,10 +126,20 @@ class _SimulatedLS50:
         return self.move_to(self._pos_mm + float(dz_mm), wait=wait)
 
     def zero_here(self):
-        # 'H Z=0' capability: redefine the current position as native 0. Deliberately NOT
-        # wired to AbstractStage.zero() -- see ASIZStage.zero().
+        # 'H Z=0': redefine the current position as native 0 (shifts the whole frame).
+        if self._hard_hi_mm is not None:
+            self._hard_hi_mm -= self._pos_mm
+        if self._lo_mm is not None:
+            self._lo_mm -= self._pos_mm
+            self._hi_mm -= self._pos_mm
         self._pos_mm = 0.0
         self._zero_count += 1
+
+    def zero_at_away_limit(self, overdrive_mm: float, timeout: float = 60.0):
+        # Drive past full travel toward the away end; the (simulated) limit switch stops
+        # the stage; define native 0 there.
+        self.move_relative(abs(float(overdrive_mm)), wait=True)
+        self.zero_here()
 
     def close(self):
         self._closed = True
@@ -181,6 +197,17 @@ class LS50Controller:
         self._serial.command(f"SU {self._axis}={float(max_mm):.4f}")
         self._range_lo, self._range_hi = float(min_mm), float(max_mm)
 
+    def clear_travel_limits(self) -> None:
+        """Overwrite any controller-side SL/SU left by a previous session with a wide window.
+
+        Stale soft limits persist in the controller across software restarts (and across
+        power cycles if they were ever saved); they would silently clamp moves -- including
+        the find-zero overdrive -- so startup clears them before anything else.
+        """
+        self._serial.command(f"SL {self._axis}=-1000")
+        self._serial.command(f"SU {self._axis}=1000")
+        self._range_lo = self._range_hi = None
+
     def get_position_mm(self) -> float:
         reply = self._serial.command(f"W {self._axis}")  # ':A -12345' or bare '-12345', in 0.1 um
         match = re.search(r"-?\d+(?:\.\d+)?", reply.replace(":A", "", 1))
@@ -229,9 +256,18 @@ class LS50Controller:
             time.sleep(_STATUS_POLL_PERIOD_S)
 
     def zero_here(self) -> None:
-        # Redefine the current position as native 0. Deliberately NOT wired to
-        # AbstractStage.zero() -- see ASIZStage.zero().
+        # Redefine the current position as native 0 (shifts the whole frame).
         self._serial.command(f"H {self._axis}=0")
+
+    def zero_at_away_limit(self, overdrive_mm: float, timeout: float = 60.0) -> None:
+        """Establish the frame: drive PAST full travel toward the away-from-sample end
+        (native +; the limit switch stops the stage safely), then define native 0 there.
+
+        Call AFTER clear_travel_limits and BEFORE set_travel_limits -- stale limits would
+        clamp the overdrive, and the fresh fence must be expressed in the new frame.
+        """
+        self.move_relative(abs(float(overdrive_mm)), wait=True, timeout=timeout)
+        self.zero_here()
 
     def stop(self) -> None:
         # HALT; the MS-2000 acks it with ':N-21', which is expected, not an error.
@@ -410,6 +446,7 @@ def connect_asi_z_stage(
     home_mm: Optional[float] = None,
     invert_z: bool = False,
     apply_software_limits: bool = True,
+    find_zero_on_startup: bool = False,
     home_on_startup: bool = False,
     z_travel_mm: float = 0.0,
     stage_config: Optional[StageConfig] = None,
@@ -444,6 +481,14 @@ def connect_asi_z_stage(
     try:
         backend.connect_serial(port, baudrate=baudrate)
         backend.initialize()
+        # Always clear first: stale controller-side SL/SU from a previous session would
+        # silently clamp everything, including the find-zero overdrive below.
+        backend.clear_travel_limits()
+        if find_zero_on_startup:
+            # Anchor the frame: drive to the away-from-sample limit switch and define
+            # native 0 there, so squid 0 is the true retracted end, never a random
+            # power-on position. Motion is in the safe (away) direction only.
+            backend.zero_at_away_limit(overdrive_mm=(z_travel_mm or 50.0) * 1.2)
         if z_travel_mm:
             backend.set_travel_limits(-z_travel_mm, z_travel_mm)
     except Exception:

--- a/software/squid/stage/asi.py
+++ b/software/squid/stage/asi.py
@@ -135,3 +135,140 @@ class _SimulatedLS50:
 
     def close(self):
         self._closed = True
+
+
+class ASIZStage(AbstractStage):
+    """Z-only AbstractStage backed by an ASI LS50. X / Y / theta are no-ops.
+
+    With ``invert_z=True`` (the standard wiring) Squid Z is the negation of the controller's
+    native mm: native + is away from the sample, so squid 0 is the retracted end and squid Z
+    increases toward the sample. A pure sign flip -- unlike the PI V-308 there is no absolute
+    positive travel limit to offset against.
+
+    ``home_mm`` (Squid mm) is the retract target home() drives to -- native/squid 0 by
+    convention. None disables home(z) entirely (warn no-op), guaranteeing no motion.
+
+    A lock serialises every backend call so a non-blocking home() cannot interleave serial
+    request/response framing with concurrent get_pos()/move_z().
+    """
+
+    def __init__(
+        self,
+        backend,
+        stage_config: Optional[StageConfig] = None,
+        home_mm: Optional[float] = None,
+        invert_z: bool = False,
+    ):
+        super().__init__(stage_config)
+        self._backend = backend
+        self._lock = threading.RLock()
+        self._closed = False
+        self._busy = False  # set while an async home holds the lock, so get_state needn't block
+
+        self._invert = invert_z
+        # NATIVE home target (the flip is an involution, so it maps squid -> native too).
+        self._home_native_mm = self._flip(home_mm) if home_mm is not None else None
+
+    def _flip(self, mm: float) -> float:
+        # squid_z = -native_z (and vice versa) when inverted; identity otherwise.
+        return -mm if self._invert else mm
+
+    def move_z(self, rel_mm: float, blocking: bool = True):
+        with self._lock:
+            self._backend.move_relative(self._flip(rel_mm), wait=blocking)
+
+    def move_z_to(self, abs_mm: float, blocking: bool = True):
+        with self._lock:
+            self._backend.move_to(self._flip(abs_mm), wait=blocking)
+
+    def get_pos(self) -> Pos:
+        with self._lock:
+            return Pos(x_mm=0.0, y_mm=0.0, z_mm=self._flip(self._backend.get_position_mm()), theta_rad=None)
+
+    def get_state(self) -> StageStage:
+        # If an async home holds the lock, report busy without blocking on it.
+        if self._busy:
+            return StageStage(busy=True)
+        with self._lock:
+            return StageStage(busy=self._backend.is_moving())
+
+    def is_referenced(self) -> bool:
+        with self._lock:
+            return self._backend.is_referenced()
+
+    def home(self, x: bool, y: bool, z: bool, theta: bool, blocking: bool = True):
+        # Home = retract to the configured target (native 0 by convention). There is no
+        # hardware referencing routine on this stage.
+        if not z:
+            return
+        if self._home_native_mm is None:
+            self._log.warning("ASIZStage home(z=True) is a no-op: no home target configured (ASI_Z_HOME_MM).")
+            return
+        if blocking:
+            self._home_z_locked()
+        else:
+            threading.Thread(target=self._home_z_locked, daemon=True, name="asi-z-home").start()
+
+    def _home_z_locked(self):
+        self._busy = True
+        try:
+            with self._lock:
+                if self._closed:  # close() won the race; do not touch the torn-down handle
+                    return
+                self._backend.move_to(self._home_native_mm, wait=True)
+        finally:
+            self._busy = False
+
+    def zero(self, x: bool, y: bool, z: bool, theta: bool, blocking: bool = True):
+        if z:
+            self._log.warning(
+                "ASIZStage.zero(z=True) is a no-op: native 0 is the retract reference, and "
+                "redefining it mid-session would shift the retract target and invalidate the "
+                "travel fence. The controller supports it (LS50Controller.zero_here) if a "
+                "re-zeroing flow is ever needed."
+            )
+
+    def set_limits(
+        self,
+        x_pos_mm: Optional[float] = None,
+        x_neg_mm: Optional[float] = None,
+        y_pos_mm: Optional[float] = None,
+        y_neg_mm: Optional[float] = None,
+        z_pos_mm: Optional[float] = None,
+        z_neg_mm: Optional[float] = None,
+        theta_pos_rad: Optional[float] = None,
+        theta_neg_rad: Optional[float] = None,
+    ):
+        if z_pos_mm is not None and z_neg_mm is not None:
+            with self._lock:
+                # Map the software Z limits to native; inversion reverses order, so take
+                # min/max after flipping both ends.
+                n1, n2 = self._flip(z_pos_mm), self._flip(z_neg_mm)
+                self._backend.set_travel_limits(min(n1, n2), max(n1, n2))
+        elif z_pos_mm is not None or z_neg_mm is not None:
+            self._log.warning("ASIZStage.set_limits ignored a one-sided Z limit; pass both z_pos_mm and z_neg_mm.")
+
+    def close(self):
+        with self._lock:
+            self._closed = True
+            self._backend.close()
+
+    def z_mm_to_usteps(self, mm: float) -> int:
+        # The 0.1 um protocol grid is the finest addressable step; the GUI's Z step snapping
+        # uses 1 / z_mm_to_usteps(1.0). Rounds to an integer like the stepper conversion.
+        return round(mm / _Z_RESOLUTION_MM)
+
+    def move_x(self, rel_mm: float, blocking: bool = True):
+        self._no_xy("move_x")
+
+    def move_y(self, rel_mm: float, blocking: bool = True):
+        self._no_xy("move_y")
+
+    def move_x_to(self, abs_mm: float, blocking: bool = True):
+        self._no_xy("move_x_to")
+
+    def move_y_to(self, abs_mm: float, blocking: bool = True):
+        self._no_xy("move_y_to")
+
+    def _no_xy(self, name: str):
+        self._log.warning(f"{name} ignored: ASIZStage is a Z-only stage (pair via CombinedStage).")

--- a/software/squid/stage/asi.py
+++ b/software/squid/stage/asi.py
@@ -269,6 +269,7 @@ class ASIZStage(AbstractStage):
         stage_config: Optional[StageConfig] = None,
         home_mm: Optional[float] = None,
         invert_z: bool = False,
+        apply_software_limits: bool = True,
     ):
         super().__init__(stage_config)
         self._backend = backend
@@ -277,6 +278,7 @@ class ASIZStage(AbstractStage):
         self._busy = False  # set while an async home holds the lock, so get_state needn't block
 
         self._invert = invert_z
+        self._apply_software_limits = apply_software_limits
         self._home_mm = home_mm  # Squid-frame retract target; None = home(z) disabled
         self._last_z_mm = 0.0  # last Squid-frame Z, served to pollers after close()
 
@@ -360,6 +362,11 @@ class ASIZStage(AbstractStage):
         theta_neg_rad: Optional[float] = None,
     ):
         if z_pos_mm is not None and z_neg_mm is not None:
+            if not self._apply_software_limits:
+                # The frame is power-on-relative: fixed squid-frame limits fence arbitrary
+                # positions unless the retract-at-power-on convention is guaranteed.
+                self._log.info("Ignoring software Z limits (ASI_Z_APPLY_SOFTWARE_LIMITS is off).")
+                return
             with self._lock:
                 # Map the software Z limits to native; inversion reverses order, so take
                 # min/max after flipping both ends.
@@ -402,6 +409,7 @@ def connect_asi_z_stage(
     axis: str = "Z",
     home_mm: Optional[float] = None,
     invert_z: bool = False,
+    apply_software_limits: bool = True,
     home_on_startup: bool = False,
     z_travel_mm: float = 0.0,
     stage_config: Optional[StageConfig] = None,
@@ -441,7 +449,13 @@ def connect_asi_z_stage(
     except Exception:
         backend.close()  # release the serial handle on any connect/init failure
         raise
-    stage = ASIZStage(backend, stage_config=stage_config, home_mm=home_mm, invert_z=invert_z)
+    stage = ASIZStage(
+        backend,
+        stage_config=stage_config,
+        home_mm=home_mm,
+        invert_z=invert_z,
+        apply_software_limits=apply_software_limits,
+    )
 
     if home_on_startup:
         if home_mm is None:

--- a/software/squid/stage/asi.py
+++ b/software/squid/stage/asi.py
@@ -1,17 +1,19 @@
 """
-Squid stage support for the ASI LS50 Z-only linear stage on its own MS-2000-family controller.
+Squid stage support for the ASI LS50 Z-only linear stage on its own MS-2000-family controller
+(an MFC-2000 on the reference machine).
 
 Provides (1) ``MS2000Serial``, the CR-terminated ASI command transport; (2) ``LS50Controller``,
 the single-axis driver; (3) ``_SimulatedLS50``, a pure-Python stand-in for hardware-free / CI
 use; and (4) ``ASIZStage``, the Z-only ``squid.abc.AbstractStage`` adapter (pair with an XY
 stage via ``squid.stage.pi.CombinedStage``).
 
-Frame and units: the controller's native unit is 1/10 um (10000 per mm). Native 0 is the
-power-on position, which by convention is the RETRACTED end; native positive is away from the
-sample and the value goes negative as the stage approaches the sample. There is no absolute
-reference or homing routine -- "home" simply retracts to native 0. Squid Z is the negation
-(``squid_z = -native_z`` with the default ``invert_z=True`` wiring), so squid 0 is retracted
-and squid Z increases toward the sample, matching the Cephla convention.
+Frame and units: the controller's native unit is 1/10 um (10000 per mm). Native positive is
+away from the sample; the value goes negative as the stage approaches the sample. With
+find-zero on (ASI_Z_FIND_ZERO_ON_STARTUP, the default), startup anchors native 0 at the
+away-from-sample limit switch, so 0 is a repeatable physical reference; with find-zero off,
+native 0 is just the arbitrary power-on position. Squid Z is the negation (``squid_z =
+-native_z`` with the default ``invert_z=True`` wiring), so squid 0 is the away end and squid Z
+increases toward the sample, matching the Cephla convention.
 
 NOTE: branch ``dragonfly-andor`` adds an XYZ ``ASIStage`` at this same path. When merging that
 branch, keep both: port ``ASIStage`` onto ``MS2000Serial`` below (its ``_send_command`` /
@@ -39,6 +41,8 @@ _DEFAULT_MOVE_TIMEOUT_S = 30.0
 _MFC2000_MAX_VELOCITY_MM_S = 0.6
 _FIND_ZERO_TIME_MARGIN = 2.0
 _STATUS_POLL_PERIOD_S = 0.05
+# Settle before retrying a dead-air first exchange (marginal RS-232 links, adapter wake-up).
+_FIRST_CONTACT_SETTLE_S = 0.2
 
 
 class MS2000Serial:
@@ -46,7 +50,10 @@ class MS2000Serial:
 
     Takes any pyserial-like object (write / read_until / close) so tests can inject a scripted
     fake; ``open()`` constructs the real ``serial.Serial``. This class is the shared ASI command
-    core -- the dragonfly-andor ``ASIStage`` (XYZ) should adopt it when that branch merges.
+    core for everything on one controller (the Z axis, the objective turret, and eventually the
+    dragonfly-andor ``ASIStage``): per-command locking makes interleaved clients frame-safe, and
+    controller-global concerns (the '/' busy byte, first-contact retries, buffer hygiene) live
+    here rather than in each axis client.
     """
 
     def __init__(self, serial_conn):
@@ -74,18 +81,54 @@ class MS2000Serial:
             raise RuntimeError(f"MS-2000 error ack {reply!r} for command {cmd!r}")
         return reply
 
+    def command_with_settle_retry(self, cmd: str, check_error: bool = True) -> str:
+        """command(), retried once after a settle + flush when the reply is dead air.
+
+        A marginal RS-232 link or a just-opened adapter can drop the first exchange without
+        being broken. Returns the (possibly still empty) reply; callers decide how to fail.
+        """
+        reply = self.command(cmd, check_error=check_error)
+        if not reply:
+            time.sleep(_FIRST_CONTACT_SETTLE_S)
+            self.reset_input_buffer()
+            reply = self.command(cmd, check_error=check_error)
+        return reply
+
+    def reset_input_buffer(self) -> None:
+        """Drop any unread bytes (line noise, stale replies) so the next reply pairs cleanly."""
+        with suppress(Exception):
+            self._serial.reset_input_buffer()
+
+    def is_busy(self) -> bool:
+        """Controller-GLOBAL busy byte ('/' -> B/N): busy while ANY axis on the box moves."""
+        return "B" in self.command("/").upper()
+
+    def wait_idle(self, timeout_s: float, what: str) -> None:
+        """Poll the global busy byte until idle; RuntimeError naming ``what`` on timeout."""
+        deadline = time.monotonic() + timeout_s
+        while self.is_busy():
+            if time.monotonic() > deadline:
+                raise RuntimeError(f"{what} did not reach idle within {timeout_s:.1f}s")
+            time.sleep(_STATUS_POLL_PERIOD_S)
+
     def close(self):
         with suppress(Exception):
             self._serial.close()
+
+
+def parse_ms2000_number(reply: str) -> Optional[float]:
+    """First number in an MS-2000 reply after stripping the ':A' ack prefix, else None."""
+    match = re.search(r"-?\d+(?:\.\d+)?", reply.replace(":A", "", 1)) if reply else None
+    return float(match.group(0)) if match else None
 
 
 class _SimulatedLS50:
     """In-memory stand-in for LS50Controller: instant moves, no serial.
 
     Mirrors the real backend's contract: until a fence is set the travel limits are unknown
-    (native 0 is just the power-on position) and targets pass through unclamped; a fence set
-    via set_travel_limits clamps. There is no referencing concept -- the power-on frame is
-    always "valid".
+    and targets pass through unclamped; a fence set via set_travel_limits clamps; an optional
+    ``_hard_hi_mm`` models the physical away-limit switch for find-zero tests. There is no
+    referencing concept.
     """
 
     def __init__(self):
@@ -130,12 +173,11 @@ class _SimulatedLS50:
         return self.move_to(self._pos_mm + float(dz_mm), wait=wait)
 
     def zero_here(self):
-        # 'H Z=0': redefine the current position as native 0 (shifts the whole frame).
+        # 'H Z=0': redefine the current position as native 0 (shifts the whole frame). The
+        # production flow clears limits before zeroing and re-fences after, so only the
+        # physical stop needs shifting here.
         if self._hard_hi_mm is not None:
             self._hard_hi_mm -= self._pos_mm
-        if self._lo_mm is not None:
-            self._lo_mm -= self._pos_mm
-            self._hi_mm -= self._pos_mm
         self._pos_mm = 0.0
         self._zero_count += 1
 
@@ -152,9 +194,9 @@ class _SimulatedLS50:
 class LS50Controller:
     """ASI LS50 Z linear stage on an MS-2000-family controller (CR text protocol, 1/10 um units).
 
-    Native 0 is the power-on position (the retracted end by convention); native negative is
-    toward the sample. There is no referencing routine, and bring-up performs no motion and
-    writes no controller parameters.
+    Native positive is away from the sample. Mechanisms only -- the bring-up sequence (clear
+    stale limits, find-zero at the away limit switch, fence) is policy owned by
+    ``connect_asi_z_stage``; ``initialize()`` itself is a motionless comms check.
     """
 
     def __init__(self, axis: str = "Z"):
@@ -172,25 +214,15 @@ class LS50Controller:
 
     def initialize(self) -> None:
         # Comms sanity only: prove the controller answers. NO motion, NO parameter writes.
-        # One retry after a settle+flush: a marginal RS-232 link or a just-opened adapter can
-        # drop/garble the very first exchange without being actually broken.
-        try:
-            try:
-                self.get_position_mm()
-                return
-            except RuntimeError:
-                time.sleep(0.2)
-                with suppress(Exception):
-                    self._serial._serial.reset_input_buffer()
-            self.get_position_mm()
-        except RuntimeError as e:
+        reply = self._serial.command_with_settle_retry(f"W {self._axis}")
+        if parse_ms2000_number(reply) is None:
             raise RuntimeError(
-                f"LS50 controller did not answer a position query ({e}). Check the baud rate "
-                f"(ASI controllers often ship at 9600; Squid defaults to 115200 -- set "
+                f"LS50 controller did not answer a position query (reply {reply!r}). Check the "
+                f"baud rate (ASI controllers often ship at 9600; Squid defaults to 115200 -- set "
                 f"ASI_Z_BAUDRATE in the machine config), that the resolved port really is the "
                 f"ASI controller, and that it is powered. "
                 f"`python3 tools/asi_z_bringup.py --sn <SN> --scan-bauds` can diagnose this."
-            ) from e
+            )
 
     def hardware_limits_mm(self) -> Tuple[Optional[float], Optional[float]]:
         return (self._range_lo, self._range_hi)
@@ -225,13 +257,13 @@ class LS50Controller:
 
     def get_position_mm(self) -> float:
         reply = self._serial.command(f"W {self._axis}")  # ':A -12345' or bare '-12345', in 0.1 um
-        match = re.search(r"-?\d+(?:\.\d+)?", reply.replace(":A", "", 1))
-        if not match:
+        value = parse_ms2000_number(reply)
+        if value is None:
             raise RuntimeError(f"Could not parse LS50 position from reply {reply!r}")
-        return float(match.group(0)) / STEPS_PER_MM
+        return value / STEPS_PER_MM
 
     def is_moving(self) -> bool:
-        return "B" in self._serial.command("/").upper()
+        return self._serial.is_busy()
 
     def _clamp_target(self, z_mm: float) -> float:
         """Clamp an absolute native target to the fence; pass through while unfenced."""
@@ -253,7 +285,7 @@ class LS50Controller:
         target = self._clamp_target(float(z_mm))
         self._serial.command(f"M {self._axis}={round(target * STEPS_PER_MM)}")
         if wait:
-            self._wait_idle(timeout)
+            self._serial.wait_idle(timeout, f"LS50 axis {self._axis}")
             return self.get_position_mm()
         return target
 
@@ -261,14 +293,6 @@ class LS50Controller:
         # Resolve to an absolute target (M) rather than sending R Z=, so a jog past the fence
         # clamps instead of erroring or overdriving.
         return self.move_to(self.get_position_mm() + float(dz_mm), wait=wait, timeout=timeout)
-
-    def _wait_idle(self, timeout_s: float) -> None:
-        # '/' polling is the only settle signal (there is no on-target query in this command set).
-        deadline = time.monotonic() + timeout_s
-        while self.is_moving():
-            if time.monotonic() > deadline:
-                raise RuntimeError(f"LS50 did not reach idle within {timeout_s:.1f}s")
-            time.sleep(_STATUS_POLL_PERIOD_S)
 
     def zero_here(self) -> None:
         # Redefine the current position as native 0 (shifts the whole frame).
@@ -308,9 +332,9 @@ class ASIZStage(AbstractStage):
     """Z-only AbstractStage backed by an ASI LS50. X / Y / theta are no-ops.
 
     With ``invert_z=True`` (the standard wiring) Squid Z is the negation of the controller's
-    native mm: native + is away from the sample, so squid 0 is the retracted end and squid Z
-    increases toward the sample. A pure sign flip -- unlike the PI V-308 there is no absolute
-    positive travel limit to offset against.
+    native mm: native + is away from the sample, so squid 0 is the away end (anchored at the
+    limit switch when find-zero runs) and squid Z increases toward the sample. A pure sign
+    flip -- unlike the PI V-308 there is no positive travel limit to offset against.
 
     ``home_mm`` (Squid mm) is the retract target home() drives to -- native/squid 0 by
     convention. None disables home(z) entirely (warn no-op), guaranteeing no motion.
@@ -372,7 +396,7 @@ class ASIZStage(AbstractStage):
             return StageStage(busy=False if self._closed else self._backend.is_moving())
 
     def is_referenced(self) -> bool:
-        return True  # no referencing concept; the power-on frame is always valid
+        return True  # no referencing concept; the frame is anchored by find-zero (or power-on)
 
     def home(self, x: bool, y: bool, z: bool, theta: bool, blocking: bool = True):
         # Home = retract to the configured target (native 0 by convention). There is no
@@ -398,13 +422,10 @@ class ASIZStage(AbstractStage):
             self._busy = False
 
     def zero(self, x: bool, y: bool, z: bool, theta: bool, blocking: bool = True):
+        # Re-zeroing mid-session would shift the retract target and invalidate the fence;
+        # LS50Controller.zero_here exists if a deliberate re-zeroing flow is ever wanted.
         if z:
-            self._log.warning(
-                "ASIZStage.zero(z=True) is a no-op: native 0 is the retract reference, and "
-                "redefining it mid-session would shift the retract target and invalidate the "
-                "travel fence. The controller supports it (LS50Controller.zero_here) if a "
-                "re-zeroing flow is ever needed."
-            )
+            self._log.warning("ASIZStage.zero(z=True) is a no-op: native 0 is the frame reference.")
 
     def set_limits(
         self,
@@ -419,8 +440,8 @@ class ASIZStage(AbstractStage):
     ):
         if z_pos_mm is not None and z_neg_mm is not None:
             if not self._apply_software_limits:
-                # The frame is power-on-relative: fixed squid-frame limits fence arbitrary
-                # positions unless the retract-at-power-on convention is guaranteed.
+                # Disabled by config (ASI_Z_APPLY_SOFTWARE_LIMITS); the coarse travel fence
+                # from connect time still bounds absurd targets.
                 self._log.info("Ignoring software Z limits (ASI_Z_APPLY_SOFTWARE_LIMITS is off).")
                 return
             with self._lock:
@@ -467,41 +488,38 @@ def connect_asi_z_stage(
     invert_z: bool = False,
     apply_software_limits: bool = True,
     find_zero_on_startup: bool = False,
-    home_on_startup: bool = False,
     z_travel_mm: float = 0.0,
     stage_config: Optional[StageConfig] = None,
 ) -> ASIZStage:
     """Open the LS50 controller over serial (or a simulated backend) and wrap it as an ASIZStage.
 
-    Bring-up performs NO motion unless home_on_startup=True (which requires home_mm and does one
-    blocking retract). z_travel_mm > 0 sets a coarse sanity fence of native [-travel, +travel]
-    around the power-on zero -- it can never exclude a reachable position, but stops absurd
-    targets; the real fence arrives via set_limits from StageConfig.Z_AXIS at microscope init.
+    Bring-up sequence: comms check, then ALWAYS clear stale controller-side limits (they
+    persist across power cycles and would clamp everything), then -- with find_zero_on_startup
+    -- drive to the away-from-sample limit switch and define native 0 there (the only bring-up
+    motion, in the safe direction, requiring z_travel_mm for the overdrive distance), then
+    apply the coarse +/- z_travel_mm sanity fence in the (new) frame. StageConfig.Z_AXIS
+    limits arrive later via set_limits and are honored only when apply_software_limits is set.
     """
+    if find_zero_on_startup and not z_travel_mm:
+        # The overdrive distance is derived from the stage's physical travel; only the
+        # user knows that, so there is no default to invent. (Also validated at machine-
+        # config load; this backstop covers programmatic use.)
+        raise ValueError("find_zero_on_startup requires the physical travel (ASI_Z_TRAVEL_MM) to be set.")
+
     if simulated:
         backend, port = _SimulatedLS50(), None
     else:
-        # Resolve the port BEFORE opening anything, so a missing controller never leaks a handle.
-        if serial_port:
-            port = serial_port
-        elif serialnum:
-            import squid.stage.utils
+        import squid.stage.utils
 
-            port = squid.stage.utils.resolve_serial_port_by_sn(
-                serialnum,
-                missing_hint=(
-                    "Verify the LS50 controller is powered and enumerates as a USB serial " "device (lsusb / dmesg)."
-                ),
-            )
-        else:
-            raise RuntimeError("Set ASI_Z_STAGE_SN or ASI_Z_SERIAL_PORT to locate the LS50 controller.")
+        # Resolve the port BEFORE opening anything, so a missing controller never leaks a handle.
+        port = squid.stage.utils.resolve_port(
+            serial_port,
+            serialnum,
+            missing_hint="Verify the LS50 controller is powered and enumerates as a USB serial device (lsusb / dmesg).",
+            unset_message="Set ASI_Z_STAGE_SN or ASI_Z_SERIAL_PORT to locate the LS50 controller.",
+        )
         backend = LS50Controller(axis=axis)
         _log.info(f"Connecting to the ASI Z stage on {port} at {baudrate} baud (axis {axis!r}).")
-
-    if find_zero_on_startup and not z_travel_mm:
-        # The overdrive distance is derived from the stage's physical travel; only the
-        # user knows that, so there is no default to invent.
-        raise ValueError("find_zero_on_startup requires the physical travel (ASI_Z_TRAVEL_MM) to be set.")
 
     try:
         backend.connect_serial(port, baudrate=baudrate)
@@ -520,17 +538,10 @@ def connect_asi_z_stage(
     except Exception:
         backend.close()  # release the serial handle on any connect/init failure
         raise
-    stage = ASIZStage(
+    return ASIZStage(
         backend,
         stage_config=stage_config,
         home_mm=home_mm,
         invert_z=invert_z,
         apply_software_limits=apply_software_limits,
     )
-
-    if home_on_startup:
-        if home_mm is None:
-            _log.warning("ASI_Z_HOME_ON_STARTUP is set but no home target is configured; skipping the retract.")
-        else:
-            stage.home(False, False, True, False, blocking=True)
-    return stage

--- a/software/squid/stage/composite.py
+++ b/software/squid/stage/composite.py
@@ -1,0 +1,120 @@
+"""Vendor-neutral composite stage: an XY stage plus a Z-only focus stage as one AbstractStage.
+
+``CombinedStage`` routes X / Y / theta to the wrapped XY stage (Cephla or Prior) and Z to a
+Z-only external focus stage (e.g. the PI V-308 in ``squid.stage.pi`` or the ASI LS50 in
+``squid.stage.asi``). Consumers keep programming against the single ``AbstractStage``
+interface; the informal contract a z_stage must satisfy is documented on the class.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from squid.abc import AbstractStage, Pos, StageStage
+from squid.config import StageConfig
+
+
+class CombinedStage(AbstractStage):
+    """AbstractStage routing X / Y / theta to xy_stage and Z to z_stage (an external Z-only focus stage, e.g. the V-308 or the ASI LS50)."""
+
+    def __init__(self, xy_stage: AbstractStage, z_stage: AbstractStage, stage_config: Optional[StageConfig] = None):
+        super().__init__(stage_config or xy_stage.get_config())
+        self._xy = xy_stage
+        self._z = z_stage
+        self._scanning_position_z_mm = None  # set/read by squid.stage.utils loading/scanning flow
+
+        # The GUI snaps Z step sizes through get_config().Z_AXIS (AutoFocus / multipoint) and via
+        # z_mm_to_usteps (navigation). Present a Z axis whose resolution is the Z stage's own
+        # (continuous ~10 nm) grid instead of the wrapped XY stepper grid, so Z-stack/autofocus
+        # steps are not snapped to the coarse stepper microstep grid. Only the resolution fields
+        # are overridden; range/speed/sign are preserved.
+        z_usteps_per_mm = abs(self._z.z_mm_to_usteps(1.0)) if hasattr(self._z, "z_mm_to_usteps") else 0.0
+        if z_usteps_per_mm:
+            fine_z = self._config.Z_AXIS.model_copy(
+                update={"SCREW_PITCH": 1.0, "MICROSTEPS_PER_STEP": 1, "FULL_STEPS_PER_REV": float(z_usteps_per_mm)}
+            )
+            self._config = self._config.model_copy(update={"Z_AXIS": fine_z})
+
+    @property
+    def z_stage(self) -> AbstractStage:
+        """The wrapped Z-only stage (public: addons sharing its transport walk through here)."""
+        return self._z
+
+    def move_x(self, rel_mm: float, blocking: bool = True):
+        self._xy.move_x(rel_mm, blocking)
+
+    def move_y(self, rel_mm: float, blocking: bool = True):
+        self._xy.move_y(rel_mm, blocking)
+
+    def move_z(self, rel_mm: float, blocking: bool = True):
+        self._z.move_z(rel_mm, blocking)
+
+    def move_x_to(self, abs_mm: float, blocking: bool = True):
+        self._xy.move_x_to(abs_mm, blocking)
+
+    def move_y_to(self, abs_mm: float, blocking: bool = True):
+        self._xy.move_y_to(abs_mm, blocking)
+
+    def move_z_to(self, abs_mm: float, blocking: bool = True):
+        self._z.move_z_to(abs_mm, blocking)
+
+    def get_pos(self) -> Pos:
+        xy, z = self._xy.get_pos(), self._z.get_pos()
+        return Pos(x_mm=xy.x_mm, y_mm=xy.y_mm, z_mm=z.z_mm, theta_rad=xy.theta_rad)
+
+    def get_state(self) -> StageStage:
+        return StageStage(busy=self._xy.get_state().busy or self._z.get_state().busy)
+
+    def is_referenced(self) -> bool:
+        return self._z.is_referenced()
+
+    def home(self, x: bool, y: bool, z: bool, theta: bool, blocking: bool = True):
+        xy_requested = x or y or theta
+        if z:
+            # Z must finish retracting before any XY sweep (e.g. the V-308 voice coil is not self-locking).
+            self._z.home(False, False, True, False, blocking or xy_requested)
+        if xy_requested:
+            self._xy.home(x, y, False, theta, blocking)
+
+    def zero(self, x: bool, y: bool, z: bool, theta: bool, blocking: bool = True):
+        if x or y or theta:
+            self._xy.zero(x, y, False, theta, blocking)
+        if z:
+            self._z.zero(False, False, True, False, blocking)
+
+    def set_limits(
+        self,
+        x_pos_mm: Optional[float] = None,
+        x_neg_mm: Optional[float] = None,
+        y_pos_mm: Optional[float] = None,
+        y_neg_mm: Optional[float] = None,
+        z_pos_mm: Optional[float] = None,
+        z_neg_mm: Optional[float] = None,
+        theta_pos_rad: Optional[float] = None,
+        theta_neg_rad: Optional[float] = None,
+    ):
+        self._xy.set_limits(
+            x_pos_mm=x_pos_mm,
+            x_neg_mm=x_neg_mm,
+            y_pos_mm=y_pos_mm,
+            y_neg_mm=y_neg_mm,
+            theta_pos_rad=theta_pos_rad,
+            theta_neg_rad=theta_neg_rad,
+        )
+        self._z.set_limits(z_pos_mm=z_pos_mm, z_neg_mm=z_neg_mm)
+
+    # The GUI (NavigationWidget.set_deltaX/Y/Z) calls these stepper-style helpers on the stage, so
+    # the wrapper must expose them. X/Y come from the wrapped XY stage; Z comes from the external
+    # Z stage's own grid, not the XY stepper grid.
+    def x_mm_to_usteps(self, mm: float):
+        return self._xy.x_mm_to_usteps(mm)
+
+    def y_mm_to_usteps(self, mm: float):
+        return self._xy.y_mm_to_usteps(mm)
+
+    def z_mm_to_usteps(self, mm: float):
+        return self._z.z_mm_to_usteps(mm)
+
+    def close(self):
+        self._z.close()  # the external Z stage's serial handle; Cephla/Prior XY close() is a no-op
+        self._xy.close()

--- a/software/squid/stage/pi.py
+++ b/software/squid/stage/pi.py
@@ -278,7 +278,7 @@ class PIFocusStage(AbstractStage):
 
 
 class CombinedStage(AbstractStage):
-    """AbstractStage routing X / Y / theta to xy_stage and Z to z_stage (the V-308)."""
+    """AbstractStage routing X / Y / theta to xy_stage and Z to z_stage (an external Z-only focus stage, e.g. the V-308 or the ASI LS50)."""
 
     def __init__(self, xy_stage: AbstractStage, z_stage: AbstractStage, stage_config: Optional[StageConfig] = None):
         super().__init__(stage_config or xy_stage.get_config())
@@ -329,7 +329,7 @@ class CombinedStage(AbstractStage):
     def home(self, x: bool, y: bool, z: bool, theta: bool, blocking: bool = True):
         xy_requested = x or y or theta
         if z:
-            # Z must finish retracting before any XY sweep (the voice coil is not self-locking).
+            # Z must finish retracting before any XY sweep (e.g. the V-308 voice coil is not self-locking).
             self._z.home(False, False, True, False, blocking or xy_requested)
         if xy_requested:
             self._xy.home(x, y, False, theta, blocking)
@@ -362,8 +362,8 @@ class CombinedStage(AbstractStage):
         self._z.set_limits(z_pos_mm=z_pos_mm, z_neg_mm=z_neg_mm)
 
     # The GUI (NavigationWidget.set_deltaX/Y/Z) calls these stepper-style helpers on the stage, so
-    # the wrapper must expose them. X/Y come from the wrapped XY stage; Z comes from the V-308
-    # (continuous), not the XY stepper grid.
+    # the wrapper must expose them. X/Y come from the wrapped XY stage; Z comes from the external
+    # Z stage's own grid, not the XY stepper grid.
     def x_mm_to_usteps(self, mm: float):
         return self._xy.x_mm_to_usteps(mm)
 
@@ -374,7 +374,7 @@ class CombinedStage(AbstractStage):
         return self._z.z_mm_to_usteps(mm)
 
     def close(self):
-        self._z.close()  # the V-308 backend's FTDI handle; Cephla/Prior XY close() is a no-op
+        self._z.close()  # the external Z stage's serial handle; Cephla/Prior XY close() is a no-op
         self._xy.close()
 
 

--- a/software/squid/stage/pi.py
+++ b/software/squid/stage/pi.py
@@ -663,14 +663,20 @@ def connect_pi_focus_stage(
             home_to_positive_limit=home_to_positive_limit,
         )
 
+    import squid.stage.utils
+
     # Resolve the port BEFORE allocating the GCSDevice, so a missing port/controller never
     # leaks an open handle.
-    if serial_port:
-        port = serial_port
-    elif serialnum:
-        port = _resolve_port_by_sn(serialnum)
-    else:
-        raise RuntimeError("Set PI_FOCUS_STAGE_SN or PI_FOCUS_SERIAL_PORT to locate the C-414.")
+    port = squid.stage.utils.resolve_port(
+        serial_port,
+        serialnum,
+        missing_hint=(
+            "On Linux the C-414's custom-VID FTDI needs the ftdi_sio bind rule "
+            "(98-pi-c414-bind.rules) installed so /dev/ttyUSB* appears; verify it is present "
+            "and the controller is powered."
+        ),
+        unset_message="Set PI_FOCUS_STAGE_SN or PI_FOCUS_SERIAL_PORT to locate the C-414.",
+    )
 
     backend = C414FocusStage(axis=axis)
     try:

--- a/software/squid/stage/pi.py
+++ b/software/squid/stage/pi.py
@@ -163,6 +163,7 @@ class PIFocusStage(AbstractStage):
         # travel limit (furthest from the sample); set_limits() narrows it to the fenced upper end.
         self._home_to_pos_limit = home_to_positive_limit
         self._home_native_mm = native_hi if home_to_positive_limit else home_mm
+        self._last_z_mm = self._to_squid(0.0)  # last Squid-frame Z, served to pollers after close()
 
     def _to_native(self, squid_mm: float) -> float:
         return (self._offset_mm - squid_mm) if self._invert else squid_mm
@@ -172,23 +173,35 @@ class PIFocusStage(AbstractStage):
 
     def move_z(self, rel_mm: float, blocking: bool = True):
         with self._lock:
+            if self._closed:
+                self._log.warning("move_z ignored: the PI focus stage is closed.")
+                return
             # A relative move flips sign under inversion (squid+ = native-), no offset.
-            self._c414.move_relative(-rel_mm if self._invert else rel_mm, wait=blocking)
+            self._last_z_mm = self._to_squid(
+                self._c414.move_relative(-rel_mm if self._invert else rel_mm, wait=blocking)
+            )
 
     def move_z_to(self, abs_mm: float, blocking: bool = True):
         with self._lock:
-            self._c414.move_to(self._to_native(abs_mm), wait=blocking)
+            if self._closed:
+                self._log.warning("move_z_to ignored: the PI focus stage is closed.")
+                return
+            self._last_z_mm = self._to_squid(self._c414.move_to(self._to_native(abs_mm), wait=blocking))
 
     def get_pos(self) -> Pos:
+        # GUI pollers can fire after shutdown closes the connection; serve the last-known Z
+        # then instead of touching the dead handle.
         with self._lock:
-            return Pos(x_mm=0.0, y_mm=0.0, z_mm=self._to_squid(self._c414.get_position_mm()), theta_rad=None)
+            if not self._closed:
+                self._last_z_mm = self._to_squid(self._c414.get_position_mm())
+            return Pos(x_mm=0.0, y_mm=0.0, z_mm=self._last_z_mm, theta_rad=None)
 
     def get_state(self) -> StageStage:
         # If an async home holds the lock, report busy without blocking on it.
         if self._busy:
             return StageStage(busy=True)
         with self._lock:
-            return StageStage(busy=self._c414.is_moving())
+            return StageStage(busy=False if self._closed else self._c414.is_moving())
 
     def is_referenced(self) -> bool:
         with self._lock:

--- a/software/squid/stage/pi.py
+++ b/software/squid/stage/pi.py
@@ -599,23 +599,17 @@ class C414FocusStage:
 
 
 def _resolve_port_by_sn(serialnum) -> str:
-    """Resolve an FTDI/USB serial number (e.g. '1UETR6I!') to a serial device path.
+    """Resolve the C-414's FTDI serial number (e.g. '1UETR6I!') to a serial device path."""
+    import squid.stage.utils  # lazy: avoids import-order coupling with control._def
 
-    Compares as strings: the config reader may coerce an all-digit serial to int, so we
-    normalise both sides. (A leading-zero numeric serial loses its zero at config-read time
-    and cannot be recovered here -- keep such serials quoted, or use PI_FOCUS_SERIAL_PORT.)
-    """
-    import serial.tools.list_ports
-
-    target = str(serialnum)
-    matches = [p.device for p in serial.tools.list_ports.comports() if str(p.serial_number) == target]
-    if not matches:
-        raise RuntimeError(
-            f"No serial port with serial_number={serialnum!r}. On Linux the C-414's custom-VID "
-            f"FTDI needs the ftdi_sio bind rule (98-pi-c414-bind.rules) installed so /dev/ttyUSB* "
-            f"appears; verify it is present and the controller is powered."
-        )
-    return matches[0]
+    return squid.stage.utils.resolve_serial_port_by_sn(
+        serialnum,
+        missing_hint=(
+            "On Linux the C-414's custom-VID FTDI needs the ftdi_sio bind rule "
+            "(98-pi-c414-bind.rules) installed so /dev/ttyUSB* appears; verify it is present "
+            "and the controller is powered."
+        ),
+    )
 
 
 def connect_pi_focus_stage(

--- a/software/squid/stage/pi.py
+++ b/software/squid/stage/pi.py
@@ -4,8 +4,8 @@ Squid stage support for the PI V-308 voice-coil focus drive on a C-414 controlle
 Provides (1) ``C414FocusStage``, a GCS-2.0 driver over a serial (FTDI VCP) link via
 pipython's pure-Python PISerial gateway (no proprietary PI GCS DLL required), with
 ``pipython`` imported lazily so this module imports fine without it; (2) ``_SimulatedC414``,
-a pure-Python stand-in for hardware-free / CI use; and (3) two ``squid.abc.AbstractStage``
-adapters -- ``PIFocusStage`` (Z-only) and ``CombinedStage`` (XY delegate + V-308 Z).
+a pure-Python stand-in for hardware-free / CI use; and (3) the ``squid.abc.AbstractStage``
+adapter ``PIFocusStage`` (Z-only; pair with an XY stage via ``squid.stage.composite.CombinedStage``).
 
 Z is pure pass-through mm: the controller's native absolute mm is Squid's Z mm, with no sign
 flip or offset and no use of ``Z_AXIS.MOVEMENT_SIGN`` (that is a Cephla-stepper calibration).
@@ -288,107 +288,6 @@ class PIFocusStage(AbstractStage):
 
     def _no_xy(self, name: str):
         self._log.warning(f"{name} ignored: PIFocusStage is a Z-only focus drive (pair via CombinedStage).")
-
-
-class CombinedStage(AbstractStage):
-    """AbstractStage routing X / Y / theta to xy_stage and Z to z_stage (an external Z-only focus stage, e.g. the V-308 or the ASI LS50)."""
-
-    def __init__(self, xy_stage: AbstractStage, z_stage: AbstractStage, stage_config: Optional[StageConfig] = None):
-        super().__init__(stage_config or xy_stage.get_config())
-        self._xy = xy_stage
-        self._z = z_stage
-        self._scanning_position_z_mm = None  # set/read by squid.stage.utils loading/scanning flow
-
-        # The GUI snaps Z step sizes through get_config().Z_AXIS (AutoFocus / multipoint) and via
-        # z_mm_to_usteps (navigation). Present a Z axis whose resolution is the Z stage's own
-        # (continuous ~10 nm) grid instead of the wrapped XY stepper grid, so Z-stack/autofocus
-        # steps are not snapped to the coarse stepper microstep grid. Only the resolution fields
-        # are overridden; range/speed/sign are preserved.
-        z_usteps_per_mm = abs(self._z.z_mm_to_usteps(1.0)) if hasattr(self._z, "z_mm_to_usteps") else 0.0
-        if z_usteps_per_mm:
-            fine_z = self._config.Z_AXIS.model_copy(
-                update={"SCREW_PITCH": 1.0, "MICROSTEPS_PER_STEP": 1, "FULL_STEPS_PER_REV": float(z_usteps_per_mm)}
-            )
-            self._config = self._config.model_copy(update={"Z_AXIS": fine_z})
-
-    def move_x(self, rel_mm: float, blocking: bool = True):
-        self._xy.move_x(rel_mm, blocking)
-
-    def move_y(self, rel_mm: float, blocking: bool = True):
-        self._xy.move_y(rel_mm, blocking)
-
-    def move_z(self, rel_mm: float, blocking: bool = True):
-        self._z.move_z(rel_mm, blocking)
-
-    def move_x_to(self, abs_mm: float, blocking: bool = True):
-        self._xy.move_x_to(abs_mm, blocking)
-
-    def move_y_to(self, abs_mm: float, blocking: bool = True):
-        self._xy.move_y_to(abs_mm, blocking)
-
-    def move_z_to(self, abs_mm: float, blocking: bool = True):
-        self._z.move_z_to(abs_mm, blocking)
-
-    def get_pos(self) -> Pos:
-        xy, z = self._xy.get_pos(), self._z.get_pos()
-        return Pos(x_mm=xy.x_mm, y_mm=xy.y_mm, z_mm=z.z_mm, theta_rad=xy.theta_rad)
-
-    def get_state(self) -> StageStage:
-        return StageStage(busy=self._xy.get_state().busy or self._z.get_state().busy)
-
-    def is_referenced(self) -> bool:
-        return self._z.is_referenced()
-
-    def home(self, x: bool, y: bool, z: bool, theta: bool, blocking: bool = True):
-        xy_requested = x or y or theta
-        if z:
-            # Z must finish retracting before any XY sweep (e.g. the V-308 voice coil is not self-locking).
-            self._z.home(False, False, True, False, blocking or xy_requested)
-        if xy_requested:
-            self._xy.home(x, y, False, theta, blocking)
-
-    def zero(self, x: bool, y: bool, z: bool, theta: bool, blocking: bool = True):
-        if x or y or theta:
-            self._xy.zero(x, y, False, theta, blocking)
-        if z:
-            self._z.zero(False, False, True, False, blocking)
-
-    def set_limits(
-        self,
-        x_pos_mm: Optional[float] = None,
-        x_neg_mm: Optional[float] = None,
-        y_pos_mm: Optional[float] = None,
-        y_neg_mm: Optional[float] = None,
-        z_pos_mm: Optional[float] = None,
-        z_neg_mm: Optional[float] = None,
-        theta_pos_rad: Optional[float] = None,
-        theta_neg_rad: Optional[float] = None,
-    ):
-        self._xy.set_limits(
-            x_pos_mm=x_pos_mm,
-            x_neg_mm=x_neg_mm,
-            y_pos_mm=y_pos_mm,
-            y_neg_mm=y_neg_mm,
-            theta_pos_rad=theta_pos_rad,
-            theta_neg_rad=theta_neg_rad,
-        )
-        self._z.set_limits(z_pos_mm=z_pos_mm, z_neg_mm=z_neg_mm)
-
-    # The GUI (NavigationWidget.set_deltaX/Y/Z) calls these stepper-style helpers on the stage, so
-    # the wrapper must expose them. X/Y come from the wrapped XY stage; Z comes from the external
-    # Z stage's own grid, not the XY stepper grid.
-    def x_mm_to_usteps(self, mm: float):
-        return self._xy.x_mm_to_usteps(mm)
-
-    def y_mm_to_usteps(self, mm: float):
-        return self._xy.y_mm_to_usteps(mm)
-
-    def z_mm_to_usteps(self, mm: float):
-        return self._z.z_mm_to_usteps(mm)
-
-    def close(self):
-        self._z.close()  # the external Z stage's serial handle; Cephla/Prior XY close() is a no-op
-        self._xy.close()
 
 
 class C414FocusStage:

--- a/software/squid/stage/utils.py
+++ b/software/squid/stage/utils.py
@@ -158,8 +158,8 @@ def move_to_scanning_position(
 
 
 def move_z_axis_to_safety_position(stage: AbstractStage):
-    if _def.USE_PI_FOCUS_STAGE:
-        # The V-308 has no Z_HOME_SAFETY_POINT concept; its retracted position is the safe Z.
+    if _def.uses_external_z_stage():
+        # External Z focus stages have no Z_HOME_SAFETY_POINT concept; near-retracted is the safe Z.
         stage.move_z_to(_def.OBJECTIVE_RETRACTED_POS_MM)
     else:
         stage.move_z_to(int(_def.Z_HOME_SAFETY_POINT) / 1000.0)

--- a/software/squid/stage/utils.py
+++ b/software/squid/stage/utils.py
@@ -183,3 +183,13 @@ def resolve_serial_port_by_sn(serialnum, missing_hint: str = "") -> str:
             message = f"{message} {missing_hint}"
         raise RuntimeError(message)
     return matches[0]
+
+
+def resolve_port(serial_port, serial_number, missing_hint: str = "", unset_message: str = "") -> str:
+    """The standard port-selection ladder: explicit port wins, else resolve by serial number,
+    else raise ``unset_message`` (which should name the config flags to set)."""
+    if serial_port:
+        return serial_port
+    if serial_number:
+        return resolve_serial_port_by_sn(serial_number, missing_hint=missing_hint)
+    raise RuntimeError(unset_message or "No serial port or serial number configured.")

--- a/software/squid/stage/utils.py
+++ b/software/squid/stage/utils.py
@@ -163,3 +163,23 @@ def move_z_axis_to_safety_position(stage: AbstractStage):
         stage.move_z_to(_def.OBJECTIVE_RETRACTED_POS_MM)
     else:
         stage.move_z_to(int(_def.Z_HOME_SAFETY_POINT) / 1000.0)
+
+
+def resolve_serial_port_by_sn(serialnum, missing_hint: str = "") -> str:
+    """Resolve a USB serial number to a serial device path via pyserial's port list.
+
+    Compares as strings: the config reader may coerce an all-digit serial to int, so both
+    sides are normalised. (A leading-zero numeric serial loses its zero at config-read time
+    and cannot be recovered here -- keep such serials quoted, or use the explicit-port flag.)
+    missing_hint is appended to the not-found error for vendor-specific guidance.
+    """
+    import serial.tools.list_ports  # lazy: real-hardware path only
+
+    target = str(serialnum)
+    matches = [p.device for p in serial.tools.list_ports.comports() if str(p.serial_number) == target]
+    if not matches:
+        message = f"No serial port with serial_number={serialnum!r}."
+        if missing_hint:
+            message = f"{message} {missing_hint}"
+        raise RuntimeError(message)
+    return matches[0]

--- a/software/tests/control/test_asi_objective_turret.py
+++ b/software/tests/control/test_asi_objective_turret.py
@@ -214,7 +214,6 @@ def _build_asi_scope(monkeypatch, skip_init):
     import control.microscope
 
     monkeypatch.setattr(control._def, "USE_ASI_Z_STAGE", True, raising=False)
-    monkeypatch.setattr(control._def, "SIMULATE_ASI_Z_STAGE", True, raising=False)
     # find-zero (default on) derives its overdrive from the physical travel; a configured
     # machine always sets this.
     monkeypatch.setattr(control._def, "ASI_Z_TRAVEL_MM", 50.0, raising=False)

--- a/software/tests/control/test_asi_objective_turret.py
+++ b/software/tests/control/test_asi_objective_turret.py
@@ -1,0 +1,238 @@
+import pytest
+
+import control._def
+import control.asi_objective_turret as aot
+from squid.stage.asi import MS2000Serial
+from tests.tools import FakeSerialConn as _FakeSerialConn, FakeZStage as FakeStage
+
+POSITIONS = {"2x": 1, "4x": 2, "10x": 3, "20x": 4, "40x": 5, "60x": 6}
+
+
+def _shared_turret(replies, stage=None, positions=POSITIONS, **kwargs):
+    """Turret on a shared (not owned) scripted transport; first reply feeds the ctor W F probe."""
+    conn = _FakeSerialConn(replies=replies)
+    turret = aot.ASIObjectiveTurret(shared_serial=MS2000Serial(conn), positions=positions, stage=stage, **kwargs)
+    return turret, conn
+
+
+# --- simulation ---------------------------------------------------------------
+
+
+def test_sim_init_open():
+    sim = aot.ASIObjectiveTurretSimulation(positions=POSITIONS)
+    assert sim.is_open is True
+    assert sim.current_objective is None
+    assert sim.current_slot is None  # unknown until commanded
+
+
+@pytest.mark.parametrize("name", sorted(POSITIONS))
+def test_sim_move_to_each_known_objective(name):
+    sim = aot.ASIObjectiveTurretSimulation(positions=POSITIONS)
+    sim.move_to_objective(name)
+    assert sim.current_objective == name
+    assert sim.current_slot == POSITIONS[name]
+
+
+def test_sim_unknown_objective_raises_key_error():
+    sim = aot.ASIObjectiveTurretSimulation(positions=POSITIONS)
+    with pytest.raises(KeyError, match="Valid names"):
+        sim.move_to_objective("95x")
+
+
+def test_sim_home_is_motionless(monkeypatch):
+    # The ASI turret has no homing; home() must not move the turret or Z.
+    monkeypatch.setattr(control._def, "HOMING_ENABLED_Z", True, raising=False)
+    stage = FakeStage()
+    sim = aot.ASIObjectiveTurretSimulation(positions=POSITIONS, stage=stage)
+    sim.move_to_objective("10x")
+    sim.home()
+    assert sim.current_objective is None  # tracked name cleared
+    assert sim.current_slot == 3  # slot unchanged: no rotation happened
+    assert stage.z_moves == [control._def.OBJECTIVE_RETRACTED_POS_MM, 3.5]  # only the earlier move's dance
+
+
+def test_sim_retract_and_restore_z(monkeypatch):
+    monkeypatch.setattr(control._def, "HOMING_ENABLED_Z", True, raising=False)
+    stage = FakeStage(z_mm=3.5)
+    sim = aot.ASIObjectiveTurretSimulation(positions=POSITIONS, stage=stage)
+    sim.move_to_objective("4x")
+    assert stage.z_moves == [control._def.OBJECTIVE_RETRACTED_POS_MM, 3.5]
+
+
+def test_sim_skips_z_without_stage(monkeypatch):
+    monkeypatch.setattr(control._def, "HOMING_ENABLED_Z", True, raising=False)
+    sim = aot.ASIObjectiveTurretSimulation(positions=POSITIONS, stage=None)
+    sim.move_to_objective("4x")  # must not raise
+
+
+def test_sim_skips_z_when_homing_z_disabled(monkeypatch):
+    monkeypatch.setattr(control._def, "HOMING_ENABLED_Z", False, raising=False)
+    stage = FakeStage()
+    sim = aot.ASIObjectiveTurretSimulation(positions=POSITIONS, stage=stage)
+    sim.move_to_objective("4x")
+    assert stage.z_moves == []
+
+
+def test_sim_alias_same_slot_skips_dance(monkeypatch):
+    monkeypatch.setattr(control._def, "HOMING_ENABLED_Z", True, raising=False)
+    stage = FakeStage()
+    positions = {"4x": 1, "4x-phase": 1, "10x": 2}
+    sim = aot.ASIObjectiveTurretSimulation(positions=positions, stage=stage)
+    sim.move_to_objective("4x")
+    moves_after_first = list(stage.z_moves)
+    sim.move_to_objective("4x-phase")  # same slot: tracked-name-only no-op
+    assert sim.current_objective == "4x-phase"
+    assert stage.z_moves == moves_after_first
+
+
+def test_sim_restore_z_false_skips_restore(monkeypatch):
+    monkeypatch.setattr(control._def, "HOMING_ENABLED_Z", True, raising=False)
+    stage = FakeStage()
+    sim = aot.ASIObjectiveTurretSimulation(positions=POSITIONS, stage=stage)
+    sim.move_to_objective("4x", restore_z=False)
+    assert stage.z_moves == [control._def.OBJECTIVE_RETRACTED_POS_MM]
+
+
+def test_sim_ops_after_close_raise():
+    sim = aot.ASIObjectiveTurretSimulation(positions=POSITIONS)
+    sim.close()
+    with pytest.raises(RuntimeError):
+        sim.move_to_objective("4x")
+
+
+def test_sim_close_idempotent_and_context_manager():
+    with aot.ASIObjectiveTurretSimulation(positions=POSITIONS) as sim:
+        assert sim.is_open
+    assert not sim.is_open
+    sim.close()  # second close must not raise
+
+
+def test_invalid_slot_positions_raise():
+    for bad in ({"4x": 0}, {"4x": 7}, {"4x": "one"}):
+        with pytest.raises(ValueError):
+            aot.ASIObjectiveTurretSimulation(positions=bad)
+        with pytest.raises(ValueError):
+            aot.ASIObjectiveTurret(shared_serial=MS2000Serial(_FakeSerialConn()), positions=bad)
+
+
+# --- real controller over a scripted transport --------------------------------
+
+
+def test_move_frames_raw_slot_command():
+    # Slot index is sent RAW ('M F=3'), not scaled by the 0.1 um unit factor.
+    turret, conn = _shared_turret([b":A 1\r\n", b":A\r\n", b"N\r\n", b":A 3\r\n"])
+    assert turret.current_slot == 1  # seeded from the ctor W F probe
+    turret.move_to_objective("10x")
+    assert conn.written == [b"W F\r", b"M F=3\r", b"/\r", b"W F\r"]
+    assert turret.current_objective == "10x"
+    assert turret.current_slot == 3
+
+
+def test_wait_idle_polls_global_busy():
+    turret, conn = _shared_turret([b":A 1\r\n", b":A\r\n", b"B\r\n", b"B\r\n", b"N\r\n", b":A 2\r\n"])
+    turret.move_to_objective("4x")
+    assert conn.written.count(b"/\r") == 3
+
+
+def test_move_timeout_raises_and_still_restores_z(monkeypatch):
+    monkeypatch.setattr(control._def, "HOMING_ENABLED_Z", True, raising=False)
+    stage = FakeStage(z_mm=2.0)
+    conn = _FakeSerialConn(replies=[b":A 1\r\n"], default=b"B\r\n")  # never idle
+    turret = aot.ASIObjectiveTurret(shared_serial=MS2000Serial(conn), positions=POSITIONS, stage=stage)
+    with pytest.raises(RuntimeError, match="idle"):
+        turret.move_to_objective("4x", timeout_s=0.12)
+    assert stage.z_moves == [control._def.OBJECTIVE_RETRACTED_POS_MM, 2.0]  # finally restored
+
+
+def test_probe_seed_short_circuits_move():
+    # Ctor W F said slot 4; moving to the slot-4 objective must not rotate.
+    turret, conn = _shared_turret([b":A 4\r\n"])
+    turret.move_to_objective("20x")
+    assert conn.written == [b"W F\r"]  # no M command
+    assert turret.current_objective == "20x"
+
+
+def test_probe_garbage_means_unknown_slot():
+    turret, conn = _shared_turret([b":N-1\r\n", b":A\r\n", b"N\r\n"])
+    assert turret.current_slot is None
+    turret.move_to_objective("2x")  # unknown never short-circuits: rotation commanded
+    assert b"M F=1\r" in conn.written
+
+
+def test_unknown_objective_keyerror_real():
+    turret, _ = _shared_turret([b":A 1\r\n"])
+    with pytest.raises(KeyError, match="Valid names"):
+        turret.move_to_objective("95x")
+
+
+def test_shared_serial_not_closed_on_close():
+    turret, conn = _shared_turret([b":A 1\r\n"])
+    assert turret.owns_serial is False
+    turret.close()
+    assert conn.closed is False  # the Z stage owns the shared transport
+
+
+def test_owned_serial_closed_on_close(monkeypatch):
+    conn = _FakeSerialConn(replies=[b":A 1\r\n"])
+    monkeypatch.setattr(MS2000Serial, "open", classmethod(lambda cls, *a, **k: MS2000Serial(conn)))
+    turret = aot.ASIObjectiveTurret(serial_port="/dev/FAKE", positions=POSITIONS)
+    assert turret.owns_serial is True
+    turret.close()
+    assert conn.closed is True
+
+
+def test_owned_ctor_probe_failure_closes_serial(monkeypatch):
+    conn = _FakeSerialConn(replies=[])  # dead air, both probe attempts
+    monkeypatch.setattr(MS2000Serial, "open", classmethod(lambda cls, *a, **k: MS2000Serial(conn)))
+    with pytest.raises(RuntimeError):
+        aot.ASIObjectiveTurret(serial_port="/dev/FAKE", positions=POSITIONS)
+    assert conn.closed is True  # no leaked handle
+
+
+def test_home_is_motionless_real():
+    turret, conn = _shared_turret([b":A 2\r\n", b":A 2\r\n"])
+    turret.home()
+    assert all(not w.startswith(b"M ") for w in conn.written)  # W F probes only, no motion
+    assert turret.current_slot == 2
+
+
+def test_error_ack_on_move_raises():
+    turret, _ = _shared_turret([b":A 1\r\n", b":N-4\r\n"])
+    with pytest.raises(RuntimeError, match="N-4"):
+        turret.move_to_objective("4x")
+
+
+def test_turret_without_port_or_sn_raises():
+    with pytest.raises(RuntimeError, match="ASI_OBJECTIVE_TURRET"):
+        aot.ASIObjectiveTurret(positions=POSITIONS)
+
+
+# --- simulated end-to-end through Microscope -----------------------------------
+
+
+def _build_asi_scope(monkeypatch, skip_init):
+    import control.microscope
+
+    monkeypatch.setattr(control._def, "USE_ASI_Z_STAGE", True, raising=False)
+    monkeypatch.setattr(control._def, "SIMULATE_ASI_Z_STAGE", True, raising=False)
+    # find-zero (default on) derives its overdrive from the physical travel; a configured
+    # machine always sets this.
+    monkeypatch.setattr(control._def, "ASI_Z_TRAVEL_MM", 50.0, raising=False)
+    monkeypatch.setattr(control._def, "USE_ASI_OBJECTIVE_TURRET", True, raising=False)
+    monkeypatch.setattr(control._def, "SIMULATE_OBJECTIVE_CHANGER", True, raising=False)
+    return control.microscope.Microscope.build_from_global_config(simulated=True, skip_init=skip_init)
+
+
+def test_microscope_builds_asi_turret_simulated(monkeypatch):
+    scope = _build_asi_scope(monkeypatch, skip_init=True)
+    changer = scope.addons.objective_changer
+    assert isinstance(changer, aot.ASIObjectiveTurretSimulation)
+    changer.move_to_objective(control._def.DEFAULT_OBJECTIVE)
+    assert changer.current_objective == control._def.DEFAULT_OBJECTIVE
+    scope.close()
+
+
+def test_microscope_startup_selects_default_objective(monkeypatch):
+    scope = _build_asi_scope(monkeypatch, skip_init=False)
+    assert scope.addons.objective_changer.current_objective == control._def.DEFAULT_OBJECTIVE
+    scope.close()

--- a/software/tests/control/test_objective_changer_2_pos_controller.py
+++ b/software/tests/control/test_objective_changer_2_pos_controller.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from unittest.mock import Mock
+
 import control._def
 from control.objective_changer_2_pos_controller import (
+    ObjectiveChanger2PosController,
     ObjectiveChanger2PosController_Simulation,
 )
 
@@ -56,3 +59,22 @@ def test_move_to_objective_unknown_raises(monkeypatch):
     sim = ObjectiveChanger2PosController_Simulation(sn="SIM", stage=FakeStage())
     with pytest.raises(KeyError):
         sim.move_to_objective("999x")
+
+
+def _controller_with_fake_xeryon() -> ObjectiveChanger2PosController:
+    # __init__ opens a serial port, so bypass it and inject only what close() touches.
+    changer = ObjectiveChanger2PosController.__new__(ObjectiveChanger2PosController)
+    changer.controller = Mock()
+    return changer
+
+
+def test_close_stops_the_xeryon_controller():
+    changer = _controller_with_fake_xeryon()
+    changer.close()
+    changer.controller.stop.assert_called_once()
+
+
+def test_close_swallows_stop_errors():
+    changer = _controller_with_fake_xeryon()
+    changer.controller.stop.side_effect = RuntimeError("port already gone")
+    changer.close()  # must not raise during teardown

--- a/software/tests/control/test_objective_changer_config.py
+++ b/software/tests/control/test_objective_changer_config.py
@@ -25,3 +25,27 @@ def test_mutual_exclusion_allows_neither():
 def test_objective_turret_positions_shape():
     assert len(OBJECTIVE_TURRET_POSITIONS) == 4
     assert sorted(OBJECTIVE_TURRET_POSITIONS.values()) == [1, 2, 3, 4]
+
+
+@pytest.mark.parametrize(
+    "xeryon,turret,asi",
+    [(True, True, False), (True, False, True), (False, True, True), (True, True, True)],
+)
+def test_mutual_exclusion_any_two_of_three_raise(xeryon, turret, asi):
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        _validate_objective_changer_flags(xeryon, turret, asi)
+
+
+def test_mutual_exclusion_allows_asi_turret_only():
+    _validate_objective_changer_flags(use_xeryon=False, use_turret=False, use_asi_turret=True)
+
+
+def test_asi_turret_positions_shape():
+    from control._def import ASI_OBJECTIVE_TURRET_POSITIONS, OBJECTIVES, DEFAULT_OBJECTIVE
+
+    assert len(ASI_OBJECTIVE_TURRET_POSITIONS) == 6
+    assert sorted(ASI_OBJECTIVE_TURRET_POSITIONS.values()) == [1, 2, 3, 4, 5, 6]
+    # Keys must be real objective names so the GUI dropdown -> move_to_objective flow works,
+    # and the default dict must cover the startup DEFAULT_OBJECTIVE fallback.
+    assert set(ASI_OBJECTIVE_TURRET_POSITIONS) <= set(OBJECTIVES)
+    assert "20x" in ASI_OBJECTIVE_TURRET_POSITIONS

--- a/software/tests/control/test_objective_turret_controller.py
+++ b/software/tests/control/test_objective_turret_controller.py
@@ -6,6 +6,7 @@ import pytest
 
 import control._def
 import control.objective_turret_controller as otc
+from tests.tools import FakeZStage as FakeStage
 from control._def import OBJECTIVE_TURRET_POSITIONS, OBJECTIVE_RETRACTED_POS_MM
 from control.objective_turret_controller import (
     ObjectiveTurret4PosController,
@@ -18,26 +19,6 @@ from control.objective_turret_controller import (
     REG_STATUS_WORD,
     REG_TARGET_POSITION,
 )
-
-
-class FakeStage:
-    """Records move_z_to calls and reports a preset Z position."""
-
-    def __init__(self, z_mm: float = 3.5):
-        self._z_mm = z_mm
-        self.z_moves: list[float] = []
-
-    def move_z_to(self, abs_mm: float, blocking: bool = True):
-        self.z_moves.append(abs_mm)
-        self._z_mm = abs_mm
-
-    def get_pos(self):
-        class _Pos:
-            pass
-
-        p = _Pos()
-        p.z_mm = self._z_mm
-        return p
 
 
 def _make_sim(stage=None):

--- a/software/tests/squid/test_stage.py
+++ b/software/tests/squid/test_stage.py
@@ -789,3 +789,15 @@ def test_pi_focus_pollers_safe_after_close():
     assert stage.get_state().busy is False
     stage.move_z_to(2.0)
     stage.move_z(0.5)
+
+
+def test_asi_z_software_limits_can_be_disabled():
+    # The LS50 frame is power-on-relative, so fixed squid-frame limits fence arbitrary
+    # positions; apply_software_limits=False makes set_limits a no-op (the coarse
+    # ASI_Z_TRAVEL_MM fence still applies at connect).
+    sim = _sim_ls50()
+    stage = squid.stage.asi.ASIZStage(sim, stage_config=squid.config.get_stage_config(), apply_software_limits=False)
+    stage.set_limits(z_pos_mm=6.0, z_neg_mm=0.5)
+    assert sim.hardware_limits_mm() == (None, None)  # backend untouched
+    stage.move_z_to(-3.0)  # outside the ignored fence: passes through
+    assert abs(stage.get_pos().z_mm - (-3.0)) < 1e-9

--- a/software/tests/squid/test_stage.py
+++ b/software/tests/squid/test_stage.py
@@ -753,3 +753,39 @@ def test_ls50_initialize_retries_once():
     ctrl = _ls50_ctrl(conn)
     ctrl.initialize()  # first W Z gets dead air, retry parses
     assert conn.written == [b"W Z\r", b"W Z\r"]
+
+
+def test_asi_z_pollers_safe_after_close():
+    # GUI position/status pollers can fire after shutdown closes the port; they must get
+    # the last-known position and idle status back, not a serial error.
+    sim = _sim_ls50()
+    stage = squid.stage.asi.ASIZStage(sim, stage_config=squid.config.get_stage_config())
+    stage.move_z_to(1.25)
+    stage.close()
+
+    def _boom():
+        raise RuntimeError("port is closed")
+
+    sim.get_position_mm = _boom
+    sim.is_moving = _boom
+    assert abs(stage.get_pos().z_mm - 1.25) < 1e-9  # cached, no backend I/O
+    assert stage.get_state().busy is False
+    stage.move_z_to(2.0)  # warn no-op, must not raise
+    stage.move_z(0.5)
+
+
+def test_pi_focus_pollers_safe_after_close():
+    sim = _make_referenced_sim()
+    stage = squid.stage.pi.PIFocusStage(sim, stage_config=squid.config.get_stage_config())
+    stage.move_z_to(1.25)
+    stage.close()
+
+    def _boom():
+        raise RuntimeError("connection closed")
+
+    sim.get_position_mm = _boom
+    sim.is_moving = _boom
+    assert abs(stage.get_pos().z_mm - 1.25) < 1e-9
+    assert stage.get_state().busy is False
+    stage.move_z_to(2.0)
+    stage.move_z(0.5)

--- a/software/tests/squid/test_stage.py
+++ b/software/tests/squid/test_stage.py
@@ -62,10 +62,10 @@ def _sim_pi_stage():
     return squid.stage.pi.PIFocusStage(_make_referenced_sim(), stage_config=squid.config.get_stage_config())
 
 
-def _sim_combined_stage():
-    """Simulated Cephla XY + PI Z composite; returns (combined, xy, z)."""
+def _sim_combined_stage(z_stage=None):
+    """Simulated Cephla XY + Z-only composite (PI Z by default); returns (combined, xy, z)."""
     xy = squid.stage.cephla.CephlaStage(get_test_micro(), squid.config.get_stage_config())
-    z = _sim_pi_stage()
+    z = z_stage if z_stage is not None else _sim_pi_stage()
     combined = squid.stage.pi.CombinedStage(xy_stage=xy, z_stage=z, stage_config=squid.config.get_stage_config())
     return combined, xy, z
 
@@ -444,16 +444,20 @@ def test_ms2000_command_framing_and_error_ack():
         ser.command("M Z=99999999")
 
 
+def _ls50_ctrl(conn):
+    """Real LS50Controller + MS2000Serial over a scripted connection."""
+    ctrl = squid.stage.asi.LS50Controller()
+    ctrl._serial = squid.stage.asi.MS2000Serial(conn)
+    return ctrl
+
+
 def _sim_asi_stage(**kwargs):
     return squid.stage.asi.ASIZStage(_sim_ls50(), stage_config=squid.config.get_stage_config(), **kwargs)
 
 
 def _sim_asi_combined():
     """Simulated Cephla XY + ASI LS50 Z via the reused pi.CombinedStage; returns (combined, xy, z)."""
-    xy = squid.stage.cephla.CephlaStage(get_test_micro(), squid.config.get_stage_config())
-    z = _sim_asi_stage(invert_z=True, home_mm=0.0)
-    combined = squid.stage.pi.CombinedStage(xy_stage=xy, z_stage=z, stage_config=squid.config.get_stage_config())
-    return combined, xy, z
+    return _sim_combined_stage(z_stage=_sim_asi_stage(invert_z=True, home_mm=0.0))
 
 
 def test_asi_z_passthrough_no_sign():
@@ -498,9 +502,7 @@ def test_asi_z_home_noop_without_target():
 def test_asi_z_home_moves_to_target():
     # Default wiring: home = retract to squid 0 (native 0, the power-on/retracted end).
     sim = _sim_ls50()
-    stage = squid.stage.asi.ASIZStage(
-        sim, stage_config=squid.config.get_stage_config(), home_mm=0.0, invert_z=True
-    )
+    stage = squid.stage.asi.ASIZStage(sim, stage_config=squid.config.get_stage_config(), home_mm=0.0, invert_z=True)
     stage.move_z_to(2.0)
     stage.home(False, False, True, False, blocking=True)
     assert abs(stage.get_pos().z_mm - 0.0) < 1e-9
@@ -538,7 +540,6 @@ def test_asi_z_xy_noop():
 def test_asi_z_grid_is_tenth_micron():
     stage = _sim_asi_stage()
     assert stage.z_mm_to_usteps(1.0) == 10000
-    assert abs(1.0 / stage.z_mm_to_usteps(1.0) - 1e-4) < 1e-12
 
 
 def test_asi_combined_stage_routes_axes():
@@ -577,8 +578,7 @@ def test_asi_z_home_after_close_is_noop():
 def test_ls50_controller_framing_and_units():
     # Real LS50Controller + MS2000Serial over a scripted connection: 0.1 um units on M/W.
     conn = _FakeSerialConn(replies=[b":A\r\n", b":A -12345\r\n"])
-    ctrl = squid.stage.asi.LS50Controller()
-    ctrl._serial = squid.stage.asi.MS2000Serial(conn)
+    ctrl = _ls50_ctrl(conn)
     assert ctrl.move_to(0.1234, wait=False) == 0.1234
     assert conn.written == [b"M Z=1234\r"]
     assert abs(ctrl.get_position_mm() - (-1.2345)) < 1e-9  # ':A -12345' -> -1.2345 mm
@@ -587,15 +587,13 @@ def test_ls50_controller_framing_and_units():
 def test_ls50_wait_idle_polls_status():
     # wait=True polls '/' until N; a stage that never idles raises RuntimeError on timeout.
     conn = _FakeSerialConn(replies=[b":A\r\n", b"B\r\n", b"B\r\n", b"N\r\n", b":A 5000\r\n"])
-    ctrl = squid.stage.asi.LS50Controller()
-    ctrl._serial = squid.stage.asi.MS2000Serial(conn)
+    ctrl = _ls50_ctrl(conn)
     assert abs(ctrl.move_to(0.5, wait=True) - 0.5) < 1e-9
     assert conn.written[0] == b"M Z=5000\r"
     assert conn.written.count(b"/\r") == 3
 
     stuck = _FakeSerialConn(replies=[b":A\r\n"], default=b"B\r\n")
-    ctrl2 = squid.stage.asi.LS50Controller()
-    ctrl2._serial = squid.stage.asi.MS2000Serial(stuck)
+    ctrl2 = _ls50_ctrl(stuck)
     with pytest.raises(RuntimeError, match="idle"):
         ctrl2.move_to(0.5, wait=True, timeout=0.12)
 
@@ -603,8 +601,7 @@ def test_ls50_wait_idle_polls_status():
 def test_ls50_stop_tolerates_halt_ack():
     # HALT ('\\') acks with ':N-21' on the MS-2000; stop() must not raise on it.
     conn = _FakeSerialConn(replies=[b":N-21\r\n"])
-    ctrl = squid.stage.asi.LS50Controller()
-    ctrl._serial = squid.stage.asi.MS2000Serial(conn)
+    ctrl = _ls50_ctrl(conn)
     ctrl.stop()
     assert conn.written == [b"\\\r"]
 

--- a/software/tests/squid/test_stage.py
+++ b/software/tests/squid/test_stage.py
@@ -657,7 +657,6 @@ def test_microscope_wraps_asi_z_when_enabled(monkeypatch):
     import control.microscope
 
     monkeypatch.setattr(control._def, "USE_ASI_Z_STAGE", True, raising=False)
-    monkeypatch.setattr(control._def, "SIMULATE_ASI_Z_STAGE", True, raising=False)
     scope = control.microscope.Microscope.build_from_global_config(simulated=True, skip_init=True)
     assert isinstance(scope.stage, squid.stage.composite.CombinedStage)
     scope.stage.move_z_to(0.3)
@@ -672,7 +671,6 @@ def test_microscope_rejects_pi_and_asi_together(monkeypatch):
     monkeypatch.setattr(control._def, "USE_PI_FOCUS_STAGE", True, raising=False)
     monkeypatch.setattr(control._def, "SIMULATE_PI_FOCUS_STAGE", True, raising=False)
     monkeypatch.setattr(control._def, "USE_ASI_Z_STAGE", True, raising=False)
-    monkeypatch.setattr(control._def, "SIMULATE_ASI_Z_STAGE", True, raising=False)
     with pytest.raises(ValueError, match="mutually exclusive"):
         control.microscope.Microscope.build_from_global_config(simulated=True, skip_init=True)
 
@@ -682,7 +680,6 @@ def test_asi_home_xyz_retracts_z_before_xy(monkeypatch):
     import control.microscope
 
     monkeypatch.setattr(control._def, "USE_ASI_Z_STAGE", True, raising=False)
-    monkeypatch.setattr(control._def, "SIMULATE_ASI_Z_STAGE", True, raising=False)
     monkeypatch.setattr(control._def, "HOMING_ENABLED_Z", True, raising=False)
     monkeypatch.setattr(control._def, "HOMING_ENABLED_X", False, raising=False)
     monkeypatch.setattr(control._def, "HOMING_ENABLED_Y", False, raising=False)

--- a/software/tests/squid/test_stage.py
+++ b/software/tests/squid/test_stage.py
@@ -9,6 +9,7 @@ import squid.stage.asi
 import squid.config
 import squid.abc
 from tests.control.test_microcontroller import get_test_micro
+from tests.tools import FakeSerialConn as _FakeSerialConn
 
 
 def test_create_simulated_stages():
@@ -417,24 +418,6 @@ def test_ls50_zero_here_redefines_frame():
     assert sim._zero_count == 1
 
 
-class _FakeSerialConn:
-    """Scripted pyserial-like object: records writes, pops queued replies."""
-
-    def __init__(self, replies=(), default=b""):
-        self.written = []
-        self.replies = list(replies)
-        self.default = default
-
-    def write(self, data):
-        self.written.append(data)
-
-    def read_until(self, expected=b"\n"):
-        return self.replies.pop(0) if self.replies else self.default
-
-    def close(self):
-        pass
-
-
 def test_ms2000_command_framing_and_error_ack():
     conn = _FakeSerialConn(replies=[b":A 0\r\n", b":N-4\r\n"])
     ser = squid.stage.asi.MS2000Serial(conn)
@@ -619,18 +602,6 @@ def test_asi_builder_default_causes_no_motion():
     # Bring-up must not move: no homing/reference/zero happens in the factory by default.
     stage = squid.stage.asi.connect_asi_z_stage(simulated=True, stage_config=squid.config.get_stage_config())
     assert abs(stage.get_pos().z_mm - 0.0) < 1e-9  # still at power-on zero
-
-
-def test_asi_builder_home_on_startup_opt_in():
-    stage = squid.stage.asi.connect_asi_z_stage(
-        simulated=True, home_mm=0.5, home_on_startup=True, stage_config=squid.config.get_stage_config()
-    )
-    assert abs(stage.get_pos().z_mm - 0.5) < 1e-9  # retracted to the home target at bring-up
-    # home_on_startup without a target: warn + no motion, no exception.
-    stage2 = squid.stage.asi.connect_asi_z_stage(
-        simulated=True, home_mm=None, home_on_startup=True, stage_config=squid.config.get_stage_config()
-    )
-    assert abs(stage2.get_pos().z_mm - 0.0) < 1e-9
 
 
 def test_asi_builder_travel_fence():

--- a/software/tests/squid/test_stage.py
+++ b/software/tests/squid/test_stage.py
@@ -5,6 +5,7 @@ import squid.stage.cephla
 import squid.stage.prior
 import squid.stage.utils
 import squid.stage.pi
+import squid.stage.composite
 import squid.stage.asi
 import squid.config
 import squid.abc
@@ -67,7 +68,7 @@ def _sim_combined_stage(z_stage=None):
     """Simulated Cephla XY + Z-only composite (PI Z by default); returns (combined, xy, z)."""
     xy = squid.stage.cephla.CephlaStage(get_test_micro(), squid.config.get_stage_config())
     z = z_stage if z_stage is not None else _sim_pi_stage()
-    combined = squid.stage.pi.CombinedStage(xy_stage=xy, z_stage=z, stage_config=squid.config.get_stage_config())
+    combined = squid.stage.composite.CombinedStage(xy_stage=xy, z_stage=z, stage_config=squid.config.get_stage_config())
     return combined, xy, z
 
 
@@ -168,7 +169,7 @@ def test_microscope_wraps_pi_focus_when_enabled(monkeypatch):
     monkeypatch.setattr(control._def, "USE_PI_FOCUS_STAGE", True, raising=False)
     monkeypatch.setattr(control._def, "SIMULATE_PI_FOCUS_STAGE", True, raising=False)
     scope = control.microscope.Microscope.build_from_global_config(simulated=True, skip_init=True)
-    assert isinstance(scope.stage, squid.stage.pi.CombinedStage)
+    assert isinstance(scope.stage, squid.stage.composite.CombinedStage)
     # skip_init leaves the V-308 unreferenced (reference=...and not skip_init); reference before moving.
     scope.stage.home(x=False, y=False, z=True, theta=False)
     scope.stage.move_z_to(0.3)
@@ -439,7 +440,7 @@ def _sim_asi_stage(**kwargs):
 
 
 def _sim_asi_combined():
-    """Simulated Cephla XY + ASI LS50 Z via the reused pi.CombinedStage; returns (combined, xy, z)."""
+    """Simulated Cephla XY + ASI LS50 Z via squid.stage.composite.CombinedStage; returns (combined, xy, z)."""
     return _sim_combined_stage(z_stage=_sim_asi_stage(invert_z=True, home_mm=0.0))
 
 
@@ -658,7 +659,7 @@ def test_microscope_wraps_asi_z_when_enabled(monkeypatch):
     monkeypatch.setattr(control._def, "USE_ASI_Z_STAGE", True, raising=False)
     monkeypatch.setattr(control._def, "SIMULATE_ASI_Z_STAGE", True, raising=False)
     scope = control.microscope.Microscope.build_from_global_config(simulated=True, skip_init=True)
-    assert isinstance(scope.stage, squid.stage.pi.CombinedStage)
+    assert isinstance(scope.stage, squid.stage.composite.CombinedStage)
     scope.stage.move_z_to(0.3)
     assert abs(scope.stage.get_pos().z_mm - 0.3) < 1e-9
     scope.close()  # exercises Microscope.close() -> CombinedStage.close() -> ASIZStage.close()
@@ -687,7 +688,7 @@ def test_asi_home_xyz_retracts_z_before_xy(monkeypatch):
     monkeypatch.setattr(control._def, "HOMING_ENABLED_Y", False, raising=False)
 
     scope = control.microscope.Microscope.build_from_global_config(simulated=True, skip_init=True)
-    assert isinstance(scope.stage, squid.stage.pi.CombinedStage)  # ASI Z wrapped, not stepper Z
+    assert isinstance(scope.stage, squid.stage.composite.CombinedStage)  # ASI Z wrapped, not stepper Z
     scope.stage.move_z_to(2.0)
     scope.home_xyz()
     # The external-Z branch retracts to the home target (squid 0 = native 0, the retracted
@@ -724,6 +725,24 @@ def test_ls50_initialize_retries_once():
     ctrl = _ls50_ctrl(conn)
     ctrl.initialize()  # first W Z gets dead air, retry parses
     assert conn.written == [b"W Z\r", b"W Z\r"]
+
+
+def test_find_shared_ms2000_walks_combined_stage():
+    # The turret (same MS-2000 controller) reuses the Z stage's transport; the accessor
+    # must return the exact MS2000Serial instance through CombinedStage or a bare ASIZStage.
+    conn = _FakeSerialConn(replies=[b":A 0\r\n"])
+    ctrl = _ls50_ctrl(conn)
+    z = squid.stage.asi.ASIZStage(ctrl, stage_config=squid.config.get_stage_config())
+    assert squid.stage.asi.find_shared_ms2000(z) is ctrl.serial
+    combined, _, _ = _sim_combined_stage(z_stage=z)
+    assert squid.stage.asi.find_shared_ms2000(combined) is ctrl.serial
+
+
+def test_find_shared_ms2000_none_for_simulated_and_foreign():
+    assert squid.stage.asi.find_shared_ms2000(_sim_asi_stage()) is None  # _SimulatedLS50 backend
+    combined, _, _ = _sim_combined_stage()  # PI Z, not ASI
+    assert squid.stage.asi.find_shared_ms2000(combined) is None
+    assert squid.stage.asi.find_shared_ms2000(None) is None
 
 
 def test_asi_z_pollers_safe_after_close():

--- a/software/tests/squid/test_stage.py
+++ b/software/tests/squid/test_stage.py
@@ -723,3 +723,24 @@ def test_asi_home_xyz_retracts_z_before_xy(monkeypatch):
     # end) instead of running the stepper Z-homing path.
     assert abs(scope.stage.get_pos().z_mm - 0.0) < 1e-6
     scope.close()
+
+
+def test_ls50_initialize_failure_mentions_baud():
+    # A dead-air first query (wrong baud/port, unpowered controller) must fail with
+    # actionable bring-up guidance, not a bare parse error.
+    ctrl = _ls50_ctrl(_FakeSerialConn(replies=[b""]))
+    with pytest.raises(RuntimeError, match="baud"):
+        ctrl.initialize()
+
+
+def test_ls50_axis_letter_configurable():
+    # Single-axis MS-2000 builds may label their lone axis X (or other); every command
+    # must use the configured letter.
+    conn = _FakeSerialConn(replies=[b":A\r\n", b":A -100\r\n", b"N\r\n"])
+    ctrl = squid.stage.asi.LS50Controller(axis="X")
+    ctrl._serial = squid.stage.asi.MS2000Serial(conn)
+    ctrl.move_to(0.5, wait=False)
+    assert conn.written == [b"M X=5000\r"]
+    assert abs(ctrl.get_position_mm() - (-0.01)) < 1e-9  # W X parsed
+    assert ctrl.is_moving() is False
+    assert conn.written[1:] == [b"W X\r", b"/\r"]

--- a/software/tests/squid/test_stage.py
+++ b/software/tests/squid/test_stage.py
@@ -852,13 +852,25 @@ def test_ls50_clear_travel_limits_serial():
     assert ctrl.hardware_limits_mm() == (None, None)
 
 
-def test_ls50_clear_travel_limits_falls_back_on_old_firmware():
-    # Firmware without the dash form (pre-~2013) error-acks it; fall back to a wide window.
-    conn = _FakeSerialConn(replies=[b":N-1\r\n", b":A\r\n", b":N-1\r\n", b":A\r\n"])
+def test_ls50_clear_travel_limits_old_firmware_raises_actionably():
+    # Firmware without the dash form (pre-~2013) error-acks it; fail loudly with guidance
+    # rather than inventing a numeric window.
+    conn = _FakeSerialConn(replies=[b":N-1\r\n"])
     ctrl = _ls50_ctrl(conn)
-    ctrl.clear_travel_limits()
-    assert conn.written == [b"SL Z-\r", b"SL Z=-1000\r", b"SU Z-\r", b"SU Z=1000\r"]
-    assert ctrl.hardware_limits_mm() == (None, None)
+    with pytest.raises(RuntimeError, match="restore-defaults"):
+        ctrl.clear_travel_limits()
+
+
+def test_asi_builder_find_zero_requires_travel():
+    # The find-zero overdrive is derived from the configured physical travel; there is no
+    # invented default to fall back on.
+    with pytest.raises(ValueError, match="ASI_Z_TRAVEL_MM"):
+        squid.stage.asi.connect_asi_z_stage(
+            simulated=True,
+            find_zero_on_startup=True,
+            z_travel_mm=0.0,
+            stage_config=squid.config.get_stage_config(),
+        )
 
 
 def test_asi_builder_default_skips_find_zero():

--- a/software/tests/squid/test_stage.py
+++ b/software/tests/squid/test_stage.py
@@ -801,3 +801,58 @@ def test_asi_z_software_limits_can_be_disabled():
     assert sim.hardware_limits_mm() == (None, None)  # backend untouched
     stage.move_z_to(-3.0)  # outside the ignored fence: passes through
     assert abs(stage.get_pos().z_mm - (-3.0)) < 1e-9
+
+
+def test_ls50_zero_at_away_limit():
+    # Startup find-zero: drive past full travel toward the away end (native +; the limit
+    # switch stops the stage), then define native 0 there ('H Z=0').
+    sim = _sim_ls50()
+    sim._pos_mm = -12.3  # powered on mid-travel (frame is power-on-relative)
+    sim._hard_hi_mm = 7.7  # physical away-limit in the power-on frame
+    sim.zero_at_away_limit(overdrive_mm=60.0)
+    assert abs(sim.get_position_mm() - 0.0) < 1e-9  # zero defined at the away end
+    assert abs(sim._hard_hi_mm - 0.0) < 1e-9  # ...which IS the physical stop now
+
+
+def test_ls50_zero_at_away_limit_serial_sequence():
+    # Overdrive move (resolved to absolute), settle, then H Z=0.
+    conn = _FakeSerialConn(replies=[b":A 0\r\n", b":A\r\n", b"B\r\n", b"N\r\n", b":A 500000\r\n", b":A\r\n"])
+    ctrl = _ls50_ctrl(conn)
+    ctrl.zero_at_away_limit(overdrive_mm=60.0)
+    assert conn.written[0] == b"W Z\r"  # current position for the relative resolve
+    assert conn.written[1] == b"M Z=600000\r"  # +60 mm in 0.1 um units, unfenced passthrough
+    assert conn.written[-1] == b"H Z=0\r"  # zero defined at the stop
+
+
+def test_asi_builder_finds_zero_on_startup():
+    stage = squid.stage.asi.connect_asi_z_stage(
+        simulated=True,
+        invert_z=True,
+        z_travel_mm=50.0,
+        find_zero_on_startup=True,
+        stage_config=squid.config.get_stage_config(),
+    )
+    backend = stage._backend
+    assert abs(backend.get_position_mm() - 0.0) < 1e-9  # at the away end, zeroed
+    assert backend._zero_count == 1
+    # The travel fence must be applied AFTER zeroing, in the new frame.
+    assert backend.hardware_limits_mm() == (-50.0, 50.0)
+    assert abs(stage.get_pos().z_mm - 0.0) < 1e-9  # squid frame: 0 = retracted
+
+
+def test_ls50_clear_travel_limits_serial():
+    # Startup must overwrite stale controller-side SL/SU from previous sessions.
+    conn = _FakeSerialConn(replies=[b":A\r\n", b":A\r\n"])
+    ctrl = _ls50_ctrl(conn)
+    ctrl._range_lo, ctrl._range_hi = -6.0, -0.5  # stale software cache too
+    ctrl.clear_travel_limits()
+    assert conn.written == [b"SL Z=-1000\r", b"SU Z=1000\r"]
+    assert ctrl.hardware_limits_mm() == (None, None)
+
+
+def test_asi_builder_default_skips_find_zero():
+    # Library-level default is no surprise motion; the config flag opts startup zeroing in.
+    stage = squid.stage.asi.connect_asi_z_stage(
+        simulated=True, z_travel_mm=50.0, stage_config=squid.config.get_stage_config()
+    )
+    assert stage._backend._zero_count == 0

--- a/software/tests/squid/test_stage.py
+++ b/software/tests/squid/test_stage.py
@@ -744,3 +744,12 @@ def test_ls50_axis_letter_configurable():
     assert abs(ctrl.get_position_mm() - (-0.01)) < 1e-9  # W X parsed
     assert ctrl.is_moving() is False
     assert conn.written[1:] == [b"W X\r", b"/\r"]
+
+
+def test_ls50_initialize_retries_once():
+    # A single lost/garbled first reply (marginal RS-232, adapter settling) must not
+    # fail bring-up: initialize flushes and retries once before raising.
+    conn = _FakeSerialConn(replies=[b"", b":A 250\r\n"])
+    ctrl = _ls50_ctrl(conn)
+    ctrl.initialize()  # first W Z gets dead air, retry parses
+    assert conn.written == [b"W Z\r", b"W Z\r"]

--- a/software/tests/squid/test_stage.py
+++ b/software/tests/squid/test_stage.py
@@ -841,12 +841,23 @@ def test_asi_builder_finds_zero_on_startup():
 
 
 def test_ls50_clear_travel_limits_serial():
-    # Startup must overwrite stale controller-side SL/SU from previous sessions.
+    # Startup must wipe stale controller-side SL/SU: on the MS-2000 they PERSIST across
+    # power cycles (manual: "automatically remembered ... through a power cycle"). Uses
+    # the restore-defaults dash form ('SL Z-').
     conn = _FakeSerialConn(replies=[b":A\r\n", b":A\r\n"])
     ctrl = _ls50_ctrl(conn)
     ctrl._range_lo, ctrl._range_hi = -6.0, -0.5  # stale software cache too
     ctrl.clear_travel_limits()
-    assert conn.written == [b"SL Z=-1000\r", b"SU Z=1000\r"]
+    assert conn.written == [b"SL Z-\r", b"SU Z-\r"]
+    assert ctrl.hardware_limits_mm() == (None, None)
+
+
+def test_ls50_clear_travel_limits_falls_back_on_old_firmware():
+    # Firmware without the dash form (pre-~2013) error-acks it; fall back to a wide window.
+    conn = _FakeSerialConn(replies=[b":N-1\r\n", b":A\r\n", b":N-1\r\n", b":A\r\n"])
+    ctrl = _ls50_ctrl(conn)
+    ctrl.clear_travel_limits()
+    assert conn.written == [b"SL Z-\r", b"SL Z=-1000\r", b"SU Z-\r", b"SU Z=1000\r"]
     assert ctrl.hardware_limits_mm() == (None, None)
 
 

--- a/software/tests/squid/test_stage.py
+++ b/software/tests/squid/test_stage.py
@@ -666,3 +666,63 @@ def test_resolve_serial_port_by_sn_shared(monkeypatch):
     monkeypatch.setattr(serial.tools.list_ports, "comports", lambda: [])
     with pytest.raises(RuntimeError, match="check the LS50 controller"):
         squid.stage.utils.resolve_serial_port_by_sn("12345", missing_hint="check the LS50 controller")
+
+
+def test_uses_external_z_stage_predicate(monkeypatch):
+    import control._def
+
+    monkeypatch.setattr(control._def, "USE_PI_FOCUS_STAGE", False, raising=False)
+    monkeypatch.setattr(control._def, "USE_ASI_Z_STAGE", False, raising=False)
+    assert control._def.uses_external_z_stage() is False
+    # Must read the globals at CALL time (the machine-ini loader overrides them after
+    # definition, and tests monkeypatch them), not capture them at definition time.
+    monkeypatch.setattr(control._def, "USE_ASI_Z_STAGE", True, raising=False)
+    assert control._def.uses_external_z_stage() is True
+    monkeypatch.setattr(control._def, "USE_ASI_Z_STAGE", False, raising=False)
+    monkeypatch.setattr(control._def, "USE_PI_FOCUS_STAGE", True, raising=False)
+    assert control._def.uses_external_z_stage() is True
+
+
+def test_microscope_wraps_asi_z_when_enabled(monkeypatch):
+    import control._def
+    import control.microscope
+
+    monkeypatch.setattr(control._def, "USE_ASI_Z_STAGE", True, raising=False)
+    monkeypatch.setattr(control._def, "SIMULATE_ASI_Z_STAGE", True, raising=False)
+    scope = control.microscope.Microscope.build_from_global_config(simulated=True, skip_init=True)
+    assert isinstance(scope.stage, squid.stage.pi.CombinedStage)
+    scope.stage.move_z_to(0.3)
+    assert abs(scope.stage.get_pos().z_mm - 0.3) < 1e-9
+    scope.close()  # exercises Microscope.close() -> CombinedStage.close() -> ASIZStage.close()
+
+
+def test_microscope_rejects_pi_and_asi_together(monkeypatch):
+    import control._def
+    import control.microscope
+
+    monkeypatch.setattr(control._def, "USE_PI_FOCUS_STAGE", True, raising=False)
+    monkeypatch.setattr(control._def, "SIMULATE_PI_FOCUS_STAGE", True, raising=False)
+    monkeypatch.setattr(control._def, "USE_ASI_Z_STAGE", True, raising=False)
+    monkeypatch.setattr(control._def, "SIMULATE_ASI_Z_STAGE", True, raising=False)
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        control.microscope.Microscope.build_from_global_config(simulated=True, skip_init=True)
+
+
+def test_asi_home_xyz_retracts_z_before_xy(monkeypatch):
+    import control._def
+    import control.microscope
+
+    monkeypatch.setattr(control._def, "USE_ASI_Z_STAGE", True, raising=False)
+    monkeypatch.setattr(control._def, "SIMULATE_ASI_Z_STAGE", True, raising=False)
+    monkeypatch.setattr(control._def, "HOMING_ENABLED_Z", True, raising=False)
+    monkeypatch.setattr(control._def, "HOMING_ENABLED_X", False, raising=False)
+    monkeypatch.setattr(control._def, "HOMING_ENABLED_Y", False, raising=False)
+
+    scope = control.microscope.Microscope.build_from_global_config(simulated=True, skip_init=True)
+    assert isinstance(scope.stage, squid.stage.pi.CombinedStage)  # ASI Z wrapped, not stepper Z
+    scope.stage.move_z_to(2.0)
+    scope.home_xyz()
+    # The external-Z branch retracts to the home target (squid 0 = native 0, the retracted
+    # end) instead of running the stepper Z-homing path.
+    assert abs(scope.stage.get_pos().z_mm - 0.0) < 1e-6
+    scope.close()

--- a/software/tests/squid/test_stage.py
+++ b/software/tests/squid/test_stage.py
@@ -5,6 +5,7 @@ import squid.stage.cephla
 import squid.stage.prior
 import squid.stage.utils
 import squid.stage.pi
+import squid.stage.asi
 import squid.config
 import squid.abc
 from tests.control.test_microcontroller import get_test_micro
@@ -379,3 +380,64 @@ def test_combined_stage_homes_z_before_xy(monkeypatch):
     combined.home(x=True, y=True, z=True, theta=False, blocking=False)
 
     assert calls == [("z", True), ("xy", False)]
+
+
+# --- ASI LS50 Z stage ---------------------------------------------------------
+
+
+def _sim_ls50():
+    return squid.stage.asi._SimulatedLS50()
+
+
+def test_simulated_ls50_move_and_clamp():
+    sim = _sim_ls50()
+    assert sim.get_position_mm() == 0.0  # power-on zero
+    assert sim.move_to(1.0) == 1.0
+    assert sim.move_relative(-0.25) == 0.75
+    assert sim.is_moving() is False
+    sim.set_travel_limits(-1.0, 1.0)
+    assert sim.move_to(5.0) == 1.0  # clamped to the fence
+    assert sim.move_to(-5.0) == -1.0
+
+
+def test_simulated_ls50_unfenced_passthrough():
+    # Native 0 is just the power-on position; until a fence is set the limits are unknown,
+    # so targets pass through unclamped (mirrors the real backend's clamp cache-miss).
+    sim = _sim_ls50()
+    assert sim.hardware_limits_mm() == (None, None)
+    assert sim.move_to(123.0) == 123.0
+
+
+def test_ls50_zero_here_redefines_frame():
+    # H Z=0 capability exists on the backend but is deliberately NOT wired to zero().
+    sim = _sim_ls50()
+    sim.move_to(1.0)
+    sim.zero_here()
+    assert sim.get_position_mm() == 0.0
+    assert sim._zero_count == 1
+
+
+class _FakeSerialConn:
+    """Scripted pyserial-like object: records writes, pops queued replies."""
+
+    def __init__(self, replies=()):
+        self.written = []
+        self.replies = list(replies)
+
+    def write(self, data):
+        self.written.append(data)
+
+    def read_until(self, expected=b"\n"):
+        return self.replies.pop(0) if self.replies else b""
+
+    def close(self):
+        pass
+
+
+def test_ms2000_command_framing_and_error_ack():
+    conn = _FakeSerialConn(replies=[b":A 0\r\n", b":N-4\r\n"])
+    ser = squid.stage.asi.MS2000Serial(conn)
+    assert ser.command("W Z") == ":A 0"
+    assert conn.written == [b"W Z\r"]
+    with pytest.raises(RuntimeError, match="-4"):
+        ser.command("M Z=99999999")

--- a/software/tests/squid/test_stage.py
+++ b/software/tests/squid/test_stage.py
@@ -420,15 +420,16 @@ def test_ls50_zero_here_redefines_frame():
 class _FakeSerialConn:
     """Scripted pyserial-like object: records writes, pops queued replies."""
 
-    def __init__(self, replies=()):
+    def __init__(self, replies=(), default=b""):
         self.written = []
         self.replies = list(replies)
+        self.default = default
 
     def write(self, data):
         self.written.append(data)
 
     def read_until(self, expected=b"\n"):
-        return self.replies.pop(0) if self.replies else b""
+        return self.replies.pop(0) if self.replies else self.default
 
     def close(self):
         pass
@@ -571,3 +572,97 @@ def test_asi_z_home_after_close_is_noop():
     stage.close()
     stage.home(False, False, True, False, blocking=True)
     assert abs(sim.get_position_mm() - 1.0) < 1e-9  # unmoved after close
+
+
+def test_ls50_controller_framing_and_units():
+    # Real LS50Controller + MS2000Serial over a scripted connection: 0.1 um units on M/W.
+    conn = _FakeSerialConn(replies=[b":A\r\n", b":A -12345\r\n"])
+    ctrl = squid.stage.asi.LS50Controller()
+    ctrl._serial = squid.stage.asi.MS2000Serial(conn)
+    assert ctrl.move_to(0.1234, wait=False) == 0.1234
+    assert conn.written == [b"M Z=1234\r"]
+    assert abs(ctrl.get_position_mm() - (-1.2345)) < 1e-9  # ':A -12345' -> -1.2345 mm
+
+
+def test_ls50_wait_idle_polls_status():
+    # wait=True polls '/' until N; a stage that never idles raises RuntimeError on timeout.
+    conn = _FakeSerialConn(replies=[b":A\r\n", b"B\r\n", b"B\r\n", b"N\r\n", b":A 5000\r\n"])
+    ctrl = squid.stage.asi.LS50Controller()
+    ctrl._serial = squid.stage.asi.MS2000Serial(conn)
+    assert abs(ctrl.move_to(0.5, wait=True) - 0.5) < 1e-9
+    assert conn.written[0] == b"M Z=5000\r"
+    assert conn.written.count(b"/\r") == 3
+
+    stuck = _FakeSerialConn(replies=[b":A\r\n"], default=b"B\r\n")
+    ctrl2 = squid.stage.asi.LS50Controller()
+    ctrl2._serial = squid.stage.asi.MS2000Serial(stuck)
+    with pytest.raises(RuntimeError, match="idle"):
+        ctrl2.move_to(0.5, wait=True, timeout=0.12)
+
+
+def test_ls50_stop_tolerates_halt_ack():
+    # HALT ('\\') acks with ':N-21' on the MS-2000; stop() must not raise on it.
+    conn = _FakeSerialConn(replies=[b":N-21\r\n"])
+    ctrl = squid.stage.asi.LS50Controller()
+    ctrl._serial = squid.stage.asi.MS2000Serial(conn)
+    ctrl.stop()
+    assert conn.written == [b"\\\r"]
+
+
+def test_asi_builder_simulated_returns_working_stage():
+    stage = squid.stage.asi.connect_asi_z_stage(
+        simulated=True, invert_z=True, stage_config=squid.config.get_stage_config()
+    )
+    assert isinstance(stage, squid.stage.asi.ASIZStage)
+    stage.move_z_to(0.5)
+    assert abs(stage.get_pos().z_mm - 0.5) < 1e-9
+
+
+def test_asi_builder_default_causes_no_motion():
+    # Bring-up must not move: no homing/reference/zero happens in the factory by default.
+    stage = squid.stage.asi.connect_asi_z_stage(simulated=True, stage_config=squid.config.get_stage_config())
+    assert abs(stage.get_pos().z_mm - 0.0) < 1e-9  # still at power-on zero
+
+
+def test_asi_builder_home_on_startup_opt_in():
+    stage = squid.stage.asi.connect_asi_z_stage(
+        simulated=True, home_mm=0.5, home_on_startup=True, stage_config=squid.config.get_stage_config()
+    )
+    assert abs(stage.get_pos().z_mm - 0.5) < 1e-9  # retracted to the home target at bring-up
+    # home_on_startup without a target: warn + no motion, no exception.
+    stage2 = squid.stage.asi.connect_asi_z_stage(
+        simulated=True, home_mm=None, home_on_startup=True, stage_config=squid.config.get_stage_config()
+    )
+    assert abs(stage2.get_pos().z_mm - 0.0) < 1e-9
+
+
+def test_asi_builder_travel_fence():
+    stage = squid.stage.asi.connect_asi_z_stage(
+        simulated=True, z_travel_mm=50.0, stage_config=squid.config.get_stage_config()
+    )
+    assert stage._backend.hardware_limits_mm() == (-50.0, 50.0)
+    stage.move_z_to(200.0)
+    assert abs(stage.get_pos().z_mm - 50.0) < 1e-9
+
+
+def test_connect_asi_requires_port():
+    with pytest.raises(RuntimeError, match="ASI_Z_STAGE_SN or ASI_Z_SERIAL_PORT"):
+        squid.stage.asi.connect_asi_z_stage(simulated=False)
+
+
+def test_resolve_serial_port_by_sn_shared(monkeypatch):
+    import serial.tools.list_ports
+
+    class _P:
+        def __init__(self, dev, sn):
+            self.device, self.serial_number = dev, sn
+
+    monkeypatch.setattr(
+        serial.tools.list_ports, "comports", lambda: [_P("/dev/ttyUSB2", 12345), _P("/dev/ttyUSB3", "abc")]
+    )
+    # String-normalized compare: an int-coerced config serial still matches.
+    assert squid.stage.utils.resolve_serial_port_by_sn("12345") == "/dev/ttyUSB2"
+    assert squid.stage.utils.resolve_serial_port_by_sn(12345) == "/dev/ttyUSB2"
+    monkeypatch.setattr(serial.tools.list_ports, "comports", lambda: [])
+    with pytest.raises(RuntimeError, match="check the LS50 controller"):
+        squid.stage.utils.resolve_serial_port_by_sn("12345", missing_hint="check the LS50 controller")

--- a/software/tests/squid/test_stage.py
+++ b/software/tests/squid/test_stage.py
@@ -441,3 +441,133 @@ def test_ms2000_command_framing_and_error_ack():
     assert conn.written == [b"W Z\r"]
     with pytest.raises(RuntimeError, match="-4"):
         ser.command("M Z=99999999")
+
+
+def _sim_asi_stage(**kwargs):
+    return squid.stage.asi.ASIZStage(_sim_ls50(), stage_config=squid.config.get_stage_config(), **kwargs)
+
+
+def _sim_asi_combined():
+    """Simulated Cephla XY + ASI LS50 Z via the reused pi.CombinedStage; returns (combined, xy, z)."""
+    xy = squid.stage.cephla.CephlaStage(get_test_micro(), squid.config.get_stage_config())
+    z = _sim_asi_stage(invert_z=True, home_mm=0.0)
+    combined = squid.stage.pi.CombinedStage(xy_stage=xy, z_stage=z, stage_config=squid.config.get_stage_config())
+    return combined, xy, z
+
+
+def test_asi_z_passthrough_no_sign():
+    stage = _sim_asi_stage(invert_z=False)
+    stage.move_z_to(1.0)
+    assert abs(stage.get_pos().z_mm - 1.0) < 1e-9
+    stage.move_z(-0.5)
+    assert abs(stage.get_pos().z_mm - 0.5) < 1e-9
+
+
+def test_asi_z_invert_is_sign_flip():
+    # Native + is away from the sample; inverted squid Z shows the negation, so squid + is
+    # toward the sample and squid 0 == native 0 == the retracted end.
+    sim = _sim_ls50()
+    stage = squid.stage.asi.ASIZStage(sim, stage_config=squid.config.get_stage_config(), invert_z=True)
+    stage.move_z_to(1.0)
+    assert abs(sim.get_position_mm() - (-1.0)) < 1e-9  # native went negative (toward sample)
+    assert abs(stage.get_pos().z_mm - 1.0) < 1e-9  # squid reports the positive value
+    stage.move_z(0.5)  # squid + relative move -> native negative
+    assert abs(sim.get_position_mm() - (-1.5)) < 1e-9
+    stage.move_z_to(0.0)
+    assert abs(sim.get_position_mm() - 0.0) < 1e-9  # squid 0 == native 0 (retract)
+
+
+def test_asi_z_zero_is_inert():
+    sim = _sim_ls50()
+    stage = squid.stage.asi.ASIZStage(sim, stage_config=squid.config.get_stage_config())
+    stage.move_z_to(1.0)
+    stage.zero(False, False, True, False)
+    assert abs(stage.get_pos().z_mm - 1.0) < 1e-9  # unchanged; zero_here() stays unwired
+    assert sim._zero_count == 0
+
+
+def test_asi_z_home_noop_without_target():
+    # Defensive: with no home target configured, home(z) must not move.
+    stage = _sim_asi_stage(home_mm=None)
+    stage.move_z_to(1.0)
+    stage.home(False, False, True, False, blocking=True)
+    assert abs(stage.get_pos().z_mm - 1.0) < 1e-9
+
+
+def test_asi_z_home_moves_to_target():
+    # Default wiring: home = retract to squid 0 (native 0, the power-on/retracted end).
+    sim = _sim_ls50()
+    stage = squid.stage.asi.ASIZStage(
+        sim, stage_config=squid.config.get_stage_config(), home_mm=0.0, invert_z=True
+    )
+    stage.move_z_to(2.0)
+    stage.home(False, False, True, False, blocking=True)
+    assert abs(stage.get_pos().z_mm - 0.0) < 1e-9
+    assert abs(sim.get_position_mm() - 0.0) < 1e-9
+    # A custom squid-frame target maps through the inversion.
+    stage2 = _sim_asi_stage(home_mm=0.2, invert_z=True)
+    stage2.home(False, False, True, False, blocking=True)
+    assert abs(stage2.get_pos().z_mm - 0.2) < 1e-9
+
+
+def test_asi_z_set_limits_reaches_backend():
+    stage = _sim_asi_stage(invert_z=False)
+    stage.set_limits(z_pos_mm=1.0, z_neg_mm=-1.0)
+    stage.move_z_to(5.0)
+    assert abs(stage.get_pos().z_mm - 1.0) < 1e-9
+
+
+def test_asi_z_set_limits_inverted_orders_fence():
+    # Software [0.05, 6.0] (squid frame) -> native fence [-6.0, -0.05] (min/max after flip).
+    sim = _sim_ls50()
+    stage = squid.stage.asi.ASIZStage(sim, stage_config=squid.config.get_stage_config(), invert_z=True)
+    stage.set_limits(z_pos_mm=6.0, z_neg_mm=0.05)
+    assert sim.hardware_limits_mm() == (-6.0, -0.05)
+    stage.move_z_to(10.0)  # over-range squid target clamps at the fence
+    assert abs(stage.get_pos().z_mm - 6.0) < 1e-9
+
+
+def test_asi_z_xy_noop():
+    stage = _sim_asi_stage()
+    stage.move_x(1.0)
+    stage.move_y(1.0)
+    assert stage.get_pos().x_mm == 0.0 and stage.get_pos().y_mm == 0.0
+
+
+def test_asi_z_grid_is_tenth_micron():
+    stage = _sim_asi_stage()
+    assert stage.z_mm_to_usteps(1.0) == 10000
+    assert abs(1.0 / stage.z_mm_to_usteps(1.0) - 1e-4) < 1e-12
+
+
+def test_asi_combined_stage_routes_axes():
+    combined, _, z = _sim_asi_combined()
+    combined.move_z_to(1.0)
+    assert abs(combined.get_pos().z_mm - 1.0) < 1e-9  # Z from the LS50
+    assert combined.get_pos().x_mm == 0.0  # X from cephla
+    combined.zero(False, False, True, False)  # z-zero routes to ASIZStage (inert)
+    assert abs(combined.get_pos().z_mm - 1.0) < 1e-9
+
+
+def test_asi_combined_zaxis_reports_ls50_grid():
+    combined, xy, z = _sim_asi_combined()
+    grid = combined.get_config().Z_AXIS.convert_real_units_to_ustep(1.0)
+    assert abs(grid) == abs(z.z_mm_to_usteps(1.0))  # 0.1 um grid, not the Cephla stepper grid
+    assert abs(grid) != abs(xy.get_config().Z_AXIS.convert_real_units_to_ustep(1.0))
+
+
+def test_asi_z_close_closes_backend():
+    sim = _sim_ls50()
+    stage = squid.stage.asi.ASIZStage(sim, stage_config=squid.config.get_stage_config())
+    stage.close()
+    assert sim._closed is True
+
+
+def test_asi_z_home_after_close_is_noop():
+    # Once closed, home must not touch the torn-down backend (non-blocking-home race guard).
+    sim = _sim_ls50()
+    stage = squid.stage.asi.ASIZStage(sim, stage_config=squid.config.get_stage_config(), home_mm=0.0)
+    stage.move_z_to(1.0)
+    stage.close()
+    stage.home(False, False, True, False, blocking=True)
+    assert abs(sim.get_position_mm() - 1.0) < 1e-9  # unmoved after close

--- a/software/tests/tools.py
+++ b/software/tests/tools.py
@@ -60,3 +60,43 @@ def get_test_piezo_stage(microcontroller: Microcontroller):
     }
 
     return PiezoStage(microcontroller=microcontroller, config=test_piezo_config)
+
+
+class FakeSerialConn:
+    """Scripted pyserial-like object for MS2000Serial tests: records writes, pops queued
+    replies (falling back to ``default``), tracks close()."""
+
+    def __init__(self, replies=(), default=b""):
+        self.written = []
+        self.replies = list(replies)
+        self.default = default
+        self.closed = False
+
+    def write(self, data):
+        self.written.append(data)
+
+    def read_until(self, expected=b"\n"):
+        return self.replies.pop(0) if self.replies else self.default
+
+    def close(self):
+        self.closed = True
+
+
+class FakeZStage:
+    """Records move_z_to calls and reports a preset Z position (objective-changer tests)."""
+
+    def __init__(self, z_mm: float = 3.5):
+        self._z_mm = z_mm
+        self.z_moves: list = []
+
+    def move_z_to(self, abs_mm: float, blocking: bool = True):
+        self.z_moves.append(abs_mm)
+        self._z_mm = abs_mm
+
+    def get_pos(self):
+        class _Pos:
+            pass
+
+        p = _Pos()
+        p.z_mm = self._z_mm
+        return p

--- a/software/tools/asi_z_bringup.py
+++ b/software/tools/asi_z_bringup.py
@@ -96,7 +96,7 @@ def read_only_checks(backend):
     report_position(backend, "Position")
     log.info(f"Busy: {backend.is_moving()}  (expect False on an idle stage)")
     if isinstance(backend, LS50Controller):
-        with_serial: MS2000Serial = backend._serial
+        with_serial: MS2000Serial = backend.serial
         for cmd in ("BU", "N"):  # build info / who
             try:
                 log.info(f"{cmd!r} -> {with_serial.command(cmd)!r}")
@@ -140,6 +140,34 @@ def fence_test(backend, fence_mm: float):
     report_position(backend, "Back at start")
 
 
+def turret_probe(serial, axis: str):
+    """Read-only: raw 'W <axis>' and '/' replies, verbatim (answers the W-T-semantics question)."""
+    log.info(f"--- Turret probe (axis {axis!r}) ---")
+    for cmd in (f"W {axis}", "/"):
+        reply = serial.command(cmd, check_error=False)
+        log.info(f"{cmd!r} -> {reply!r}")
+
+
+def turret_move_test(serial, axis: str, slot: int):
+    """Rotate to a slot, logging '/' busy transitions with timestamps, then read back."""
+    log.info(f"--- Turret move test: slot {slot} ---")
+    log.info(f"'M {axis}={slot}' -> {serial.command(f'M {axis}={slot}', check_error=False)!r}")
+    t0 = time.monotonic()
+    last = None
+    deadline = t0 + 30.0
+    while time.monotonic() < deadline:
+        busy = "B" in serial.command("/").upper()
+        if busy != last:
+            log.info(f"t={time.monotonic() - t0:6.2f}s busy={busy}")
+            last = busy
+        if last is False:
+            break
+        time.sleep(0.05)
+    log.info(f"readback 'W {axis}' -> {serial.command(f'W {axis}', check_error=False)!r}")
+    log.info(f"same-slot repeat 'M {axis}={slot}' -> {serial.command(f'M {axis}={slot}', check_error=False)!r}")
+    log.info("If busy never went True, '/' may not cover turret rotation (note for the driver).")
+
+
 def find_zero_test(backend, travel_mm: float):
     """Clear stale limits, drive to the away limit, zero there -- the startup routine, observable."""
     log.info("--- Find-zero test ---")
@@ -164,6 +192,12 @@ def main():
     parser.add_argument("--jog-mm", type=float, default=0.5, help="Jog distance in native mm (default 0.5, away)")
     parser.add_argument("--fence-mm", type=float, default=0.0, help="Also test the +/- soft-limit fence (0 = skip)")
     parser.add_argument("--scan-bauds", action="store_true", help="Try each ASI baud rate and report which answers")
+    parser.add_argument("--turret", action="store_true", help="Probe the objective turret axis (read-only)")
+    parser.add_argument("--turret-axis", default="F", help="Turret axis letter (default F, per the MFC-2000)")
+    parser.add_argument(
+        "--turret-slot", type=int, choices=range(1, 7), help="Rotate to this slot (1..6); requires --allow-motion"
+    )
+
     parser.add_argument(
         "--find-zero",
         action="store_true",
@@ -187,6 +221,8 @@ def main():
     backend = connect(args)
     try:
         read_only_checks(backend)
+        if args.turret and isinstance(backend, LS50Controller):
+            turret_probe(backend.serial, args.turret_axis)
 
         if not args.allow_motion:
             log.info("Read-only run complete. Re-run with --allow-motion for the jog test.")
@@ -206,6 +242,8 @@ def main():
         jog_test(backend, args.jog_mm)
         if args.fence_mm > 0:
             fence_test(backend, args.fence_mm)
+        if args.turret and args.turret_slot and isinstance(backend, LS50Controller):
+            turret_move_test(backend.serial, args.turret_axis, args.turret_slot)
 
         log.info("--- Done. Next steps for the machine ini ---")
         log.info("[GENERAL]: use_asi_z_stage = True, asi_z_stage_sn = <SN>, asi_z_travel_mm = 50")

--- a/software/tools/asi_z_bringup.py
+++ b/software/tools/asi_z_bringup.py
@@ -6,9 +6,10 @@ a small jog AWAY from the sample and back, plus an optional soft-limit fence che
 
 Read-only by default: without --allow-motion the stage never moves.
 
-Frame reminder: native 0 is the power-on position (power on with the stage retracted!),
-native POSITIVE is away from the sample. Squid displays the negation (asi_z_invert = True),
-so squid + is toward the sample.
+Frame reminder: native 0 is wherever last zeroed -- the power-on position until --find-zero
+(or the GUI's startup find-zero) anchors it at the away-from-sample limit switch. Native
+POSITIVE is away from the sample; Squid displays the negation (asi_z_invert = True), so
+squid + is toward the sample.
 
 Usage:
     python3 tools/asi_z_bringup.py --sn <USB serial number>            # read-only checks

--- a/software/tools/asi_z_bringup.py
+++ b/software/tools/asi_z_bringup.py
@@ -168,7 +168,7 @@ def main():
         action="store_true",
         help="Startup frame routine: clear limits, drive to the away limit, zero there (needs --allow-motion)",
     )
-    parser.add_argument("--travel-mm", type=float, default=50.0, help="Physical travel for the overdrive (default 50)")
+    parser.add_argument("--travel-mm", type=float, help="Physical travel in mm (required for --find-zero; LS-50 = 50)")
     args = parser.parse_args()
 
     if args.scan_bauds:
@@ -198,6 +198,9 @@ def main():
                 return
 
         if args.find_zero:
+            if not args.travel_mm:
+                log.error("--find-zero needs --travel-mm (the stage's physical travel; LS-50 = 50).")
+                sys.exit(1)
             find_zero_test(backend, args.travel_mm)
         jog_test(backend, args.jog_mm)
         if args.fence_mm > 0:

--- a/software/tools/asi_z_bringup.py
+++ b/software/tools/asi_z_bringup.py
@@ -1,0 +1,157 @@
+"""ASI LS50 Z-stage controller bring-up test.
+
+Exercises the production driver (squid.stage.asi.LS50Controller) against real hardware:
+port discovery, comms sanity, position/status readout, and -- only with --allow-motion --
+a small jog AWAY from the sample and back, plus an optional soft-limit fence check.
+
+Read-only by default: without --allow-motion the stage never moves.
+
+Frame reminder: native 0 is the power-on position (power on with the stage retracted!),
+native POSITIVE is away from the sample. Squid displays the negation (asi_z_invert = True),
+so squid + is toward the sample.
+
+Usage:
+    python3 tools/asi_z_bringup.py --sn <USB serial number>            # read-only checks
+    python3 tools/asi_z_bringup.py --sn <SN> --allow-motion            # + jog test
+    python3 tools/asi_z_bringup.py --sn <SN> --allow-motion --fence-mm 50   # + fence test
+    python3 tools/asi_z_bringup.py --simulate --allow-motion           # dry run, no hardware
+"""
+
+import argparse
+import sys
+import time
+
+sys.path.insert(0, ".")  # run from the software/ directory
+
+import squid.logging
+from squid.stage.asi import LS50Controller, MS2000Serial, _SimulatedLS50
+
+log = squid.logging.get_logger("asi-z-bringup")
+
+
+def report_position(backend, label: str) -> float:
+    native = backend.get_position_mm()
+    squid_mm = -native + 0.0  # +0.0 avoids the confusing '-0.0000' rendering
+    log.info(f"{label}: native = {native:+.4f} mm  (squid would display {squid_mm:+.4f} mm)")
+    return native
+
+
+def connect(args):
+    if args.simulate:
+        log.info("SIMULATED backend (no hardware).")
+        backend = _SimulatedLS50()
+        backend.initialize()
+        return backend
+
+    if args.port:
+        port = args.port
+    elif args.sn:
+        import squid.stage.utils
+
+        try:
+            port = squid.stage.utils.resolve_serial_port_by_sn(args.sn)
+        except RuntimeError as e:
+            import serial.tools.list_ports
+
+            log.error(str(e))
+            log.error("Available ports:")
+            for p in serial.tools.list_ports.comports():
+                log.error(f"  {p.device}  serial_number={p.serial_number}  {p.description}")
+            sys.exit(1)
+    else:
+        log.error("Pass --sn <USB serial number>, --port </dev/ttyUSB*>, or --simulate.")
+        sys.exit(1)
+
+    log.info(f"Connecting to {port} at {args.baud} baud ...")
+    backend = LS50Controller()
+    backend.connect_serial(port, baudrate=args.baud)
+    backend.initialize()  # one W Z round-trip; no motion
+    return backend
+
+
+def read_only_checks(backend):
+    log.info("--- Read-only checks ---")
+    report_position(backend, "Position")
+    log.info(f"Busy: {backend.is_moving()}  (expect False on an idle stage)")
+    if isinstance(backend, LS50Controller):
+        with_serial: MS2000Serial = backend._serial
+        for cmd in ("BU", "N"):  # build info / who
+            try:
+                log.info(f"{cmd!r} -> {with_serial.command(cmd)!r}")
+            except Exception as e:
+                log.warning(f"{cmd!r} failed: {e} (informational only)")
+
+
+def jog_test(backend, jog_mm: float):
+    log.info("--- Jog test ---")
+    start = report_position(backend, "Start")
+    log.info(f"Jogging native +{jog_mm} mm. WATCH THE STAGE: it must move AWAY from the sample.")
+    t0 = time.monotonic()
+    backend.move_relative(+jog_mm, wait=True)
+    log.info(f"Move + settle took {time.monotonic() - t0:.2f} s")
+    after = report_position(backend, "After jog")
+    if abs((after - start) - jog_mm) > 0.01:
+        log.warning(f"Jog moved {after - start:+.4f} mm, expected {jog_mm:+.4f} mm -- check units/backlash.")
+    log.info("Returning to the start position ...")
+    backend.move_to(start, wait=True)
+    end = report_position(backend, "Back at start")
+    if abs(end - start) > 0.005:
+        log.warning(f"Did not return exactly to start (off by {end - start:+.4f} mm).")
+    log.info("If the stage moved TOWARD the sample on the jog, the wiring/direction is flipped:")
+    log.info("do NOT set asi_z_invert = False blindly -- re-check the controller axis polarity first.")
+
+
+def fence_test(backend, fence_mm: float):
+    log.info(f"--- Soft-limit fence test (native +/-{fence_mm} mm) ---")
+    backend.set_travel_limits(-fence_mm, fence_mm)
+    log.info(f"Fence set; controller SL/SU written. hardware_limits_mm = {backend.hardware_limits_mm()}")
+    start = backend.get_position_mm()
+    target = fence_mm + 5.0  # beyond the fence, in the AWAY direction
+    log.info(f"Commanding native {target:+.1f} mm (beyond the fence) -- the driver must clamp it.")
+    reached = backend.move_to(target, wait=True)
+    if reached <= fence_mm + 0.01:
+        log.info(f"OK: clamped to {reached:+.4f} mm.")
+    else:
+        log.warning(f"NOT clamped: reached {reached:+.4f} mm!")
+    log.info("Returning to the start position ...")
+    backend.move_to(start, wait=True)
+    report_position(backend, "Back at start")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--sn", help="Controller USB serial number (resolved to a port)")
+    parser.add_argument("--port", help="Explicit serial port (overrides --sn)")
+    parser.add_argument("--baud", type=int, default=115200, help="Baud rate (default 115200)")
+    parser.add_argument("--simulate", action="store_true", help="Use the simulated backend (no hardware)")
+    parser.add_argument("--allow-motion", action="store_true", help="Enable the jog / fence tests (MOVES the stage)")
+    parser.add_argument("--jog-mm", type=float, default=0.5, help="Jog distance in native mm (default 0.5, away)")
+    parser.add_argument("--fence-mm", type=float, default=0.0, help="Also test the +/- soft-limit fence (0 = skip)")
+    args = parser.parse_args()
+
+    backend = connect(args)
+    try:
+        read_only_checks(backend)
+
+        if not args.allow_motion:
+            log.info("Read-only run complete. Re-run with --allow-motion for the jog test.")
+            return
+
+        if not args.simulate:
+            log.warning(f"About to MOVE the stage: +{args.jog_mm} mm native (away from the sample) and back.")
+            if input("Type 'move' to continue: ").strip().lower() != "move":
+                log.info("Aborted before motion.")
+                return
+
+        jog_test(backend, args.jog_mm)
+        if args.fence_mm > 0:
+            fence_test(backend, args.fence_mm)
+
+        log.info("--- Done. Next steps for the machine ini ---")
+        log.info("[GENERAL]: use_asi_z_stage = True, asi_z_stage_sn = <SN>, asi_z_travel_mm = 50")
+    finally:
+        backend.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/software/tools/asi_z_bringup.py
+++ b/software/tools/asi_z_bringup.py
@@ -36,6 +36,27 @@ def report_position(backend, label: str) -> float:
     return native
 
 
+ASI_BAUD_RATES = (115200, 9600, 19200, 28800)  # rates the MS-2000 family supports
+
+
+def scan_bauds(port: str):
+    """Try each ASI baud rate on the port until the controller answers a position query."""
+    for baud in ASI_BAUD_RATES:
+        backend = LS50Controller()
+        try:
+            backend.connect_serial(port, baudrate=baud)
+            native = backend.get_position_mm()
+            log.info(f"{baud} baud: ANSWERED (native position {native:+.4f} mm)")
+            log.info(f"-> set asi_z_baudrate = {baud} in the machine ini (Squid default is 115200).")
+            return baud
+        except Exception as e:
+            log.info(f"{baud} baud: no valid reply ({e})")
+        finally:
+            backend.close()
+    log.error("No baud rate answered. Check the port is the ASI controller and that it is powered.")
+    return None
+
+
 def connect(args):
     if args.simulate:
         log.info("SIMULATED backend (no hardware).")
@@ -62,8 +83,8 @@ def connect(args):
         log.error("Pass --sn <USB serial number>, --port </dev/ttyUSB*>, or --simulate.")
         sys.exit(1)
 
-    log.info(f"Connecting to {port} at {args.baud} baud ...")
-    backend = LS50Controller()
+    log.info(f"Connecting to {port} at {args.baud} baud (axis {args.axis!r}) ...")
+    backend = LS50Controller(axis=args.axis)
     backend.connect_serial(port, baudrate=args.baud)
     backend.initialize()  # one W Z round-trip; no motion
     return backend
@@ -123,11 +144,25 @@ def main():
     parser.add_argument("--sn", help="Controller USB serial number (resolved to a port)")
     parser.add_argument("--port", help="Explicit serial port (overrides --sn)")
     parser.add_argument("--baud", type=int, default=115200, help="Baud rate (default 115200)")
+    parser.add_argument("--axis", default="Z", help="Axis letter on the controller (default Z)")
     parser.add_argument("--simulate", action="store_true", help="Use the simulated backend (no hardware)")
     parser.add_argument("--allow-motion", action="store_true", help="Enable the jog / fence tests (MOVES the stage)")
     parser.add_argument("--jog-mm", type=float, default=0.5, help="Jog distance in native mm (default 0.5, away)")
     parser.add_argument("--fence-mm", type=float, default=0.0, help="Also test the +/- soft-limit fence (0 = skip)")
+    parser.add_argument("--scan-bauds", action="store_true", help="Try each ASI baud rate and report which answers")
     args = parser.parse_args()
+
+    if args.scan_bauds:
+        if args.port:
+            port = args.port
+        elif args.sn:
+            import squid.stage.utils
+
+            port = squid.stage.utils.resolve_serial_port_by_sn(args.sn)
+        else:
+            log.error("--scan-bauds needs --sn or --port.")
+            sys.exit(1)
+        sys.exit(0 if scan_bauds(port) else 1)
 
     backend = connect(args)
     try:

--- a/software/tools/asi_z_bringup.py
+++ b/software/tools/asi_z_bringup.py
@@ -139,6 +139,19 @@ def fence_test(backend, fence_mm: float):
     report_position(backend, "Back at start")
 
 
+def find_zero_test(backend, travel_mm: float):
+    """Clear stale limits, drive to the away limit, zero there -- the startup routine, observable."""
+    log.info("--- Find-zero test ---")
+    report_position(backend, "Before")
+    backend.clear_travel_limits()
+    log.info("Stale controller soft limits cleared (SL/SU wide).")
+    log.info("Driving PAST full travel toward the AWAY-from-sample end; the limit switch stops it ...")
+    t0 = time.monotonic()
+    backend.zero_at_away_limit(overdrive_mm=travel_mm * 1.2)
+    log.info(f"Reached the away limit and zeroed in {time.monotonic() - t0:.1f} s.")
+    report_position(backend, "After (should be native 0)")
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--sn", help="Controller USB serial number (resolved to a port)")
@@ -150,6 +163,12 @@ def main():
     parser.add_argument("--jog-mm", type=float, default=0.5, help="Jog distance in native mm (default 0.5, away)")
     parser.add_argument("--fence-mm", type=float, default=0.0, help="Also test the +/- soft-limit fence (0 = skip)")
     parser.add_argument("--scan-bauds", action="store_true", help="Try each ASI baud rate and report which answers")
+    parser.add_argument(
+        "--find-zero",
+        action="store_true",
+        help="Startup frame routine: clear limits, drive to the away limit, zero there (needs --allow-motion)",
+    )
+    parser.add_argument("--travel-mm", type=float, default=50.0, help="Physical travel for the overdrive (default 50)")
     args = parser.parse_args()
 
     if args.scan_bauds:
@@ -178,6 +197,8 @@ def main():
                 log.info("Aborted before motion.")
                 return
 
+        if args.find_zero:
+            find_zero_test(backend, args.travel_mm)
         jog_test(backend, args.jog_mm)
         if args.fence_mm > 0:
             fence_test(backend, args.fence_mm)


### PR DESCRIPTION
Adds the ASI LS50 Z-only linear stage (own MS-2000-family controller, own USB serial port) as the microscope's Z axis, following the PR #569 pattern: a Z-only `AbstractStage` adapter composed with the configured XY stage via the (reused, unchanged) `CombinedStage`.

> **Stacked on #569** (`feat/v308-pi-focus-stage`) — needs `CombinedStage` from that branch. Merge #569 first; this PR's diff is the last 4 commits.

## What's in here

- **`squid/stage/asi.py`** (new):
  - `MS2000Serial` — the shared CR-terminated ASI command transport (locked write/read, `:N` error acks, test-injectable serial object). Deliberately placed at the same path as `dragonfly-andor`'s XYZ `ASIStage`, so merging that branch raises an add/add conflict whose resolution is porting `ASIStage` onto this core (no silently-duplicated ASI serial code).
  - `LS50Controller` — the driver: `M Z=`/`W Z` in 0.1 µm units, `/` busy polling as the settle signal, `SL`/`SU` soft limits (mm), fence clamping with pass-through while unfenced, relative moves resolved to absolute so jogs clamp, HALT tolerating its `:N-21` ack. Bring-up performs **no motion** and writes no parameters.
  - `_SimulatedLS50` + `ASIZStage` (adapter mirroring `PIFocusStage`: RLock, async-home `_busy` flag, close-race guard, XY warn-stubs, 0.1 µm `z_mm_to_usteps` grid) + `connect_asi_z_stage` factory.
- **Frame semantics** (hardware-verified convention): native + is away from the sample, native 0 = the retracted position, no referencing routine exists or is needed. `ASI_Z_INVERT` defaults **True**: squid shows −native, so squid 0 = retracted and squid Z+ is toward the sample (Cephla convention). `home()` = retract to native 0. The only possible bring-up motion is the doubly-opt-in `ASI_Z_HOME_ON_STARTUP`.
- **`uses_external_z_stage()`** in `_def.py` — the four external-Z policy sites (`home_xyz` Z-homing skip + retract-before-XY, cached-Z restore, `move_z_axis_to_safety_position`) now ask this one predicate instead of OR-ing vendor flags. It is a function, not a derived constant, because the machine-config loader overrides flag globals after definition.
- **Mutual exclusion**: `USE_PI_FOCUS_STAGE` + `USE_ASI_Z_STAGE` together raises at config load AND at `Microscope` construction (prevents silently nesting one `CombinedStage` inside the other).
- **Shared port-by-SN resolver** extracted to `squid.stage.utils.resolve_serial_port_by_sn`; the PI module delegates to it.

## Config

```ini
[GENERAL]
use_asi_z_stage = True
asi_z_stage_sn = <controller USB serial>   ; or asi_z_serial_port = /dev/ttyUSB0
asi_z_travel_mm = 50                        ; coarse ± sanity fence around power-on zero
```

## Tests

29 new tests in `tests/squid/test_stage.py` mirroring the PI suite (all written red-first): sim clamp/unfenced-passthrough, sign-flip mapping, protocol framing/parsing against a scripted serial, `/` wait-idle + timeout, builder no-motion guarantees, predicate call-time reads, Microscope wrap/mutual-exclusion/`home_xyz` retract, close chain.

- `tests/squid`: 132 passed
- `tests/control/test_HighContentScreeningGui.py`: 3 passed
- full-tree collection (1487 tests) clean — all imports work against the new flags
- simulated end-to-end: `CombinedStage` wrap → squid +0.5 = native −0.5 → retract to 0 → clean close

## Hardware bring-up

Power the controller on with the stage retracted (native 0 = retracted), set `asi_z_stage_sn` + `asi_z_travel_mm = 50`, jog to confirm squid + moves toward the sample (else flip `asi_z_invert`), then consider `asi_z_home_on_startup`. Known caveat (documented in the flag comments): the frame survives power cycles only if the stage is powered off retracted; `LS50Controller.zero_here()` (`H Z=0`) exists unwired for a future re-zeroing flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)