### PR TITLE
fix(acquisition): default per-channel Z-offset to OFF

### DIFF
--- a/software/control/core/multi_point_controller.py
+++ b/software/control/core/multi_point_controller.py
@@ -213,7 +213,10 @@ class MultiPointController:
 
         self.do_autofocus = False
         self.do_reflection_af = False
-        self.apply_channel_offset = True
+        # GUI-facing default: OFF, so the per-channel Z-offset applies only when the user
+        # opts in via the checkbox. Independent of AcquisitionParameters.apply_channel_offset,
+        # which stays True as the direct-constructor contract for TCP/MCP callers.
+        self.apply_channel_offset = False
         self.display_resolution_scaling = control._def.Acquisition.IMAGE_DISPLAY_SCALING_FACTOR
         self.use_piezo = control._def.MULTIPOINT_USE_PIEZO_FOR_ZSTACKS
         self.experiment_ID = None

--- a/software/control/core/multi_point_controller.py
+++ b/software/control/core/multi_point_controller.py
@@ -214,8 +214,11 @@ class MultiPointController:
         self.do_autofocus = False
         self.do_reflection_af = False
         # GUI-facing default: OFF, so the per-channel Z-offset applies only when the user
-        # opts in via the checkbox. Independent of AcquisitionParameters.apply_channel_offset,
-        # which stays True as the direct-constructor contract for TCP/MCP callers.
+        # opts in (the GUI checkbox seeds this flag on construction). build_params() copies
+        # this flag into AcquisitionParameters.apply_channel_offset at acquisition time, so
+        # the two are coupled at runtime; only the dataclass *default* stays True, as the
+        # direct-constructor contract for TCP/MCP callers that build AcquisitionParameters
+        # without going through this controller.
         self.apply_channel_offset = False
         self.display_resolution_scaling = control._def.Acquisition.IMAGE_DISPLAY_SCALING_FACTOR
         self.use_piezo = control._def.MULTIPOINT_USE_PIEZO_FOR_ZSTACKS

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -974,9 +974,13 @@ class _ApplyChannelOffsetMixin:
     )
 
     def _create_apply_channel_offset_checkbox(self):
-        """Build the (default-checked) per-channel Z-offset checkbox and wire its toggle."""
+        """Build the (default-unchecked) per-channel Z-offset checkbox and wire its toggle.
+
+        Defaults OFF so the offset is applied only when the user opts in; the controller's
+        instance flag defaults to False to match (see MultiPointController.__init__).
+        """
         self.checkbox_applyChannelOffset = QCheckBox("Per-channel Z-offset")
-        self.checkbox_applyChannelOffset.setChecked(True)
+        self.checkbox_applyChannelOffset.setChecked(False)
         self.checkbox_applyChannelOffset.setToolTip(self._APPLY_CHANNEL_OFFSET_TOOLTIP)
         self.checkbox_applyChannelOffset.toggled.connect(self._on_apply_channel_offset_changed)
 

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -976,13 +976,18 @@ class _ApplyChannelOffsetMixin:
     def _create_apply_channel_offset_checkbox(self):
         """Build the (default-unchecked) per-channel Z-offset checkbox and wire its toggle.
 
-        Defaults OFF so the offset is applied only when the user opts in; the controller's
-        instance flag defaults to False to match (see MultiPointController.__init__).
+        Defaults OFF so the offset is applied only when the user opts in. The controller
+        flag is then seeded from the checkbox's initial state, so the runtime flag always
+        reflects the visible checkbox instead of relying on the two classes' hardcoded
+        defaults happening to match.
         """
         self.checkbox_applyChannelOffset = QCheckBox("Per-channel Z-offset")
         self.checkbox_applyChannelOffset.setChecked(False)
         self.checkbox_applyChannelOffset.setToolTip(self._APPLY_CHANNEL_OFFSET_TOOLTIP)
         self.checkbox_applyChannelOffset.toggled.connect(self._on_apply_channel_offset_changed)
+        # Seed the controller from the checkbox so its flag matches the visible state
+        # (multipointController is assigned before this runs in every host widget).
+        self._on_apply_channel_offset_changed(self.checkbox_applyChannelOffset.isChecked())
 
     def _update_apply_channel_offset_enable_state(self, laser_af_on: bool):
         # Visibility follows laser AF (the offset is meaningless without an AF reference


### PR DESCRIPTION
## Problem

The **Per-channel Z-offset** checkbox started **checked** on every launch, and the `MultiPointController` instance flag independently defaulted to `True`. Turning the option off before closing the software had no effect — it reset to on at the next startup.

## Why two lines change

The checkbox sets its initial state *before* its `toggled` signal is connected, so it never pushes that state to the controller. The checkbox default and the controller instance default therefore have to agree — flipping only the checkbox would leave the box showing unchecked while the offset kept applying during acquisition. So both are defaulted to OFF.

## Changes

- `control/widgets.py` — `checkbox_applyChannelOffset` now starts unchecked.
- `control/core/multi_point_controller.py` — `self.apply_channel_offset` instance flag defaults to `False`.

## Deliberately unchanged

`AcquisitionParameters.apply_channel_offset` (the dataclass default) stays `True`. That is the direct-constructor contract for TCP/MCP callers (and has its own test), not the GUI-facing default.

## Result

On startup the per-channel Z-offset is off until the user ticks the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)