### PR TITLE
fix(scan-coordinates): sort 1536-well rows AA-AF after Z, not interleaved with A-F

### DIFF
--- a/software/control/core/job_processing.py
+++ b/software/control/core/job_processing.py
@@ -440,7 +440,7 @@ class ZarrWriterInfo:
 
         Returns:
             Tuple of (rows, cols, wells) where:
-            - rows: sorted unique row letters (e.g., ["A", "B", "C"])
+            - rows: unique row letters in plate order (e.g., ["A", "B", "C"])
             - cols: sorted unique column numbers (e.g., [1, 2, 3])
             - wells: list of (row, col) tuples for all wells
         """
@@ -454,7 +454,9 @@ class ZarrWriterInfo:
             cols_set.add(int(col_num))
             wells.append((row_letter, int(col_num)))
 
-        rows = sorted(rows_set)
+        # Sort by row index, not lexicographically: on a 1536-well plate "AA" is row 26
+        # and belongs after "Z", but sorts before "B" as a string.
+        rows = sorted(rows_set, key=utils.row_to_index)
         cols = sorted(cols_set)
         return rows, cols, wells
 

--- a/software/control/core/scan_coordinates.py
+++ b/software/control/core/scan_coordinates.py
@@ -2,14 +2,18 @@ from dataclasses import dataclass
 import itertools
 import math
 import re
-from typing import Callable, List, Tuple
+from typing import Callable, List, Optional, Tuple
 
 import numpy as np
 
 import control._def
+import control.utils
 from control.core.objective_store import ObjectiveStore
 from squid.abc import AbstractStage, AbstractCamera
 import squid.logging
+
+# Well region names are a row label followed by a 1-based column number, e.g. "A1", "AF48".
+_WELL_KEY_PATTERN = re.compile(r"^([A-Za-z]+)(\d+)$")
 
 
 @dataclass
@@ -92,7 +96,8 @@ class ScanCoordinates:
         self.well_spacing_mm = spacing_mm
         self.number_of_skip = number_of_skip
 
-    def _index_to_row(self, index):
+    @staticmethod
+    def _index_to_row(index):
         index += 1
         row = ""
         while index > 0:
@@ -100,6 +105,18 @@ class ScanCoordinates:
             row = chr(index % 26 + ord("A")) + row
             index //= 26
         return row
+
+    @staticmethod
+    def _parse_well_key(key: str) -> Optional[Tuple[int, int]]:
+        """Split a well region name like "AA12" into 0-based (row, column) indices.
+
+        Returns None for region names that are not well IDs (e.g. "current" or a
+        user-supplied flexible-region name).
+        """
+        match = _WELL_KEY_PATTERN.match(key)
+        if not match:
+            return None
+        return (control.utils.row_to_index(match.group(1)), int(match.group(2)) - 1)
 
     def get_selected_wells(self):
         # get selected wells from the widget
@@ -550,6 +567,9 @@ class ScanCoordinates:
         if len(self.region_centers) <= 1:
             return
 
+        # Parse each region name once; wells[key] is (row, col) or None for non-well names.
+        wells = {key: None if self._is_manual_region(key) else self._parse_well_key(key) for key in self.region_centers}
+
         def sort_key(item):
             key, coord = item
             if self._is_manual_region(key):
@@ -557,36 +577,42 @@ class ScanCoordinates:
                 # They sort before wells (priority 0 vs 1)
                 return (0, self._get_manual_region_index(key), 0)
 
-            # Well regions sort by row letter, then column number (e.g., A1, A2, B1, B2)
-            letters = "".join(c for c in key if c.isalpha())
-            numbers = "".join(c for c in key if c.isdigit())
+            if wells[key] is None:
+                # Not a well ID (e.g. "current", or a named flexible region). Keep these
+                # after the wells in insertion order - sorted() is stable.
+                return (2, 0, 0)
 
-            # Convert multi-letter row (e.g., "AA") to numeric value
-            letter_value = 0
-            for i, letter in enumerate(reversed(letters)):
-                letter_value += (ord(letter) - ord("A")) * (26**i)
-
-            return (1, letter_value, int(numbers))
+            # Well regions sort by row, then column number (e.g., A1, A2, B1, B2)
+            return (1, *wells[key])
 
         sorted_items = sorted(self.region_centers.items(), key=sort_key)
 
         if self.acquisition_pattern == "S-Pattern":
             # S-Pattern only applies to well plates - manual regions stay in drawing order
             # because the user's drawing order already represents their intended path
-            manual_items = [(k, v) for k, v in sorted_items if self._is_manual_region(k)]
-            well_items = [(k, v) for k, v in sorted_items if not self._is_manual_region(k)]
+            manual_items = []
+            well_items = []
+            other_items = []
+            for k, v in sorted_items:
+                if self._is_manual_region(k):
+                    manual_items.append((k, v))
+                elif wells[k] is not None:
+                    well_items.append((k, v))
+                else:
+                    other_items.append((k, v))
 
-            # Reverse alternate rows to create serpentine path (reduces stage travel)
-            if well_items:
-                rows = itertools.groupby(well_items, key=lambda x: x[0][0])
-                well_items = []
-                for i, (_, group) in enumerate(rows):
-                    row = list(group)
-                    if i % 2 == 1:
-                        row.reverse()
-                    well_items.extend(row)
+            # Reverse alternate rows to create serpentine path (reduces stage travel).
+            # Group by row index rather than the first character, since "A1" and "AA1"
+            # are different rows on a 1536-well plate.
+            serpentined = []
+            row_groups = itertools.groupby(well_items, key=lambda item: wells[item[0]][0])
+            for i, (_, group) in enumerate(row_groups):
+                row = list(group)
+                if i % 2 == 1:
+                    row.reverse()
+                serpentined.extend(row)
 
-            sorted_items = manual_items + well_items
+            sorted_items = manual_items + serpentined + other_items
 
         # Update dictionaries efficiently
         self.region_centers = {k: v for k, v in sorted_items}
@@ -704,30 +730,15 @@ class ScanCoordinatesSiLA2(ScanCoordinates):
         pattern = r"([A-Za-z]+)(\d+):?([A-Za-z]*)(\d*)"
         descriptions = well_names.split(",")
 
-        def row_to_index(row):
-            index = 0
-            for char in row:
-                index = index * 26 + (ord(char.upper()) - ord("A") + 1)
-            return index - 1
-
-        def index_to_row(index):
-            index += 1
-            row = ""
-            while index > 0:
-                index -= 1
-                row = chr(index % 26 + ord("A")) + row
-                index //= 26
-            return row
-
         for desc in descriptions:
             match = re.match(pattern, desc.strip())
             if match:
                 start_row, start_col, end_row, end_col = match.groups()
-                start_row_index = row_to_index(start_row)
+                start_row_index = control.utils.row_to_index(start_row)
                 start_col_index = int(start_col) - 1
 
                 if end_row and end_col:  # It's a range
-                    end_row_index = row_to_index(end_row)
+                    end_row_index = control.utils.row_to_index(end_row)
                     end_col_index = int(end_col) - 1
                     for row in range(min(start_row_index, end_row_index), max(start_row_index, end_row_index) + 1):
                         cols = range(min(start_col_index, end_col_index), max(start_col_index, end_col_index) + 1)
@@ -746,7 +757,7 @@ class ScanCoordinatesSiLA2(ScanCoordinates):
                                 + row * wellplate_settings["well_spacing_mm"]
                                 + control._def.WELLPLATE_OFFSET_Y_mm
                             )
-                            self.region_centers[index_to_row(row) + str(col + 1)] = (x_mm, y_mm)
+                            self.region_centers[self._index_to_row(row) + str(col + 1)] = (x_mm, y_mm)
                 else:
                     x_mm = (
                         wellplate_settings["a1_x_mm"]

--- a/software/control/utils.py
+++ b/software/control/utils.py
@@ -652,6 +652,26 @@ def parse_well_id(well_id: str) -> Tuple[str, str]:
     return (letter_part, number_part)
 
 
+def row_to_index(row: str) -> int:
+    """Convert a well row label to a 0-based row index.
+
+    Row labels are bijective base-26 (A=0, ..., Z=25, AA=26, ..., AF=31 on a
+    1536-well plate), so a leading "A" is worth 26 and must not be treated as a
+    plain base-26 zero digit. Sorting rows by this index is NOT the same as
+    sorting the labels as strings ("AA" < "B" lexicographically).
+
+    Args:
+        row: Row letters, e.g. "A", "Z", "AA" (case-insensitive)
+
+    Returns:
+        0-based row index
+    """
+    index = 0
+    for char in row.upper():
+        index = index * 26 + (ord(char) - ord("A") + 1)
+    return index - 1
+
+
 # -----------------------------------------------------------------------------
 # Zarr path building utilities
 # -----------------------------------------------------------------------------

--- a/software/tests/control/core/test_scan_coordinates.py
+++ b/software/tests/control/core/test_scan_coordinates.py
@@ -1,4 +1,5 @@
 import tests.control.gui_test_stubs as gts
+import control.utils
 import squid.stage
 from control.core.scan_coordinates import (
     ScanCoordinates,
@@ -102,3 +103,55 @@ def test_sort_coordinates_manual_regions_preserve_drawing_order():
     keys = list(sc.region_centers.keys())
     # Manual regions first (drawing order), then wells (S-Pattern: row B reversed)
     assert keys == ["manual0", "manual1", "A1", "A2", "B2", "B1"]
+
+
+def _make_scan_coordinates(pattern, region_names):
+    """Build a ScanCoordinates with the given acquisition pattern and region names.
+
+    Region positions are irrelevant to sorting, so they are all zeroed.
+    """
+    scope = Microscope.build_from_global_config(simulated=True)
+    sc = ScanCoordinates(scope.objective_store, scope.stage, scope.camera)
+    sc.acquisition_pattern = pattern
+    sc.region_centers = {name: [0.0, 0.0] for name in region_names}
+    sc.region_fov_coordinates = {name: [(0.0, 0.0, 0.0)] for name in region_names}
+    return sc
+
+
+def test_row_to_index_roundtrips_multi_letter_rows():
+    """Row labels are bijective base-26, so AA is row 26 - not a duplicate of A."""
+    for index in range(32):  # A..AF, the rows of a 1536-well plate
+        assert control.utils.row_to_index(ScanCoordinates._index_to_row(index)) == index
+
+    assert control.utils.row_to_index("A") == 0
+    assert control.utils.row_to_index("Z") == 25
+    assert control.utils.row_to_index("AA") == 26
+    assert control.utils.row_to_index("AF") == 31
+
+
+def test_sort_coordinates_orders_multi_letter_rows_after_single_letter():
+    """1536-well rows AA..AF must come after Z, not interleave with A..F."""
+    sc = _make_scan_coordinates("Unidirectional", ["AB1", "B1", "AA2", "A1", "Z1", "AA1", "A2"])
+
+    sc.sort_coordinates()
+
+    assert list(sc.region_centers.keys()) == ["A1", "A2", "B1", "Z1", "AA1", "AA2", "AB1"]
+
+
+def test_sort_coordinates_s_pattern_treats_multi_letter_rows_as_distinct_rows():
+    """Serpentine grouping must key on the whole row label, not its first character."""
+    sc = _make_scan_coordinates("S-Pattern", ["A1", "A2", "AA1", "AA2", "AB1", "AB2"])
+
+    sc.sort_coordinates()
+
+    # Three separate rows (A, AA, AB), so only the middle one is reversed.
+    assert list(sc.region_centers.keys()) == ["A1", "A2", "AA2", "AA1", "AB1", "AB2"]
+
+
+def test_sort_coordinates_keeps_non_well_region_names():
+    """Region names that aren't well IDs sort last instead of raising."""
+    sc = _make_scan_coordinates("S-Pattern", ["B1", "current", "A1", "my region"])
+
+    sc.sort_coordinates()
+
+    assert list(sc.region_centers.keys()) == ["A1", "B1", "current", "my region"]


### PR DESCRIPTION
## Problem

Selecting wells across multiple rows on a **1536-well plate** acquires them out of order: rows `AA`–`AF` are interleaved with `A`–`F` instead of following `Z`.

`ScanCoordinates.sort_coordinates()` converted row labels with **plain** base-26:

```python
letter_value += (ord(letter) - ord("A")) * (26**i)
```

Well row labels are **bijective** base-26 — a leading `A` is worth 26, not 0. So `"AA"` evaluated to `0*26 + 0 = 0`, tying exactly with `"A"`, and `"AB"` tied with `"B"`. That put `AA1` before `B1`, `AB1` before `C1`, and so on. Only 1536-well plates are affected, since they are the only format with rows past `Z`.

A second, related defect: the S-Pattern serpentine grouped rows with `key=lambda x: x[0][0]` — the *first character only* — so `A` and `AA`…`AF` collapsed into a single row group and were reversed as one unit.

## Fix

- Added `control.utils.row_to_index()` next to the existing `parse_well_id()` as the canonical bijective base-26 converter.
- `sort_coordinates()` sorts on parsed `(row, col)` indices, so ordering is `A1…A48, B1…, Z48, AA1…AF48`. Each region name is parsed once and shared between the sort key, the serpentine partition, and the groupby key.
- S-Pattern groups by row *index*, so `AA` and `AB` are distinct rows.
- Region names that aren't well IDs (`"current"`, named flexible regions) now sort last instead of hitting `int("")` → `ValueError` — a latent crash whenever a non-well region was mixed with another region.
- `get_hcs_structure()` in `job_processing.py` sorted row letters as strings, so OME-NGFF plate metadata listed rows as `A, AA, AB, …, AF, B, C…` — the order viewers render. Now sorted by row index.
- Removed the nested `row_to_index`/`index_to_row` copies inside `ScanCoordinatesSiLA2.get_selected_well_coordinates()`, which duplicated the class helpers. Net effect: this change *reduces* the number of row-label converters in the codebase.

## Testing

Four new tests in `tests/control/core/test_scan_coordinates.py` covering the roundtrip, multi-letter ordering, S-Pattern row distinctness, and non-well region names. Confirmed they **fail against the old code** (4 failed / 2 passed) and pass with the fix.

- `tests/control/core/`: 324 passed, 3 skipped (re-run after rebasing onto current master)
- Smoke-tested the edited SiLA2 range parser across the Z→AA boundary: `"Z1:AA2"` → `Z1, Z2, AA1, AA2`
- Black clean on all touched files

## Known issue, not addressed here

`control/stitcher.py` assumes single-letter rows (`well_id[0]`, `well_id[1:]` at lines 683, 689, 784-786, 1470, 1635, 1830, 1857). On 1536-well data this writes `"AA1"` as path `A/A1`, and `int("A1")` at line 784 raises. Separate structural issue in the stitching output, deliberately out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)