### PR TITLE
fix(camera): don't reuse a pre-trigger frame in DefaultCamera.read_camera_frame

### DIFF
--- a/software/control/camera.py
+++ b/software/control/camera.py
@@ -385,8 +385,18 @@ class DefaultCamera(AbstractCamera):
 
         total_exposure_time_ms = self._exposure_time_ms + self._strobe_delay_us / 1000.0
 
-        # If the last frame we got was from <exposure time ago, use it.
-        if self._current_frame and time.time() - self._current_frame.timestamp <= total_exposure_time_ms / 1000.0:
+        # Only reuse the cached frame if it was captured AFTER the most recent trigger and is
+        # still fresh. The trigger-timestamp guard prevents returning a pre-trigger frame in
+        # software/hardware trigger mode -- e.g. the laser-AF measure -> piezo move -> verify
+        # loop, where a stale pre-move frame would fail the cross-correlation check and revert
+        # a correct focus move. In continuous mode no per-read trigger is sent, so
+        # _last_trigger_timestamp stays old and every streamed frame passes this guard, keeping
+        # the previous fast-path behavior.
+        if (
+            self._current_frame
+            and self._current_frame.timestamp >= self._last_trigger_timestamp
+            and time.time() - self._current_frame.timestamp <= total_exposure_time_ms / 1000.0
+        ):
             return self._current_frame
 
         # The camera api isn't really fast, so it is easy to time out waiting for a frame and its processing.  So

--- a/software/control/camera.py
+++ b/software/control/camera.py
@@ -385,7 +385,7 @@ class DefaultCamera(AbstractCamera):
 
         total_exposure_time_ms = self._exposure_time_ms + self._strobe_delay_us / 1000.0
 
-        # Only reuse the cached frame if it was captured AFTER the most recent trigger and is
+        # Only reuse the cached frame if it was captured at or after the most recent trigger and is
         # still fresh. The trigger-timestamp guard prevents returning a pre-trigger frame in
         # software/hardware trigger mode -- e.g. the laser-AF measure -> piezo move -> verify
         # loop, where a stale pre-move frame would fail the cross-correlation check and revert


### PR DESCRIPTION
## Problem

Laser (reflection) autofocus is less stable on recent builds: it intermittently leaves FOVs defocused, most noticeably when a larger focus correction is needed.

## Root cause

`DefaultCamera.read_camera_frame` has a fast path that returns the cached `_current_frame` when it is younger than `exposure + strobe`:

```python
if self._current_frame and time.time() - self._current_frame.timestamp <= total_exposure_time_ms / 1000.0:
    return self._current_frame
```

In a trigger-then-read pattern (`send_trigger()` then `read_frame()`) this can return the frame from *before* the trigger, because the freshly triggered frame has not arrived yet.

The laser-AF loop is:
1. `measure_displacement()` — reads the spot, computes the correction (**correct**).
2. `_move_z()` — moves the piezo (**correct**, instant).
3. `_verify_spot_alignment()` — triggers a read and cross-correlates against the reference.

At step 3 the read returns the **pre-move** frame, so verification sees the spot still displaced, fails the cross-correlation, and `move_to_target` **reverts the correct correction** — leaving the FOV defocused.

The window governing the fast path grew from ~2.7 ms to ~27 ms once the focus camera began recomputing its strobe delay in software-trigger mode (`_update_strobe_time` uses the full 2064-row sensor, not the 256-row ROI), turning an unlikely race into the common case.

## Fix

Only reuse the cached frame if it was captured at/after the most recent trigger:

```python
if (
    self._current_frame
    and self._current_frame.timestamp >= self._last_trigger_timestamp
    and time.time() - self._current_frame.timestamp <= total_exposure_time_ms / 1000.0
):
    return self._current_frame
```

- **Strobe untouched** — illumination-sync behavior and imaging use of `DefaultCamera` are unaffected.
- **Continuous / live mode unchanged** — no per-read trigger is sent, so `_last_trigger_timestamp` stays old and every streamed frame passes the guard (fast path preserved).
- **Future hardware-triggered focus camera** works — `send_trigger` stamps `_last_trigger_timestamp` in both software and hardware paths.
- `PhotometricsCamera.read_camera_frame` has no reuse fast path and needs no change.

## Testing

- `pytest tests/squid/test_camera.py` → **4 passed** (`test_read_frame_on_timeout` already asserts each `send_trigger`→`read_frame` returns that trigger's own frame).
- `python -m py_compile control/camera.py` → OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
