### PR TITLE
feat(turret): per-slot calibration, backlash compensation, software homing, factory parameter set

### DIFF
--- a/software/conftest.py
+++ b/software/conftest.py
@@ -1,0 +1,8 @@
+import pyqtgraph
+
+# pyqtgraph's atexit cleanup sweeps every gc-tracked object to re-parent stray
+# QGraphicsItems while the Qt C++ side is already tearing down. In CI this sweep
+# intermittently segfaults the interpreter AFTER the whole suite has passed
+# (exit code 139 with "1488 passed" above it). The sweep only matters for
+# long-lived interactive sessions; a test process is about to exit anyway.
+pyqtgraph.setConfigOptions(exitCleanup=False)

--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -1249,6 +1249,18 @@ OBJECTIVE_TURRET_POSITIONS = {"4x": 1, "10x": 2, "20x": 3, "40x": 4}
 # does not sit exactly at slot 1. 0 on all normal units; set per machine (may be
 # negative).
 OBJECTIVE_TURRET_OFFSET_PULSES = 0
+# Per-slot calibrated absolute pulse targets: slot index (1..4) -> pulses from the
+# homing zero, measured by jogging each slot into alignment (e.g. with the
+# SingleMotor tool). Slots absent from the dict fall back to the theoretical
+# (slot-1)*pulses_per_position + OBJECTIVE_TURRET_OFFSET_PULSES; a listed slot uses
+# its calibrated value verbatim (the global offset is not added). Empty on all
+# normal units; set per machine in the .ini, e.g. {"1": -12, "3": 6640}.
+OBJECTIVE_TURRET_CALIBRATED_PULSES = {}
+# Gear backlash compensation in turret degrees (0..1, 0 disables). When > 0 every
+# slot change first overshoots below the target by this angle and then approaches
+# it from below, so the final approach direction is always the same and gear
+# backlash cancels out.
+OBJECTIVE_TURRET_BACKLASH_DEG = 0.0
 
 
 def _validate_objective_changer_flags(use_xeryon: bool, use_turret: bool) -> None:

--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -1264,6 +1264,15 @@ OBJECTIVE_TURRET_CALIBRATED_PULSES = {}
 # it from below, so the final approach direction is always the same and gear
 # backlash cancels out.
 OBJECTIVE_TURRET_BACKLASH_DEG = 0.0
+# Set True for turret motor models wired with the opposite phase order (same
+# commands spin the other way). The controller then negates move targets, jog
+# signs and the homing-sweep direction bit, and flips position readbacks, so
+# slot mapping, calibration and backlash logic keep working in the same logical
+# coordinate system — OBJECTIVE_TURRET_CALIBRATED_PULSES values are always
+# logical-coordinate pulses. After toggling on an existing machine, re-home and
+# re-measure the calibrated slots: the physical zero moves with the sweep
+# direction.
+OBJECTIVE_TURRET_DIRECTION_INVERTED = False
 
 
 def _validate_objective_changer_flags(use_xeryon: bool, use_turret: bool) -> None:

--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -1254,7 +1254,10 @@ OBJECTIVE_TURRET_OFFSET_PULSES = 0
 # SingleMotor tool). Slots absent from the dict fall back to the theoretical
 # (slot-1)*pulses_per_position + OBJECTIVE_TURRET_OFFSET_PULSES; a listed slot uses
 # its calibrated value verbatim (the global offset is not added). Empty on all
-# normal units; set per machine in the .ini, e.g. {"1": -12, "3": 6640}.
+# normal units; set per machine in the .ini, e.g. {"1": -12, "3": 4415}.
+# NOTE: software homing (2026-07) zeroes at the sensor's fine-search trigger edge,
+# which sits slightly differently from the old driver-homing zero — re-measure
+# calibrated slots after upgrading a machine that had values from the old scheme.
 OBJECTIVE_TURRET_CALIBRATED_PULSES = {}
 # Gear backlash compensation in turret degrees (0..1, 0 disables). When > 0 every
 # slot change first overshoots below the target by this angle and then approaches

--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -1273,6 +1273,13 @@ OBJECTIVE_TURRET_BACKLASH_DEG = 0.0
 # re-measure the calibrated slots: the physical zero moves with the sweep
 # direction.
 OBJECTIVE_TURRET_DIRECTION_INVERTED = False
+# Set True for objective changers whose origin-switch sensor triggers on the
+# opposite logic level (port of SingleMotor's "原点开关极性取反" option, 2026-08-12).
+# Software homing / distance search then invert the DI1 trigger verdict, so the
+# homing direction and the sweep-backoff-fine-search state machine stay unchanged.
+# Toggling on an existing machine requires re-homing: the sensor edge found by
+# fine search (and thus the physical zero) sits on the other side of the window.
+OBJECTIVE_TURRET_DI_INVERT = False
 
 
 def _validate_objective_changer_flags(use_xeryon: bool, use_turret: bool) -> None:

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -160,6 +160,7 @@ class MicroscopeAddons:
                 offset_pulses=control._def.OBJECTIVE_TURRET_OFFSET_PULSES,
                 calibrated_pulses=control._def.OBJECTIVE_TURRET_CALIBRATED_PULSES,
                 backlash_deg=control._def.OBJECTIVE_TURRET_BACKLASH_DEG,
+                direction_inverted=control._def.OBJECTIVE_TURRET_DIRECTION_INVERTED,
                 stage=stage,
             )
             objective_changer = (

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -158,6 +158,8 @@ class MicroscopeAddons:
                 baudrate=control._def.OBJECTIVE_TURRET_BAUDRATE,
                 positions=control._def.OBJECTIVE_TURRET_POSITIONS,
                 offset_pulses=control._def.OBJECTIVE_TURRET_OFFSET_PULSES,
+                calibrated_pulses=control._def.OBJECTIVE_TURRET_CALIBRATED_PULSES,
+                backlash_deg=control._def.OBJECTIVE_TURRET_BACKLASH_DEG,
                 stage=stage,
             )
             objective_changer = (

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -161,6 +161,7 @@ class MicroscopeAddons:
                 calibrated_pulses=control._def.OBJECTIVE_TURRET_CALIBRATED_PULSES,
                 backlash_deg=control._def.OBJECTIVE_TURRET_BACKLASH_DEG,
                 direction_inverted=control._def.OBJECTIVE_TURRET_DIRECTION_INVERTED,
+                di_invert=control._def.OBJECTIVE_TURRET_DI_INVERT,
                 stage=stage,
             )
             objective_changer = (

--- a/software/control/modbus_rtu.py
+++ b/software/control/modbus_rtu.py
@@ -416,6 +416,19 @@ class ModbusRTUClient:
         response = self._send_receive(frame, expected_response_len=7)
         return (response[3] << 8) | response[4]
 
+    def read_input_registers(self, slave_id: int, address: int, count: int) -> list[int]:
+        """Read `count` consecutive 16-bit input registers in one FC 0x04 transaction.
+
+        One frame instead of `count` round-trips — needed by pollers that must see a
+        consistent snapshot of several registers (e.g. DI level + position + alarm)
+        within a tight polling period.
+        """
+        self._require_connected()
+        frame = build_read_input_registers_frame(slave_id, address, count)
+        # Response: slave(1) + fc(1) + byte_count(1) + data(2*count) + crc(2)
+        response = self._send_receive(frame, expected_response_len=5 + 2 * count)
+        return [(response[3 + 2 * i] << 8) | response[4 + 2 * i] for i in range(count)]
+
     def read_input_register_32bit(self, slave_id: int, address: int, signed: bool = False) -> int:
         """Read a 32-bit input register pair via FC 0x04 (see read_input_register)."""
         self._require_connected()

--- a/software/control/objective_turret_controller.py
+++ b/software/control/objective_turret_controller.py
@@ -22,6 +22,9 @@ GEAR_RATIO = 132 / 48
 MOTOR_STEPS_PER_REV = 200
 POSITIONS_PER_REV = 4  # 90 degrees per objective
 POSITION_TOLERANCE_PULSES = 50
+# Upper bound for backlash compensation, in turret degrees. Real gear backlash is a
+# small fraction of a degree; anything larger indicates a misconfigured .ini.
+BACKLASH_MAX_DEG = 1.0
 
 # NiMotion Modbus register map
 REG_SAVE_PARAMS = 0x0008
@@ -120,6 +123,42 @@ _HOMING_PARAMS = [
 ]
 
 
+def _normalize_calibration(calibrated_pulses: Optional[dict]) -> dict:
+    """Validate a slot->absolute-pulses calibration map and normalize its keys to int.
+
+    Comes from per-machine .ini parsing, where JSON object keys are strings and
+    values may be arbitrary; reject anything that is not slot 1..POSITIONS_PER_REV
+    mapped to an integer pulse count so misconfiguration fails fast at init.
+    """
+    if not calibrated_pulses:
+        return {}
+    normalized = {}
+    for key, value in calibrated_pulses.items():
+        try:
+            slot = int(key)
+        except (TypeError, ValueError):
+            raise ValueError(f"OBJECTIVE_TURRET_CALIBRATED_PULSES key {key!r} is not a slot index") from None
+        if not 1 <= slot <= POSITIONS_PER_REV:
+            raise ValueError(f"OBJECTIVE_TURRET_CALIBRATED_PULSES slot {slot} out of range 1..{POSITIONS_PER_REV}")
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError(
+                f"OBJECTIVE_TURRET_CALIBRATED_PULSES[{slot}] must be an integer number of pulses, got {value!r}"
+            )
+        normalized[slot] = value
+    return normalized
+
+
+def _validate_backlash_deg(backlash_deg) -> float:
+    if isinstance(backlash_deg, bool) or not isinstance(backlash_deg, (int, float)):
+        raise ValueError(f"OBJECTIVE_TURRET_BACKLASH_DEG must be a number of degrees, got {backlash_deg!r}")
+    deg = float(backlash_deg)
+    if not 0.0 <= deg <= BACKLASH_MAX_DEG:
+        raise ValueError(
+            f"OBJECTIVE_TURRET_BACKLASH_DEG={deg} out of range 0..{BACKLASH_MAX_DEG} degrees; check the machine .ini"
+        )
+    return deg
+
+
 def _resolve_position(objective_name: str, positions: dict) -> int:
     try:
         return positions[objective_name]
@@ -163,14 +202,17 @@ class ObjectiveTurret4PosControllerSimulation:
         timeout: float = 0.5,
         positions: Optional[dict] = None,
         stage: Optional[squid.abc.AbstractStage] = None,
-        offset_pulses: Optional[int] = None,  # accepted for constructor parity with the real controller
+        # Accepted for constructor parity with the real controller; the simulation
+        # tracks objectives by name and never computes pulses, so all three are unused.
+        offset_pulses: Optional[int] = None,
+        calibrated_pulses: Optional[dict] = None,
+        backlash_deg: Optional[float] = None,
     ):
         from control._def import OBJECTIVE_TURRET_POSITIONS
 
         self._is_open = True
         self._current_objective: Optional[str] = None
         self._positions = dict(positions) if positions is not None else dict(OBJECTIVE_TURRET_POSITIONS)
-        # offset_pulses is unused here: the simulation tracks objectives by name and never computes pulses.
         self._stage = stage
         logger.info("Simulated turret opened (sn=%s)", serial_number)
 
@@ -259,8 +301,15 @@ class ObjectiveTurret4PosController:
         positions: Optional[dict] = None,
         stage: Optional[squid.abc.AbstractStage] = None,
         offset_pulses: Optional[int] = None,
+        calibrated_pulses: Optional[dict] = None,
+        backlash_deg: Optional[float] = None,
     ) -> None:
-        from control._def import OBJECTIVE_TURRET_POSITIONS, OBJECTIVE_TURRET_OFFSET_PULSES
+        from control._def import (
+            OBJECTIVE_TURRET_POSITIONS,
+            OBJECTIVE_TURRET_OFFSET_PULSES,
+            OBJECTIVE_TURRET_CALIBRATED_PULSES,
+            OBJECTIVE_TURRET_BACKLASH_DEG,
+        )
 
         self._slave_id = slave_id
         self._positions = dict(positions) if positions is not None else dict(OBJECTIVE_TURRET_POSITIONS)
@@ -270,6 +319,12 @@ class ObjectiveTurret4PosController:
         if isinstance(offset, bool) or not isinstance(offset, int):
             raise ValueError(f"OBJECTIVE_TURRET_OFFSET_PULSES must be an integer number of pulses, got {offset!r}")
         self._offset_pulses = offset
+        self._calibrated_pulses = _normalize_calibration(
+            calibrated_pulses if calibrated_pulses is not None else OBJECTIVE_TURRET_CALIBRATED_PULSES
+        )
+        self._backlash_deg = _validate_backlash_deg(
+            backlash_deg if backlash_deg is not None else OBJECTIVE_TURRET_BACKLASH_DEG
+        )
         self._stage = stage
         self._current_objective: Optional[str] = None
         self._is_open = False
@@ -299,6 +354,21 @@ class ObjectiveTurret4PosController:
                     f"OBJECTIVE_TURRET_OFFSET_PULSES={self._offset_pulses} exceeds one slot "
                     f"(±{self._pulses_per_position} pulses ≈ 90°); check the machine .ini"
                 )
+
+            # A calibrated slot target that deviates from its theoretical position by more
+            # than one slot means the calibration was measured at a different microstep or
+            # against the wrong slot — same rationale as the offset bound above.
+            for slot, pulses in self._calibrated_pulses.items():
+                theoretical = (slot - 1) * self._pulses_per_position
+                if abs(pulses - theoretical) > self._pulses_per_position:
+                    raise ValueError(
+                        f"OBJECTIVE_TURRET_CALIBRATED_PULSES[{slot}]={pulses} deviates from the "
+                        f"theoretical {theoretical} by more than one slot "
+                        f"(±{self._pulses_per_position} pulses ≈ 90°); check the machine .ini"
+                    )
+
+            # Backlash compensation in motor pulses (one turret revolution = POSITIONS_PER_REV slots).
+            self._backlash_pulses = round(self._backlash_deg / 360.0 * POSITIONS_PER_REV * self._pulses_per_position)
 
             changed = [self._calibrate_motion_params(), self._calibrate_homing_config()]
             if any(changed):
@@ -405,26 +475,33 @@ class ObjectiveTurret4PosController:
         if not self._is_open:
             raise RuntimeError("Turret controller is closed")
 
+    def _target_pulses(self, position_index: int) -> int:
+        """Absolute pulse target for a slot: the per-machine calibrated value when
+        present, else the theoretical slot position shifted by the global offset."""
+        calibrated = self._calibrated_pulses.get(position_index)
+        if calibrated is not None:
+            return calibrated
+        return (position_index - 1) * self._pulses_per_position + self._offset_pulses
+
     def _rotate_to(self, objective_name: str, timeout_s: float) -> None:
         position_index = _resolve_position(objective_name, self._positions)
-        target_pulses = (position_index - 1) * self._pulses_per_position + self._offset_pulses
+        target_pulses = self._target_pulses(position_index)
 
         logger.info(
-            "Rotating to %s: start=%d, target=%d",
+            "Rotating to %s: start=%d, target=%d, backlash_comp=%d",
             objective_name,
             self.current_position_pulses,
             target_pulses,
+            self._backlash_pulses,
         )
 
-        self._write_control(CW_DISABLE)
-        self._write_holding(REG_RUN_MODE, MODE_POSITION)
-        self._modbus.write_register_32bit(self._slave_id, REG_TARGET_POSITION, target_pulses, signed=True)
-        self._write_control(CW_STARTUP)
-        self._write_control(CW_ENABLE)
-        self._write_control(CW_RUN_ABSOLUTE)
-        self._write_control(CW_TRIGGER_ABSOLUTE)
         try:
-            self._wait_for_position(target_pulses, timeout_s)
+            # Backlash compensation: overshoot below the target first, then approach it
+            # from below, so the final approach direction is the same for every slot
+            # change and gear backlash cancels out. comp=0 moves directly.
+            if self._backlash_pulses > 0:
+                self._run_absolute_move(target_pulses - self._backlash_pulses, timeout_s)
+            self._run_absolute_move(target_pulses, timeout_s)
         finally:
             self._deenergize()
         logger.info(
@@ -433,6 +510,16 @@ class ObjectiveTurret4PosController:
             target_pulses,
             self.current_position_pulses,
         )
+
+    def _run_absolute_move(self, target_pulses: int, timeout_s: float) -> None:
+        self._write_control(CW_DISABLE)
+        self._write_holding(REG_RUN_MODE, MODE_POSITION)
+        self._modbus.write_register_32bit(self._slave_id, REG_TARGET_POSITION, target_pulses, signed=True)
+        self._write_control(CW_STARTUP)
+        self._write_control(CW_ENABLE)
+        self._write_control(CW_RUN_ABSOLUTE)
+        self._write_control(CW_TRIGGER_ABSOLUTE)
+        self._wait_for_position(target_pulses, timeout_s)
 
     def _retract_z_if_possible(self) -> Optional[float]:
         from control._def import HOMING_ENABLED_Z, OBJECTIVE_RETRACTED_POS_MM

--- a/software/control/objective_turret_controller.py
+++ b/software/control/objective_turret_controller.py
@@ -28,25 +28,35 @@ BACKLASH_MAX_DEG = 1.0
 
 # NiMotion Modbus register map
 REG_SAVE_PARAMS = 0x0008
-REG_DI_FUNCTION = 0x002C
+REG_CURRENT_DECEL = 0x0015  # x10mA (firmware currently drops writes; see _INIT_PARAMS)
+REG_CURRENT_IDLE = 0x0016  # x10mA; writable only while disabled
+REG_CURRENT_ACCEL = 0x0017  # x10mA
+REG_CURRENT_RUN = 0x0018  # x10mA
+REG_CURRENT_OVERLOAD = 0x0019  # x100mA — unit differs from 0x15..0x18!
 REG_MICROSTEP = 0x001A
-REG_LOW_SPEED_OPT = 0x001F  # holding-register view; same address as status word on input side
-REG_STATUS_WORD = 0x001F
+REG_STATUS_WORD = 0x001F  # input-register side; holding side at this address is unrelated
 REG_CURRENT_POSITION = 0x0021
+REG_DI_FUNCTION = 0x002C
 REG_RUN_MODE = 0x0039
+REG_SET_ZERO = 0x0047
 REG_CONTROL_WORD = 0x0051
+REG_DIRECTION = 0x0052  # 0=reverse, 1=forward; also sets the sign of relative moves
 REG_TARGET_POSITION = 0x0053
+REG_TARGET_SPEED = 0x0055
 REG_MAX_SPEED = 0x005B
 REG_MIN_SPEED = 0x005D
 REG_ACCEL = 0x005F
 REG_DECEL = 0x0061
-REG_HOMING_OFFSET = 0x0069
-REG_HOMING_METHOD = 0x006B
-REG_HOMING_SEARCH_SPEED = 0x006C
-REG_HOMING_ZERO_SPEED = 0x006E
-REG_ZERO_RETURN = 0x0072
 REG_CLEAR_ERROR_STORAGE = 0x0073
-REG_SET_ZERO = 0x0047
+
+# Batch status snapshot (FC 0x04 input registers 0x17..0x26, same block SingleMotor
+# polls): value offsets within the 16-register read.
+STATUS_BLOCK_START = 0x0017
+STATUS_BLOCK_COUNT = 16
+_OFS_DI = 1  # 0x18: raw DI level, bit0 = DI1
+_OFS_STATUS_WORD = 8  # 0x1F
+_OFS_POSITION = 10  # 0x21..0x22, INT32
+_OFS_ALARM = 15  # 0x26
 
 # Control word values
 CW_DISABLE = 0x0000
@@ -54,6 +64,8 @@ CW_STARTUP = 0x0006
 CW_ENABLE = 0x0007
 CW_RUN_ABSOLUTE = 0x000F
 CW_TRIGGER_ABSOLUTE = 0x001F
+CW_RUN_RELATIVE = 0x004F
+CW_TRIGGER_RELATIVE = 0x005F
 CW_CLEAR_FAULT = 0x0080
 
 # Magic values
@@ -63,63 +75,75 @@ SET_ZERO_MAGIC = 0x535A
 
 # Run modes
 MODE_POSITION = 1
-MODE_HOMING = 3
+MODE_SPEED = 2
 
 # Status word bits
 STATUS_BIT_FAULT = 1 << 3
 STATUS_BIT_RUNNING = 1 << 12
 
-# Motion parameter defaults (auto-calibrated on first connect).
-# 200/200 accel/decel avoids step loss under the turret's inertial load (sharper
-# ramps skip steps mid-move).
-EXPECTED_ACCEL = 200
-EXPECTED_DECEL = 200
-EXPECTED_MAX_SPEED = 250
-# NiMotion ramps cruise → min_speed at end of position moves, then continues at
-# min_speed for final-approach pulses. Default 16 step/s makes that segment audibly
-# slow; 150 keeps it brief while leaving decel range.
-EXPECTED_MIN_SPEED = 150
-# 0x001F low-speed optimization. Manual says 0 = disabled; empirically a no-op on
-# this firmware (motion is identical at 0 or 1). Set to 0 for documented-disabled.
-DRIVE_PARAM = 0
+# Factory parameter set, ported from SingleMotor MotorService.INIT_PARAMS
+# (2026-07-24 acceptance values, max speed revised 2026-07-25). Speed registers are
+# in Step/s (full steps); pulses/s = Step/s x microstep.
+MICROSTEP_REG_VALUE = 4  # 2^4 = 16 microsteps; register takes effect after power cycle
+EXPECTED_ACCEL = 1000  # Step/s^2 (hardware limit ~2000; >=3000 is rejected)
+EXPECTED_DECEL = 1000
+EXPECTED_MIN_SPEED = 16  # manual default start/stop speed
+EXPECTED_MAX_SPEED = 200  # x16 microstep = 3200 pulses/s ~= 131 deg/s at the turret
+# Currents: with 2 objectives loaded the factory 0.51 A run current loses steps;
+# 0.85 A and up does not. Driver firmware caps 0x16..0x18 at 95 (=0.95 A).
+EXPECTED_CURRENT_OVERLOAD = 13  # x100mA = 1.3 A
+EXPECTED_CURRENT_IDLE = 60  # x10mA = 0.6 A
+EXPECTED_CURRENT_ACCEL = 95  # x10mA = 0.95 A
+EXPECTED_CURRENT_RUN = 95  # x10mA = 0.95 A
+EXPECTED_CURRENT_DECEL = 95  # x10mA = 0.95 A (see volatile note in _INIT_PARAMS)
+# DI1 is permanently "origin switch" (3). The homing sensor must NEVER be configured
+# as a limit switch: the turret is a disc with no travel limits, and a limit-mapped
+# sensor faults FF0E whenever a normal move passes it (the pre-2026-07-24 scheme).
+DI1_FUNCTION_ORIGIN_SWITCH = 3
 
-# Homing defaults (auto-calibrated on first connect). counter=0 is established at
-# the limit switch by the SET_ZERO in home(); HOMING_ORIGIN_OFFSET=0 keeps the
-# NiMotion's own homing-offset register out of the picture (SET_ZERO cancels it
-# anyway). On units where slot 1 does not sit exactly at the switch, the
-# correction is applied in software instead — see OBJECTIVE_TURRET_OFFSET_PULSES.
-HOMING_METHOD = 17
-HOMING_ORIGIN_OFFSET = 0
-HOMING_SEARCH_SPEED = 1000
-HOMING_ZERO_SPEED = 200
-HOMING_ZERO_RETURN = 1
-DI1_FUNCTION_NEG_LIMIT = 1
+# Software homing (ported from SingleMotor HomeSearch, 2026-07-24): sweep toward the
+# sensor in velocity mode while polling the DI level, decel-stop on trigger, back off
+# until the switch releases, then fine-step back to the trigger edge and SET_ZERO
+# there. The driver's built-in homing modes are no longer used — the sensed window is
+# only ~50 pulses wide and the sweep speed/poll period pair below guarantees the
+# window cannot be crossed between two polls (62.5 ms crossing >= 2 poll periods).
+HOMING_SWEEP_SPEED = 50  # Step/s, velocity-mode sweep toward the sensor
+HOMING_POLL_S = 0.025  # DI poll period during the sweep
+HOMING_STOP_SETTLE_S = 0.4  # settle after the sweep decel-stop
+HOMING_BACKOFF_STEP = 150  # pulses per backoff jog (release the switch)
+HOMING_FINE_STEP = 5  # pulses per fine-search jog; sets home repeatability (+/-5)
+HOMING_MAX_TRAVEL = 10000  # pulses; > one turret revolution (8800 at microstep 16)
+HOMING_FINE_TRAVEL_LIMIT = 400  # backoff 150 + window 50 + margin; bounds a bad trigger
+HOMING_JOG_SPEED = 60  # Step/s; max speed is temporarily lowered to this for jogs
+HOMING_SETTLE_MARGIN_S = 0.3  # fixed margin on top of the per-jog travel-time estimate
 
 # Polling
 POLL_INTERVAL_S = 0.05
-# At accel=200/max_speed=250, slot 1 → slot 4 (~6600 pulses) takes ~25s. 30s
-# matches SingleMotor's UI timeout (_MOVING_TIMEOUT_MS in turret_panel.py).
+# At accel=1000/max_speed=200, a worst-case 3-slot move stays well inside 30s.
 DEFAULT_MOVE_TIMEOUT_S = 30.0
-DEFAULT_HOME_TIMEOUT_S = 30.0
+# Software homing worst case: sweep up to one revolution at 800 pulses/s plus tens of
+# ~0.3s fine/backoff jogs. Matches SingleMotor's 120s watchdog.
+DEFAULT_HOME_TIMEOUT_S = 120.0
 
 # Settle time after a control-word transition before the next write.
 CONTROL_WORD_SETTLE_S = 0.1
 
-# Calibration tables: (register, expected value, label, kwargs-for-_calibrate_one).
-_MOTION_PARAMS = [
+# Init calibration table: (register, expected value, label, kwargs-for-_calibrate_one).
+# Order matters: min_speed must be written before max_speed (the firmware rejects a
+# max-speed write below the current min speed). "volatile": the write never sticks
+# (firmware bug: 0x15 echoes OK but reads back 0), so it must not trigger an EEPROM
+# save on every connect.
+_INIT_PARAMS = [
     (REG_ACCEL, EXPECTED_ACCEL, "accel", {"is_32bit": True}),
     (REG_DECEL, EXPECTED_DECEL, "decel", {"is_32bit": True}),
-    (REG_MAX_SPEED, EXPECTED_MAX_SPEED, "max_speed", {"is_32bit": True}),
     (REG_MIN_SPEED, EXPECTED_MIN_SPEED, "min_speed", {"is_32bit": True}),
-    (REG_LOW_SPEED_OPT, DRIVE_PARAM, "drive_param", {}),
-]
-_HOMING_PARAMS = [
-    (REG_HOMING_METHOD, HOMING_METHOD, "homing_method", {}),
-    (REG_HOMING_OFFSET, HOMING_ORIGIN_OFFSET, "homing_offset", {"is_32bit": True, "signed": True}),
-    (REG_HOMING_SEARCH_SPEED, HOMING_SEARCH_SPEED, "homing_search_speed", {"is_32bit": True}),
-    (REG_HOMING_ZERO_SPEED, HOMING_ZERO_SPEED, "homing_zero_speed", {"is_32bit": True}),
-    (REG_ZERO_RETURN, HOMING_ZERO_RETURN, "zero_return", {}),
-    (REG_DI_FUNCTION, DI1_FUNCTION_NEG_LIMIT, "DI1_function", {"is_32bit": True, "mask": 0xF}),
+    (REG_MAX_SPEED, EXPECTED_MAX_SPEED, "max_speed", {"is_32bit": True}),
+    (REG_CURRENT_OVERLOAD, EXPECTED_CURRENT_OVERLOAD, "overload_current", {}),
+    (REG_CURRENT_IDLE, EXPECTED_CURRENT_IDLE, "idle_current", {}),
+    (REG_CURRENT_ACCEL, EXPECTED_CURRENT_ACCEL, "accel_current", {}),
+    (REG_CURRENT_RUN, EXPECTED_CURRENT_RUN, "run_current", {}),
+    (REG_CURRENT_DECEL, EXPECTED_CURRENT_DECEL, "decel_current", {"volatile": True}),
+    (REG_DI_FUNCTION, DI1_FUNCTION_ORIGIN_SWITCH, "DI1_function", {"is_32bit": True, "mask": 0xF}),
 ]
 
 
@@ -343,6 +367,18 @@ class ObjectiveTurret4PosController:
             microstep_raw = self._modbus.read_register(self._slave_id, REG_MICROSTEP)
             if not 0 <= microstep_raw <= 7:
                 raise ValueError(f"Invalid microstep register value {microstep_raw} (expected 0..7)")
+            if microstep_raw != MICROSTEP_REG_VALUE:
+                # Factory config fixes microstep at 16; per-machine calibrated pulses
+                # and the homing sweep math assume it. The register only takes effect
+                # after a power cycle, so fail fast instead of running this session on
+                # a mismatched scale.
+                self._modbus.write_register(self._slave_id, REG_MICROSTEP, MICROSTEP_REG_VALUE)
+                self._save_to_eeprom()
+                raise RuntimeError(
+                    f"Turret microstep register was {microstep_raw} (2^{microstep_raw} microsteps); "
+                    f"wrote factory value {MICROSTEP_REG_VALUE} (16 microsteps) and saved to EEPROM. "
+                    "Power-cycle the turret and restart."
+                )
             self._microstep = 2**microstep_raw
             self._pulses_per_position = int(MOTOR_STEPS_PER_REV * self._microstep * GEAR_RATIO / POSITIONS_PER_REV)
 
@@ -370,16 +406,20 @@ class ObjectiveTurret4PosController:
             # Backlash compensation in motor pulses (one turret revolution = POSITIONS_PER_REV slots).
             self._backlash_pulses = round(self._backlash_deg / 360.0 * POSITIONS_PER_REV * self._pulses_per_position)
 
-            changed = [self._calibrate_motion_params(), self._calibrate_homing_config()]
-            if any(changed):
+            changed = self._calibrate_init_params()
+            if changed:
                 self._save_to_eeprom()
+            # RAM-only runtime parameter, written AFTER the EEPROM save so it is not
+            # persisted (the save command snapshots current RAM; the manual forbids
+            # persisting the direction register, which moves rewrite dynamically).
+            self._calibrate_one(REG_DIRECTION, 1, "direction")
 
             logger.info(
                 "Turret controller ready: port=%s microstep=%d pulses/position=%d calibrated=%s",
                 port,
                 self._microstep,
                 self._pulses_per_position,
-                any(changed),
+                changed,
             )
 
             # Leave the motor de-energized; home()/move_to_objective() energize on demand.
@@ -390,25 +430,46 @@ class ObjectiveTurret4PosController:
             raise
 
     def home(self, timeout_s: float = DEFAULT_HOME_TIMEOUT_S) -> None:
+        """Software homing, ported from SingleMotor HomeSearch.start_homing.
+
+        sweep -> backoff -> fine-search, then SET_ZERO at the sensor's trigger edge
+        and clamp at home with holding torque. The driver's built-in homing modes
+        are not used. Repeatability is +/-HOMING_FINE_STEP pulses (hardware-measured
+        0-pulse deviation between runs).
+        """
         self._require_open()
+        deadline = time.monotonic() + timeout_s
+        # Parameter writes require the disabled state.
         self._write_control(CW_DISABLE)
-        self._write_holding(REG_RUN_MODE, MODE_HOMING)
-        self._write_control(CW_STARTUP)
-        self._write_control(CW_ENABLE)
-        self._write_control(CW_RUN_ABSOLUTE)
-        self._write_control(CW_TRIGGER_ABSOLUTE)
+        # Zero the counter at the start so the sweep travel bound is relative to it.
+        self._write_holding(REG_SET_ZERO, SET_ZERO_MAGIC)
+        # Temporarily lower max speed for backoff/fine jog precision; restore after.
+        orig_max_speed = self._modbus.read_register_32bit(self._slave_id, REG_MAX_SPEED)
+        if orig_max_speed != HOMING_JOG_SPEED:
+            self._modbus.write_register_32bit(self._slave_id, REG_MAX_SPEED, HOMING_JOG_SPEED)
         try:
-            self._wait_until_idle(timeout_s)
-            # Reset counter to 0 at the post-homing position so absolute slot targets
-            # land at the correct physical angle.
-            pre = self.current_position_pulses
+            di1, _, _, alarm = self._read_status_snapshot()
+            self._check_alarm(alarm)
+            if not di1:  # already inside the sensor window -> skip straight to backoff
+                self._sweep_to_sensor(deadline)
+            self._backoff_off_sensor(deadline)
+            self._fine_search_to_edge(deadline)
+            # At the trigger edge: establish the home reference.
             self._write_holding(REG_SET_ZERO, SET_ZERO_MAGIC)
             time.sleep(0.05)
-            post = self.current_position_pulses
         finally:
+            # Stop before restoring parameters (writes are rejected while enabled).
+            # Best-effort so cleanup never masks the fault/timeout that got us here.
             self._deenergize()
+            if orig_max_speed != HOMING_JOG_SPEED:
+                try:
+                    self._modbus.write_register_32bit(self._slave_id, REG_MAX_SPEED, orig_max_speed)
+                except Exception as exc:
+                    logger.warning("Failed to restore max speed after homing: %s", exc)
+        # Success: hold the turret at home with torque until the next move.
+        self._hold_position_clamp()
         self._current_objective = None
-        logger.info("Homed: pre_set_zero=%d, post_set_zero=%d", pre, post)
+        logger.info("Homed at sensor edge (repeatability +/-%d pulses)", HOMING_FINE_STEP)
 
     def enable(self) -> None:
         """Run the disable -> startup -> enable state-machine cycle."""
@@ -521,6 +582,106 @@ class ObjectiveTurret4PosController:
         self._write_control(CW_TRIGGER_ABSOLUTE)
         self._wait_for_position(target_pulses, timeout_s)
 
+    # --- software homing internals ---
+
+    def _read_status_snapshot(self) -> tuple:
+        """One batched input-register read -> (di1_triggered, status_word, position, alarm).
+
+        A single FC 0x04 frame keeps the sweep poll period tight and the DI/position
+        values consistent with each other (same block SingleMotor polls)."""
+        vals = self._modbus.read_input_registers(self._slave_id, STATUS_BLOCK_START, STATUS_BLOCK_COUNT)
+        di1 = bool(vals[_OFS_DI] & 1)
+        position = (vals[_OFS_POSITION] << 16) | vals[_OFS_POSITION + 1]
+        if position >= 0x80000000:
+            position -= 0x100000000
+        return di1, vals[_OFS_STATUS_WORD], position, vals[_OFS_ALARM]
+
+    @staticmethod
+    def _check_alarm(alarm: int) -> None:
+        # Fail fast: an alarm (undervoltage etc.) interrupts motion, so waiting for
+        # the timeout would only hide the cause.
+        if alarm != 0:
+            raise RuntimeError(f"Drive alarm 0x{alarm:04X} during homing")
+
+    @staticmethod
+    def _check_deadline(deadline: float, phase: str) -> None:
+        if time.monotonic() > deadline:
+            raise TimeoutError(f"Homing timed out during {phase}")
+
+    def _sweep_to_sensor(self, deadline: float) -> None:
+        """Velocity-mode sweep toward the sensor, polling the DI level; decel-stop on
+        trigger. The sweep-speed/poll-period pairing guarantees the ~50-pulse sensor
+        window cannot be skipped between two polls."""
+        self._write_control(CW_DISABLE)
+        self._write_holding(REG_RUN_MODE, MODE_SPEED)
+        self._write_holding(REG_DIRECTION, 0)  # negative, toward the sensor
+        self._modbus.write_register_32bit(self._slave_id, REG_TARGET_SPEED, HOMING_SWEEP_SPEED)
+        self._write_control(CW_STARTUP)
+        self._write_control(CW_ENABLE)
+        self._write_control(CW_RUN_ABSOLUTE)
+        try:
+            while True:
+                self._check_deadline(deadline, "sweep")
+                di1, _, position, alarm = self._read_status_snapshot()
+                self._check_alarm(alarm)
+                if di1:
+                    return
+                if abs(position) > HOMING_MAX_TRAVEL:
+                    raise RuntimeError("Homing sweep found no sensor within one revolution (direction/wiring?)")
+                time.sleep(HOMING_POLL_S)
+        finally:
+            self._write_control(CW_ENABLE)  # decelerate-stop
+            time.sleep(HOMING_STOP_SETTLE_S)
+
+    def _jog(self, pulses: int) -> None:
+        """Relative move: direction from REG_DIRECTION, REG_TARGET_POSITION takes the
+        positive magnitude only (a negative value is rejected as invalid). Settle is
+        time-based because short jogs do not reliably assert the RUNNING bit."""
+        self._write_control(CW_DISABLE)
+        self._write_holding(REG_RUN_MODE, MODE_POSITION)
+        self._write_holding(REG_DIRECTION, 1 if pulses >= 0 else 0)
+        self._modbus.write_register_32bit(self._slave_id, REG_TARGET_POSITION, abs(pulses))
+        self._write_control(CW_STARTUP)
+        self._write_control(CW_ENABLE)
+        self._write_control(CW_RUN_RELATIVE)
+        self._write_control(CW_TRIGGER_RELATIVE)
+        jog_pps = HOMING_JOG_SPEED * self._microstep
+        time.sleep(abs(pulses) / jog_pps * 1.3 + HOMING_SETTLE_MARGIN_S)
+
+    def _backoff_off_sensor(self, deadline: float) -> None:
+        """Back away (positive direction) until the switch releases."""
+        while True:
+            self._check_deadline(deadline, "backoff")
+            di1, _, _, alarm = self._read_status_snapshot()
+            self._check_alarm(alarm)
+            if not di1:
+                return
+            self._jog(+HOMING_BACKOFF_STEP)
+
+    def _fine_search_to_edge(self, deadline: float) -> None:
+        """Approach the sensor again in HOMING_FINE_STEP jogs until it triggers; that
+        quantized edge is the home reference."""
+        travel = 0
+        while True:
+            self._check_deadline(deadline, "fine search")
+            self._jog(-HOMING_FINE_STEP)
+            travel += HOMING_FINE_STEP
+            di1, _, _, alarm = self._read_status_snapshot()
+            self._check_alarm(alarm)
+            if di1:
+                return
+            if travel > HOMING_FINE_TRAVEL_LIMIT:
+                raise RuntimeError("Homing fine search overran the sensor window (trigger signal wiring?)")
+
+    def _hold_position_clamp(self) -> None:
+        """Re-enable to OPERATION_ENABLED in position mode without a trigger bit: no
+        motion results, but only 0x0F applies holding current — this clamps the
+        turret at home against external disturbance."""
+        self._write_holding(REG_RUN_MODE, MODE_POSITION)
+        self._write_control(CW_STARTUP)
+        self._write_control(CW_ENABLE)
+        self._write_control(CW_RUN_ABSOLUTE)
+
     def _retract_z_if_possible(self) -> Optional[float]:
         from control._def import HOMING_ENABLED_Z, OBJECTIVE_RETRACTED_POS_MM
 
@@ -562,11 +723,17 @@ class ObjectiveTurret4PosController:
         logger.info("%s @ 0x%04X: %s -> %s (wrote)", label, addr, current_str, desired_str)
         return True
 
-    def _calibrate_motion_params(self) -> bool:
-        return any([self._calibrate_one(*a, **kw) for *a, kw in _MOTION_PARAMS])
-
-    def _calibrate_homing_config(self) -> bool:
-        return any([self._calibrate_one(*a, **kw) for *a, kw in _HOMING_PARAMS])
+    def _calibrate_init_params(self) -> bool:
+        """Bring every factory parameter in line with _INIT_PARAMS; return whether a
+        persistent write happened (volatile entries are rewritten each connect but
+        must not trigger an EEPROM save every time)."""
+        changed = False
+        for addr, expected, label, kwargs in _INIT_PARAMS:
+            kwargs = dict(kwargs)
+            volatile = kwargs.pop("volatile", False)
+            wrote = self._calibrate_one(addr, expected, label, **kwargs)
+            changed = changed or (wrote and not volatile)
+        return changed
 
     def _save_to_eeprom(self) -> None:
         self._write_holding(REG_SAVE_PARAMS, SAVE_PARAMS_MAGIC)
@@ -597,17 +764,6 @@ class ObjectiveTurret4PosController:
     def _check_fault(status_word: int) -> None:
         if status_word & STATUS_BIT_FAULT:
             raise RuntimeError(f"Motor reported fault (status word=0x{status_word:04X})")
-
-    def _wait_until_idle(self, timeout_s: float) -> None:
-        deadline = time.monotonic() + timeout_s
-        time.sleep(POLL_INTERVAL_S)
-        while time.monotonic() < deadline:
-            status = self._read_status_word()
-            self._check_fault(status)
-            if not (status & STATUS_BIT_RUNNING):
-                return
-            time.sleep(POLL_INTERVAL_S)
-        raise TimeoutError(f"Motion did not finish within {timeout_s:.1f}s")
 
     def _wait_for_position(self, target_pulses: int, timeout_s: float) -> None:
         # No leading sleep: seen_running prevents stall detection before the motor asserts RUNNING.

--- a/software/control/objective_turret_controller.py
+++ b/software/control/objective_turret_controller.py
@@ -232,10 +232,11 @@ class ObjectiveTurret4PosControllerSimulation:
         positions: Optional[dict] = None,
         stage: Optional[squid.abc.AbstractStage] = None,
         # Accepted for constructor parity with the real controller; the simulation
-        # tracks objectives by name and never computes pulses, so all three are unused.
+        # tracks objectives by name and never computes pulses, so all four are unused.
         offset_pulses: Optional[int] = None,
         calibrated_pulses: Optional[dict] = None,
         backlash_deg: Optional[float] = None,
+        direction_inverted: Optional[bool] = None,
     ):
         from control._def import OBJECTIVE_TURRET_POSITIONS
 
@@ -332,12 +333,14 @@ class ObjectiveTurret4PosController:
         offset_pulses: Optional[int] = None,
         calibrated_pulses: Optional[dict] = None,
         backlash_deg: Optional[float] = None,
+        direction_inverted: Optional[bool] = None,
     ) -> None:
         from control._def import (
             OBJECTIVE_TURRET_POSITIONS,
             OBJECTIVE_TURRET_OFFSET_PULSES,
             OBJECTIVE_TURRET_CALIBRATED_PULSES,
             OBJECTIVE_TURRET_BACKLASH_DEG,
+            OBJECTIVE_TURRET_DIRECTION_INVERTED,
         )
 
         self._slave_id = slave_id
@@ -354,6 +357,14 @@ class ObjectiveTurret4PosController:
         self._backlash_deg = _validate_backlash_deg(
             backlash_deg if backlash_deg is not None else OBJECTIVE_TURRET_BACKLASH_DEG
         )
+        # Direction inversion for motor models wired with the opposite phase order.
+        # Applied only at the register boundary (move targets, jog signs, sweep
+        # direction bit, position readbacks); everything above works in logical
+        # coordinates, so calibration/backlash/homing logic is inversion-agnostic.
+        inverted = direction_inverted if direction_inverted is not None else OBJECTIVE_TURRET_DIRECTION_INVERTED
+        if not isinstance(inverted, bool):
+            raise ValueError(f"OBJECTIVE_TURRET_DIRECTION_INVERTED must be a boolean, got {inverted!r}")
+        self._direction_inverted = inverted
         self._stage = stage
         self._current_objective: Optional[str] = None
         self._is_open = False
@@ -417,7 +428,7 @@ class ObjectiveTurret4PosController:
             # RAM-only runtime parameter, written AFTER the EEPROM save so it is not
             # persisted (the save command snapshots current RAM; the manual forbids
             # persisting the direction register, which moves rewrite dynamically).
-            self._calibrate_one(REG_DIRECTION, 1, "direction")
+            self._calibrate_one(REG_DIRECTION, self._physical_direction(1), "direction")
 
             logger.info(
                 "Turret controller ready: port=%s microstep=%d pulses/position=%d calibrated=%s",
@@ -538,7 +549,8 @@ class ObjectiveTurret4PosController:
 
     @property
     def current_position_pulses(self) -> int:
-        return self._modbus.read_input_register_32bit(self._slave_id, REG_CURRENT_POSITION, signed=True)
+        raw = self._modbus.read_input_register_32bit(self._slave_id, REG_CURRENT_POSITION, signed=True)
+        return -raw if self._direction_inverted else raw
 
     @property
     def current_objective(self) -> Optional[str]:
@@ -553,6 +565,10 @@ class ObjectiveTurret4PosController:
     def _require_open(self) -> None:
         if not self._is_open:
             raise RuntimeError("Turret controller is closed")
+
+    def _physical_direction(self, logical_direction: int) -> int:
+        """Map a logical direction bit (1=positive) to the physical register value."""
+        return logical_direction ^ 1 if self._direction_inverted else logical_direction
 
     def _target_pulses(self, position_index: int) -> int:
         """Absolute pulse target for a slot: the per-machine calibrated value when
@@ -593,7 +609,10 @@ class ObjectiveTurret4PosController:
     def _run_absolute_move(self, target_pulses: int, timeout_s: float) -> None:
         self._write_control(CW_DISABLE)
         self._write_holding(REG_RUN_MODE, MODE_POSITION)
-        self._modbus.write_register_32bit(self._slave_id, REG_TARGET_POSITION, target_pulses, signed=True)
+        # The register takes physical coordinates; the wait below compares logical
+        # target against the logical position readback, so it stays un-negated.
+        physical_target = -target_pulses if self._direction_inverted else target_pulses
+        self._modbus.write_register_32bit(self._slave_id, REG_TARGET_POSITION, physical_target, signed=True)
         self._write_control(CW_STARTUP)
         self._write_control(CW_ENABLE)
         self._write_control(CW_RUN_ABSOLUTE)
@@ -612,6 +631,8 @@ class ObjectiveTurret4PosController:
         position = (vals[_OFS_POSITION] << 16) | vals[_OFS_POSITION + 1]
         if position >= 0x80000000:
             position -= 0x100000000
+        if self._direction_inverted:
+            position = -position
         return di1, vals[_OFS_STATUS_WORD], position, vals[_OFS_ALARM]
 
     @staticmethod
@@ -632,7 +653,7 @@ class ObjectiveTurret4PosController:
         window cannot be skipped between two polls."""
         self._write_control(CW_DISABLE)
         self._write_holding(REG_RUN_MODE, MODE_SPEED)
-        self._write_holding(REG_DIRECTION, 0)  # negative, toward the sensor
+        self._write_holding(REG_DIRECTION, self._physical_direction(0))  # logical negative, toward the sensor
         self._modbus.write_register_32bit(self._slave_id, REG_TARGET_SPEED, HOMING_SWEEP_SPEED)
         self._write_control(CW_STARTUP)
         self._write_control(CW_ENABLE)
@@ -654,7 +675,10 @@ class ObjectiveTurret4PosController:
     def _jog(self, pulses: int) -> None:
         """Relative move: direction from REG_DIRECTION, REG_TARGET_POSITION takes the
         positive magnitude only (a negative value is rejected as invalid). Settle is
-        time-based because short jogs do not reliably assert the RUNNING bit."""
+        time-based because short jogs do not reliably assert the RUNNING bit.
+        `pulses` is logical; inversion negates it before the direction/magnitude split."""
+        if self._direction_inverted:
+            pulses = -pulses
         self._write_control(CW_DISABLE)
         self._write_holding(REG_RUN_MODE, MODE_POSITION)
         self._write_holding(REG_DIRECTION, 1 if pulses >= 0 else 0)

--- a/software/control/objective_turret_controller.py
+++ b/software/control/objective_turret_controller.py
@@ -28,7 +28,7 @@ BACKLASH_MAX_DEG = 1.0
 
 # NiMotion Modbus register map
 REG_SAVE_PARAMS = 0x0008
-REG_CURRENT_DECEL = 0x0015  # x10mA (firmware currently drops writes; see _INIT_PARAMS)
+REG_CURRENT_DECEL = 0x0015  # unused: the SDM42 drive has no decel current (writes silently dropped, reads 0)
 REG_CURRENT_IDLE = 0x0016  # x10mA; writable only while disabled
 REG_CURRENT_ACCEL = 0x0017  # x10mA
 REG_CURRENT_RUN = 0x0018  # x10mA
@@ -88,40 +88,48 @@ MICROSTEP_REG_VALUE = 4  # 2^4 = 16 microsteps; register takes effect after powe
 EXPECTED_ACCEL = 1000  # Step/s^2 (hardware limit ~2000; >=3000 is rejected)
 EXPECTED_DECEL = 1000
 EXPECTED_MIN_SPEED = 16  # manual default start/stop speed
-EXPECTED_MAX_SPEED = 200  # x16 microstep = 3200 pulses/s ~= 131 deg/s at the turret
+# 200 -> 150 (2026-07-28): the 0.95 A driver current cap leaves no margin at speed
+# 200 and the loaded turret was observed losing steps; 150 x16 = 2400 pulses/s
+# ~= 98 deg/s at the turret.
+EXPECTED_MAX_SPEED = 150
 # Currents: with 2 objectives loaded the factory 0.51 A run current loses steps;
 # 0.85 A and up does not. Driver firmware caps 0x16..0x18 at 95 (=0.95 A).
 EXPECTED_CURRENT_OVERLOAD = 13  # x100mA = 1.3 A
-EXPECTED_CURRENT_IDLE = 60  # x10mA = 0.6 A
+EXPECTED_CURRENT_IDLE = 21  # displayed 0.69 A (manager-specified conversion, 2026-07-27; not a literal x10mA)
 EXPECTED_CURRENT_ACCEL = 95  # x10mA = 0.95 A
 EXPECTED_CURRENT_RUN = 95  # x10mA = 0.95 A
-EXPECTED_CURRENT_DECEL = 95  # x10mA = 0.95 A (see volatile note in _INIT_PARAMS)
+# Decel current (0x15) is deliberately NOT calibrated: the SDM42 drive has no such
+# parameter — the firmware silently drops writes and always reads back 0.
 # DI1 is permanently "origin switch" (3). The homing sensor must NEVER be configured
 # as a limit switch: the turret is a disc with no travel limits, and a limit-mapped
 # sensor faults FF0E whenever a normal move passes it (the pre-2026-07-24 scheme).
 DI1_FUNCTION_ORIGIN_SWITCH = 3
 
-# Software homing (ported from SingleMotor HomeSearch, 2026-07-24): sweep toward the
-# sensor in velocity mode while polling the DI level, decel-stop on trigger, back off
-# until the switch releases, then fine-step back to the trigger edge and SET_ZERO
-# there. The driver's built-in homing modes are no longer used — the sensed window is
-# only ~50 pulses wide and the sweep speed/poll period pair below guarantees the
-# window cannot be crossed between two polls (62.5 ms crossing >= 2 poll periods).
-HOMING_SWEEP_SPEED = 50  # Step/s, velocity-mode sweep toward the sensor
-HOMING_POLL_S = 0.025  # DI poll period during the sweep
+# Software homing (ported from SingleMotor HomeSearch, 2026-07-24, params revised
+# 2026-07-28): sweep toward the sensor in velocity mode while polling the DI level,
+# decel-stop on trigger, back off until the switch releases, then fine-step back to
+# the trigger edge and SET_ZERO there. The driver's built-in homing modes are no
+# longer used — the sensed window is only ~50 pulses wide and the sweep speed/poll
+# period pair below guarantees the window cannot be crossed between two polls
+# (52 ms crossing >= 2.6 poll periods). Worst-case overshoot past the trigger edge is
+# stop distance 29 + detection lag 20 = 49 pulses < HOMING_BACKOFF_STEP, so a single
+# backoff jog clears the window (the backoff loop is only a fallback).
+HOMING_SWEEP_SPEED = 60  # Step/s, velocity-mode sweep toward the sensor (x16 = 960 pulses/s)
+HOMING_POLL_S = 0.02  # DI poll period during the sweep
 HOMING_STOP_SETTLE_S = 0.4  # settle after the sweep decel-stop
-HOMING_BACKOFF_STEP = 150  # pulses per backoff jog (release the switch)
-HOMING_FINE_STEP = 5  # pulses per fine-search jog; sets home repeatability (+/-5)
+HOMING_BACKOFF_STEP = 60  # pulses per backoff jog (release the switch)
+HOMING_FINE_STEP = 2  # pulses per fine-search jog; sets home repeatability (+/-2)
 HOMING_MAX_TRAVEL = 10000  # pulses; > one turret revolution (8800 at microstep 16)
-HOMING_FINE_TRAVEL_LIMIT = 400  # backoff 150 + window 50 + margin; bounds a bad trigger
+HOMING_FINE_TRAVEL_LIMIT = 200  # backoff 60 + window 50 + margin; bounds a bad trigger
 HOMING_JOG_SPEED = 60  # Step/s; max speed is temporarily lowered to this for jogs
+HOMING_FINE_ACCEL = 50  # Step/s^2; accel is temporarily lowered for the fine search
 HOMING_SETTLE_MARGIN_S = 0.3  # fixed margin on top of the per-jog travel-time estimate
 
 # Polling
 POLL_INTERVAL_S = 0.05
-# At accel=1000/max_speed=200, a worst-case 3-slot move stays well inside 30s.
+# At accel=1000/max_speed=150, a worst-case 3-slot move stays well inside 30s.
 DEFAULT_MOVE_TIMEOUT_S = 30.0
-# Software homing worst case: sweep up to one revolution at 800 pulses/s plus tens of
+# Software homing worst case: sweep up to one revolution at 960 pulses/s plus tens of
 # ~0.3s fine/backoff jogs. Matches SingleMotor's 120s watchdog.
 DEFAULT_HOME_TIMEOUT_S = 120.0
 
@@ -130,9 +138,7 @@ CONTROL_WORD_SETTLE_S = 0.1
 
 # Init calibration table: (register, expected value, label, kwargs-for-_calibrate_one).
 # Order matters: min_speed must be written before max_speed (the firmware rejects a
-# max-speed write below the current min speed). "volatile": the write never sticks
-# (firmware bug: 0x15 echoes OK but reads back 0), so it must not trigger an EEPROM
-# save on every connect.
+# max-speed write below the current min speed).
 _INIT_PARAMS = [
     (REG_ACCEL, EXPECTED_ACCEL, "accel", {"is_32bit": True}),
     (REG_DECEL, EXPECTED_DECEL, "decel", {"is_32bit": True}),
@@ -142,7 +148,6 @@ _INIT_PARAMS = [
     (REG_CURRENT_IDLE, EXPECTED_CURRENT_IDLE, "idle_current", {}),
     (REG_CURRENT_ACCEL, EXPECTED_CURRENT_ACCEL, "accel_current", {}),
     (REG_CURRENT_RUN, EXPECTED_CURRENT_RUN, "run_current", {}),
-    (REG_CURRENT_DECEL, EXPECTED_CURRENT_DECEL, "decel_current", {"volatile": True}),
     (REG_DI_FUNCTION, DI1_FUNCTION_ORIGIN_SWITCH, "DI1_function", {"is_32bit": True, "mask": 0xF}),
 ]
 
@@ -445,6 +450,8 @@ class ObjectiveTurret4PosController:
         self._write_holding(REG_SET_ZERO, SET_ZERO_MAGIC)
         # Temporarily lower max speed for backoff/fine jog precision; restore after.
         orig_max_speed = self._modbus.read_register_32bit(self._slave_id, REG_MAX_SPEED)
+        orig_accel = self._modbus.read_register_32bit(self._slave_id, REG_ACCEL)
+        accel_lowered = False
         if orig_max_speed != HOMING_JOG_SPEED:
             self._modbus.write_register_32bit(self._slave_id, REG_MAX_SPEED, HOMING_JOG_SPEED)
         try:
@@ -453,6 +460,12 @@ class ObjectiveTurret4PosController:
             if not di1:  # already inside the sensor window -> skip straight to backoff
                 self._sweep_to_sensor(deadline)
             self._backoff_off_sensor(deadline)
+            # Fine search only: lower the acceleration to soften the microstep approach
+            # to the trigger edge (SingleMotor 2026-07-28); restored in the finally.
+            if orig_accel != HOMING_FINE_ACCEL:
+                self._write_control(CW_DISABLE)  # parameter writes require the disabled state
+                self._modbus.write_register_32bit(self._slave_id, REG_ACCEL, HOMING_FINE_ACCEL)
+                accel_lowered = True
             self._fine_search_to_edge(deadline)
             # At the trigger edge: establish the home reference.
             self._write_holding(REG_SET_ZERO, SET_ZERO_MAGIC)
@@ -466,6 +479,11 @@ class ObjectiveTurret4PosController:
                     self._modbus.write_register_32bit(self._slave_id, REG_MAX_SPEED, orig_max_speed)
                 except Exception as exc:
                     logger.warning("Failed to restore max speed after homing: %s", exc)
+            if accel_lowered:
+                try:
+                    self._modbus.write_register_32bit(self._slave_id, REG_ACCEL, orig_accel)
+                except Exception as exc:
+                    logger.warning("Failed to restore acceleration after homing: %s", exc)
         # Success: hold the turret at home with torque until the next move.
         self._hold_position_clamp()
         self._current_objective = None
@@ -725,14 +743,10 @@ class ObjectiveTurret4PosController:
 
     def _calibrate_init_params(self) -> bool:
         """Bring every factory parameter in line with _INIT_PARAMS; return whether a
-        persistent write happened (volatile entries are rewritten each connect but
-        must not trigger an EEPROM save every time)."""
+        write happened (i.e. whether the set should be persisted to EEPROM)."""
         changed = False
         for addr, expected, label, kwargs in _INIT_PARAMS:
-            kwargs = dict(kwargs)
-            volatile = kwargs.pop("volatile", False)
-            wrote = self._calibrate_one(addr, expected, label, **kwargs)
-            changed = changed or (wrote and not volatile)
+            changed = self._calibrate_one(addr, expected, label, **kwargs) or changed
         return changed
 
     def _save_to_eeprom(self) -> None:

--- a/software/control/objective_turret_controller.py
+++ b/software/control/objective_turret_controller.py
@@ -232,11 +232,12 @@ class ObjectiveTurret4PosControllerSimulation:
         positions: Optional[dict] = None,
         stage: Optional[squid.abc.AbstractStage] = None,
         # Accepted for constructor parity with the real controller; the simulation
-        # tracks objectives by name and never computes pulses, so all four are unused.
+        # tracks objectives by name and never computes pulses, so all five are unused.
         offset_pulses: Optional[int] = None,
         calibrated_pulses: Optional[dict] = None,
         backlash_deg: Optional[float] = None,
         direction_inverted: Optional[bool] = None,
+        di_invert: Optional[bool] = None,
     ):
         from control._def import OBJECTIVE_TURRET_POSITIONS
 
@@ -334,6 +335,7 @@ class ObjectiveTurret4PosController:
         calibrated_pulses: Optional[dict] = None,
         backlash_deg: Optional[float] = None,
         direction_inverted: Optional[bool] = None,
+        di_invert: Optional[bool] = None,
     ) -> None:
         from control._def import (
             OBJECTIVE_TURRET_POSITIONS,
@@ -341,6 +343,7 @@ class ObjectiveTurret4PosController:
             OBJECTIVE_TURRET_CALIBRATED_PULSES,
             OBJECTIVE_TURRET_BACKLASH_DEG,
             OBJECTIVE_TURRET_DIRECTION_INVERTED,
+            OBJECTIVE_TURRET_DI_INVERT,
         )
 
         self._slave_id = slave_id
@@ -365,6 +368,14 @@ class ObjectiveTurret4PosController:
         if not isinstance(inverted, bool):
             raise ValueError(f"OBJECTIVE_TURRET_DIRECTION_INVERTED must be a boolean, got {inverted!r}")
         self._direction_inverted = inverted
+        # Origin-switch (DI1) polarity inversion for changers whose sensor triggers
+        # on the opposite logic level (SingleMotor 2026-08-12). Applied only to the
+        # DI trigger verdict in the status snapshot; the homing state machine,
+        # direction logic and calibration all stay in the same logical frame.
+        di_inv = di_invert if di_invert is not None else OBJECTIVE_TURRET_DI_INVERT
+        if not isinstance(di_inv, bool):
+            raise ValueError(f"OBJECTIVE_TURRET_DI_INVERT must be a boolean, got {di_inv!r}")
+        self._di_invert = di_inv
         self._stage = stage
         self._current_objective: Optional[str] = None
         self._is_open = False
@@ -628,6 +639,8 @@ class ObjectiveTurret4PosController:
         values consistent with each other (same block SingleMotor polls)."""
         vals = self._modbus.read_input_registers(self._slave_id, STATUS_BLOCK_START, STATUS_BLOCK_COUNT)
         di1 = bool(vals[_OFS_DI] & 1)
+        if self._di_invert:
+            di1 = not di1
         position = (vals[_OFS_POSITION] << 16) | vals[_OFS_POSITION + 1]
         if position >= 0x80000000:
             position -= 0x100000000

--- a/software/tests/control/test_objective_turret_controller.py
+++ b/software/tests/control/test_objective_turret_controller.py
@@ -350,3 +350,126 @@ def test_sim_accepts_offset_kwarg():
     sim.move_to_objective("20x")
     assert sim.current_objective == "20x"
     sim.close()
+
+
+# --- per-slot calibration ---
+
+
+def test_calibrated_slots_used_verbatim_others_fall_back(monkeypatch):
+    # A calibrated slot targets its calibrated value (global offset NOT added);
+    # uncalibrated slots keep the theoretical (slot-1)*pp + offset behavior.
+    controller, fake = _make_real_controller(monkeypatch, offset_pulses=25, calibrated_pulses={2: 2210, 4: 6585})
+    pp = controller.pulses_per_position
+    expected = {"4x": 0 * pp + 25, "10x": 2210, "20x": 2 * pp + 25, "40x": 6585}
+    for name, target in expected.items():
+        fake.writes.clear()
+        controller.move_to_objective(name)
+        assert fake.target_position_writes()[-1] == target
+    controller.close()
+
+
+def test_calibration_accepts_string_keys_from_ini(monkeypatch):
+    # .ini JSON parsing yields string keys; they must be normalized to int slots.
+    controller, fake = _make_real_controller(monkeypatch, calibrated_pulses={"3": 4415})
+    fake.writes.clear()
+    controller.move_to_objective("20x")  # slot 3
+    assert fake.target_position_writes()[-1] == 4415
+    controller.close()
+
+
+def test_calibration_falls_back_to_def_when_not_passed(monkeypatch):
+    monkeypatch.setattr(control._def, "OBJECTIVE_TURRET_CALIBRATED_PULSES", {1: -12})
+    controller, fake = _make_real_controller(monkeypatch)
+    fake.writes.clear()
+    controller.move_to_objective("4x")  # slot 1
+    assert fake.target_position_writes()[-1] == -12
+    controller.close()
+
+
+@pytest.mark.parametrize(
+    "bad_calibration",
+    [{"x": 100}, {0: 100}, {5: 100}, {2: 100.5}, {2: True}, {2: "100"}],
+    ids=["non-int-key", "slot-0", "slot-5", "float-value", "bool-value", "str-value"],
+)
+def test_invalid_calibration_raises(monkeypatch, bad_calibration):
+    monkeypatch.setattr(otc, "_find_port", lambda serial_number: "FAKE_PORT")
+    monkeypatch.setattr(otc, "ModbusRTUClient", lambda **kwargs: _FakeModbus())
+    with pytest.raises(ValueError):
+        ObjectiveTurret4PosController(serial_number="SIM", stage=None, calibrated_pulses=bad_calibration)
+
+
+def test_calibration_deviating_more_than_one_slot_raises(monkeypatch):
+    # Slot 2's theoretical target is 2200 (microstep 16); a calibrated value a full
+    # slot away means it was measured at another microstep or against the wrong slot.
+    monkeypatch.setattr(otc, "_find_port", lambda serial_number: "FAKE_PORT")
+    monkeypatch.setattr(otc, "ModbusRTUClient", lambda **kwargs: _FakeModbus())
+    with pytest.raises(ValueError):
+        ObjectiveTurret4PosController(serial_number="SIM", stage=None, calibrated_pulses={2: 4500})
+
+
+# --- backlash compensation ---
+
+
+def test_backlash_moves_via_undershoot_then_target(monkeypatch):
+    # comp > 0: pre-move to target-comp, then final approach from below.
+    controller, fake = _make_real_controller(monkeypatch, backlash_deg=0.5)
+    pp = controller.pulses_per_position
+    comp = round(0.5 / 360 * 4 * pp)
+    assert comp > 0
+    fake.writes.clear()
+    controller.move_to_objective("40x")  # slot 4 -> target 3*pp
+    assert fake.target_position_writes() == [3 * pp - comp, 3 * pp]
+    controller.close()
+
+
+def test_zero_backlash_moves_directly(monkeypatch):
+    controller, fake = _make_real_controller(monkeypatch, backlash_deg=0.0)
+    pp = controller.pulses_per_position
+    fake.writes.clear()
+    controller.move_to_objective("10x")  # slot 2
+    assert fake.target_position_writes() == [1 * pp]
+    controller.close()
+
+
+def test_backlash_applies_to_calibrated_slots_too(monkeypatch):
+    controller, fake = _make_real_controller(monkeypatch, calibrated_pulses={2: 2210}, backlash_deg=1.0)
+    pp = controller.pulses_per_position
+    comp = round(1.0 / 360 * 4 * pp)
+    fake.writes.clear()
+    controller.move_to_objective("10x")  # slot 2, calibrated
+    assert fake.target_position_writes() == [2210 - comp, 2210]
+    controller.close()
+
+
+def test_backlash_falls_back_to_def_when_not_passed(monkeypatch):
+    monkeypatch.setattr(control._def, "OBJECTIVE_TURRET_BACKLASH_DEG", 0.5)
+    controller, fake = _make_real_controller(monkeypatch)
+    pp = controller.pulses_per_position
+    comp = round(0.5 / 360 * 4 * pp)
+    fake.writes.clear()
+    controller.move_to_objective("4x")  # slot 1 -> target 0
+    assert fake.target_position_writes() == [-comp, 0]
+    controller.close()
+
+
+@pytest.mark.parametrize("bad_deg", [-0.1, 1.5, True, "0.5"], ids=["negative", "too-large", "bool", "str"])
+def test_invalid_backlash_raises(monkeypatch, bad_deg):
+    monkeypatch.setattr(otc, "_find_port", lambda serial_number: "FAKE_PORT")
+    monkeypatch.setattr(otc, "ModbusRTUClient", lambda **kwargs: _FakeModbus())
+    with pytest.raises(ValueError):
+        ObjectiveTurret4PosController(serial_number="SIM", stage=None, backlash_deg=bad_deg)
+
+
+def test_sim_accepts_calibration_and_backlash_kwargs():
+    # Constructor parity: microscope.py builds one turret_kwargs dict for both twins.
+    sim = ObjectiveTurret4PosControllerSimulation(
+        serial_number="SIM-001",
+        positions=OBJECTIVE_TURRET_POSITIONS,
+        offset_pulses=42,
+        calibrated_pulses={2: 2210},
+        backlash_deg=0.5,
+    )
+    assert sim.is_open
+    sim.move_to_objective("20x")
+    assert sim.current_objective == "20x"
+    sim.close()

--- a/software/tests/control/test_objective_turret_controller.py
+++ b/software/tests/control/test_objective_turret_controller.py
@@ -712,3 +712,88 @@ def test_sim_accepts_direction_inverted_kwarg():
     sim.move_to_objective("10x")
     assert sim.current_objective == "10x"
     sim.close()
+
+
+# --- DI polarity inversion (opposite-logic origin switches) ---
+#
+# With di_invert the raw DI level flips meaning: 1 = released, 0 = inside the
+# sensor window (the exact inverse of the default logic). The scripts below are
+# raw levels; the flipped verdicts drive the same state machine as the
+# non-inverted homing tests.
+
+
+def test_di_invert_home_from_inside_window_uses_inverted_levels(monkeypatch):
+    # Raw [0, 0, 1, 0] -> verdicts [1, 1, 0, 1]: inside -> backoff releases after
+    # one jog -> fine jog hits the edge. Same flow as the default-polarity case:
+    # no velocity sweep, SET_ZERO at start and at the trigger edge, clamped at home.
+    controller, fake = _make_real_controller(monkeypatch, di_invert=True, direction_inverted=False)
+    _fast_homing(monkeypatch)
+    fake.writes.clear()
+    fake.di_script = [0, 0, 1, 0]
+    controller.home()
+    assert (REG_RUN_MODE, MODE_SPEED) not in fake.writes
+    assert [v for (a, v) in fake.writes if a == REG_SET_ZERO] == [SET_ZERO_MAGIC, SET_ZERO_MAGIC]
+    assert fake.control_word_writes()[-3:] == [CW_STARTUP, CW_ENABLE, CW_RUN_ABSOLUTE]
+    controller.close()
+
+
+def test_di_invert_home_sweeps_when_released_level_high(monkeypatch):
+    # Raw level 1 = released -> the sweep starts; the sweep direction bit stays the
+    # same (logical negative, toward the sensor) — only the trigger verdict flips.
+    controller, fake = _make_real_controller(monkeypatch, di_invert=True, direction_inverted=False)
+    _fast_homing(monkeypatch)
+    fake.writes.clear()
+    # released -> sweep polls miss then trigger (0) -> backoff released (1) ->
+    # fine jog hits the edge (0).
+    fake.di_script = [1, 1, 0, 1, 0]
+    controller.home()
+    assert (REG_RUN_MODE, MODE_SPEED) in fake.writes
+    assert (REG_DIRECTION, 0) in fake.writes
+    assert (REG_TARGET_SPEED, HOMING_SWEEP_SPEED) in fake.writes
+    controller.close()
+
+
+def test_di_invert_backoff_jog_direction_unchanged(monkeypatch):
+    # Backoff still jogs positive (away from the sensor); the inversion applies to
+    # the trigger verdict only, never to the jog direction.
+    controller, fake = _make_real_controller(monkeypatch, di_invert=True, direction_inverted=False)
+    _fast_homing(monkeypatch)
+    fake.writes.clear()
+    fake.di_script = [0, 0, 1, 0]
+    controller.home()
+    assert (otc.REG_TARGET_POSITION, otc.HOMING_BACKOFF_STEP) in fake.writes
+    controller.close()
+
+
+def test_di_invert_falls_back_to_def_when_not_passed(monkeypatch):
+    monkeypatch.setattr(control._def, "OBJECTIVE_TURRET_DI_INVERT", True)
+    controller, fake = _make_real_controller(monkeypatch, direction_inverted=False)
+    _fast_homing(monkeypatch)
+    fake.writes.clear()
+    fake.di_script = [0, 0, 1, 0]  # raw 0 = inside the window under inverted logic
+    controller.home()
+    assert (REG_RUN_MODE, MODE_SPEED) not in fake.writes  # inside-window path taken
+    controller.close()
+
+
+@pytest.mark.parametrize("bad_invert", [1, "true", 0.0], ids=["int", "str", "float"])
+def test_non_bool_di_invert_raises(monkeypatch, bad_invert):
+    # .ini parsing can yield an int/str; only a real boolean is accepted.
+    monkeypatch.setattr(otc, "_find_port", lambda serial_number: "FAKE_PORT")
+    monkeypatch.setattr(otc, "ModbusRTUClient", lambda **kwargs: _FakeModbus())
+    with pytest.raises(ValueError):
+        ObjectiveTurret4PosController(
+            serial_number="SIM", stage=None, direction_inverted=False, di_invert=bad_invert
+        )
+
+
+def test_sim_accepts_di_invert_kwarg():
+    sim = ObjectiveTurret4PosControllerSimulation(
+        serial_number="SIM-001",
+        positions=OBJECTIVE_TURRET_POSITIONS,
+        di_invert=True,
+    )
+    assert sim.is_open
+    sim.move_to_objective("10x")
+    assert sim.current_objective == "10x"
+    sim.close()

--- a/software/tests/control/test_objective_turret_controller.py
+++ b/software/tests/control/test_objective_turret_controller.py
@@ -12,11 +12,32 @@ from control.objective_turret_controller import (
     ObjectiveTurret4PosControllerSimulation,
     CW_DISABLE,
     CW_ENABLE,
+    CW_STARTUP,
+    CW_RUN_ABSOLUTE,
+    DI1_FUNCTION_ORIGIN_SWITCH,
+    EXPECTED_CURRENT_OVERLOAD,
+    EXPECTED_CURRENT_RUN,
+    EXPECTED_MAX_SPEED,
+    EXPECTED_MIN_SPEED,
+    HOMING_SWEEP_SPEED,
+    MICROSTEP_REG_VALUE,
+    MODE_SPEED,
     REG_CONTROL_WORD,
+    REG_CURRENT_OVERLOAD,
     REG_CURRENT_POSITION,
+    REG_CURRENT_RUN,
+    REG_DIRECTION,
+    REG_DI_FUNCTION,
+    REG_MAX_SPEED,
     REG_MICROSTEP,
-    REG_STATUS_WORD,
+    REG_MIN_SPEED,
+    REG_RUN_MODE,
+    REG_SAVE_PARAMS,
+    REG_SET_ZERO,
     REG_TARGET_POSITION,
+    REG_TARGET_SPEED,
+    SAVE_PARAMS_MAGIC,
+    SET_ZERO_MAGIC,
 )
 
 
@@ -205,6 +226,10 @@ class _FakeModbus:
         self.connected = False
         self.writes = []  # (address, value) in order
         self._position = 0
+        self.microstep_raw = MICROSTEP_REG_VALUE  # register value 4 -> 16 microsteps
+        # DI1 levels consumed one per status-snapshot read; the last value repeats.
+        self.di_script = []
+        self._di = 0
 
     def connect(self, port=None, baudrate=None):
         self.connected = True
@@ -217,8 +242,7 @@ class _FakeModbus:
         return self.connected
 
     def read_register(self, slave_id, address):
-        # Microstep register must be 0..7; 4 -> 16 microsteps.
-        return 4 if address == REG_MICROSTEP else 0
+        return self.microstep_raw if address == REG_MICROSTEP else 0
 
     def read_register_32bit(self, slave_id, address, signed=False):
         return 0
@@ -231,6 +255,18 @@ class _FakeModbus:
         # Report the commanded target as the live position so the move-complete
         # tolerance check passes immediately.
         return self._position if address == REG_CURRENT_POSITION else 0
+
+    def read_input_registers(self, slave_id, address, count):
+        # Status snapshot for software homing: everything idle/zero except the DI
+        # level (offset 1) driven by di_script, and the position (offsets 10..11).
+        if self.di_script:
+            self._di = self.di_script.pop(0)
+        vals = [0] * count
+        vals[1] = self._di
+        pos = self._position & 0xFFFFFFFF
+        vals[10] = (pos >> 16) & 0xFFFF
+        vals[11] = pos & 0xFFFF
+        return vals
 
     def write_register(self, slave_id, address, value):
         self.writes.append((address, value))
@@ -271,12 +307,82 @@ def test_move_to_objective_deenergizes_when_idle(monkeypatch):
     controller.close()
 
 
-def test_home_deenergizes_when_idle(monkeypatch):
+def _fast_homing(monkeypatch):
+    """Zero out the real-time settle/poll sleeps so homing tests run instantly."""
+    monkeypatch.setattr(otc, "HOMING_SETTLE_MARGIN_S", 0.0)
+    monkeypatch.setattr(otc, "HOMING_STOP_SETTLE_S", 0.0)
+    monkeypatch.setattr(otc, "HOMING_POLL_S", 0.0)
+
+
+def test_home_zeroes_at_edge_and_clamps(monkeypatch):
     controller, fake = _make_real_controller(monkeypatch)
+    _fast_homing(monkeypatch)
     fake.writes.clear()
+    # Snapshot sequence: already in the window (1) -> backoff sees released after one
+    # jog (1, 0) -> first fine jog lands on the trigger edge (1).
+    fake.di_script = [1, 1, 0, 1]
     controller.home()
+    # SET_ZERO twice: once at start (travel bound) and once at the trigger edge.
+    assert [v for (a, v) in fake.writes if a == REG_SET_ZERO] == [SET_ZERO_MAGIC, SET_ZERO_MAGIC]
+    # Ends clamped at home (position-mode 0x06/0x07/0x0F, no trigger), not de-energized.
+    assert fake.control_word_writes()[-3:] == [CW_STARTUP, CW_ENABLE, CW_RUN_ABSOLUTE]
+    assert controller.current_objective is None
+    controller.close()
+
+
+def test_home_sweeps_in_velocity_mode_when_off_sensor(monkeypatch):
+    controller, fake = _make_real_controller(monkeypatch)
+    _fast_homing(monkeypatch)
+    fake.writes.clear()
+    # Off the window (0) -> sweep polls miss then hit (0, 1) -> backoff already
+    # released (0) -> fine jog hits the edge (1).
+    fake.di_script = [0, 0, 1, 0, 1]
+    controller.home()
+    assert (REG_RUN_MODE, MODE_SPEED) in fake.writes
+    assert (REG_DIRECTION, 0) in fake.writes  # sweep runs negative, toward the sensor
+    assert (REG_TARGET_SPEED, HOMING_SWEEP_SPEED) in fake.writes
+    controller.close()
+
+
+def test_home_timeout_leaves_motor_deenergized(monkeypatch):
+    controller, fake = _make_real_controller(monkeypatch)
+    _fast_homing(monkeypatch)
+    fake.di_script = [0]  # sensor never triggers; fake position never exceeds travel
+    with pytest.raises(TimeoutError):
+        controller.home(timeout_s=0.2)
+    # Failure cleanup: stopped and de-energized, NOT left clamped.
     assert fake.control_word_writes()[-1] == CW_DISABLE
     controller.close()
+
+
+def test_init_calibrates_factory_params(monkeypatch):
+    # Fake reads return 0 for every parameter, so init must write the full factory
+    # set (SingleMotor 2026-07-24/25 acceptance values) and persist it.
+    controller, fake = _make_real_controller(monkeypatch)
+    writes = fake.writes
+    # min_speed must be written before max_speed: the firmware rejects a max-speed
+    # write below the current min speed.
+    assert writes.index((REG_MIN_SPEED, EXPECTED_MIN_SPEED)) < writes.index((REG_MAX_SPEED, EXPECTED_MAX_SPEED))
+    assert (REG_CURRENT_RUN, EXPECTED_CURRENT_RUN) in writes
+    assert (REG_CURRENT_OVERLOAD, EXPECTED_CURRENT_OVERLOAD) in writes
+    # DI1 must be "origin switch" — a limit-mapped homing sensor faults FF0E.
+    assert (REG_DI_FUNCTION, DI1_FUNCTION_ORIGIN_SWITCH) in writes
+    # Direction is RAM-only: written after the EEPROM save so it is not persisted.
+    assert writes.index((REG_SAVE_PARAMS, SAVE_PARAMS_MAGIC)) < writes.index((REG_DIRECTION, 1))
+    controller.close()
+
+
+def test_init_microstep_mismatch_writes_factory_value_and_raises(monkeypatch):
+    # A wrong microstep invalidates calibrated pulses and the homing math, and the
+    # register only takes effect after a power cycle: write it, save, fail fast.
+    fake = _FakeModbus()
+    fake.microstep_raw = 7
+    monkeypatch.setattr(otc, "_find_port", lambda serial_number: "FAKE_PORT")
+    monkeypatch.setattr(otc, "ModbusRTUClient", lambda **kwargs: fake)
+    with pytest.raises(RuntimeError, match="[Pp]ower-cycle"):
+        ObjectiveTurret4PosController(serial_number="SIM", stage=None)
+    assert (REG_MICROSTEP, MICROSTEP_REG_VALUE) in fake.writes
+    assert (REG_SAVE_PARAMS, SAVE_PARAMS_MAGIC) in fake.writes
 
 
 def test_deenergize_is_best_effort(monkeypatch):

--- a/software/tests/control/test_objective_turret_controller.py
+++ b/software/tests/control/test_objective_turret_controller.py
@@ -19,9 +19,11 @@ from control.objective_turret_controller import (
     EXPECTED_CURRENT_RUN,
     EXPECTED_MAX_SPEED,
     EXPECTED_MIN_SPEED,
+    HOMING_FINE_ACCEL,
     HOMING_SWEEP_SPEED,
     MICROSTEP_REG_VALUE,
     MODE_SPEED,
+    REG_ACCEL,
     REG_CONTROL_WORD,
     REG_CURRENT_OVERLOAD,
     REG_CURRENT_POSITION,
@@ -341,6 +343,19 @@ def test_home_sweeps_in_velocity_mode_when_off_sensor(monkeypatch):
     assert (REG_RUN_MODE, MODE_SPEED) in fake.writes
     assert (REG_DIRECTION, 0) in fake.writes  # sweep runs negative, toward the sensor
     assert (REG_TARGET_SPEED, HOMING_SWEEP_SPEED) in fake.writes
+    controller.close()
+
+
+def test_home_lowers_accel_for_fine_search_and_restores(monkeypatch):
+    # The fine search runs at HOMING_FINE_ACCEL to soften the microstep approach to
+    # the trigger edge; the original acceleration (fake reads 0) is restored after.
+    controller, fake = _make_real_controller(monkeypatch)
+    _fast_homing(monkeypatch)
+    fake.writes.clear()
+    fake.di_script = [1, 1, 0, 1]
+    controller.home()
+    accel_writes = [v for (a, v) in fake.writes if a == REG_ACCEL]
+    assert accel_writes == [HOMING_FINE_ACCEL, 0]
     controller.close()
 
 

--- a/software/tests/control/test_objective_turret_controller.py
+++ b/software/tests/control/test_objective_turret_controller.py
@@ -594,3 +594,121 @@ def test_sim_accepts_calibration_and_backlash_kwargs():
     sim.move_to_objective("20x")
     assert sim.current_objective == "20x"
     sim.close()
+
+
+# --- direction inversion (opposite-phase motor models) ---
+
+
+def test_inverted_move_writes_negated_target(monkeypatch):
+    # Slot targets stay logical; only the register write is negated. The move still
+    # completes because the position readback is flipped back symmetrically.
+    # Explicit offset/calibration keep the theoretical targets independent of any
+    # machine .ini values loaded into _def.
+    controller, fake = _make_real_controller(
+        monkeypatch, direction_inverted=True, offset_pulses=0, calibrated_pulses={}
+    )
+    pp = controller.pulses_per_position
+    fake.writes.clear()
+    controller.move_to_objective("20x")  # slot 3 -> logical target 2*pp
+    assert fake.target_position_writes() == [-2 * pp]
+    controller.close()
+
+
+def test_inverted_backlash_order_preserved_logically(monkeypatch):
+    # Undershoot-then-target stays expressed in logical coordinates; both writes
+    # come out negated but the logical approach-from-below order is unchanged.
+    controller, fake = _make_real_controller(
+        monkeypatch, backlash_deg=0.5, direction_inverted=True, offset_pulses=0, calibrated_pulses={}
+    )
+    pp = controller.pulses_per_position
+    comp = round(0.5 / 360 * 4 * pp)
+    fake.writes.clear()
+    controller.move_to_objective("10x")  # slot 2 -> logical target 1*pp
+    assert fake.target_position_writes() == [-(pp - comp), -pp]
+    controller.close()
+
+
+def test_inverted_position_readback_returns_logical(monkeypatch):
+    controller, fake = _make_real_controller(monkeypatch, direction_inverted=True)
+    fake._position = -1234  # physical counter
+    assert controller.current_position_pulses == 1234
+    controller.close()
+
+
+def test_inverted_home_flips_sweep_and_fine_jog_direction_bits(monkeypatch):
+    controller, fake = _make_real_controller(monkeypatch, direction_inverted=True)
+    _fast_homing(monkeypatch)
+    fake.writes.clear()
+    # Off the window (0) -> sweep polls miss then hit (0, 1) -> backoff already
+    # released (0) -> fine jog hits the edge (1).
+    fake.di_script = [0, 0, 1, 0, 1]
+    controller.home()
+    assert (REG_RUN_MODE, MODE_SPEED) in fake.writes
+    # Sweep is logical-negative -> physical bit 1; fine jog -2 -> physical bit 1.
+    assert [v for (a, v) in fake.writes if a == REG_DIRECTION] == [1, 1]
+    controller.close()
+
+
+def test_inverted_backoff_jog_flips_direction_keeps_magnitude(monkeypatch):
+    controller, fake = _make_real_controller(monkeypatch, direction_inverted=True)
+    _fast_homing(monkeypatch)
+    fake.writes.clear()
+    # In the window (1) -> one backoff jog releases (1, 0) -> fine jog hits (1).
+    fake.di_script = [1, 1, 0, 1]
+    controller.home()
+    # Backoff +60 -> physical bit 0; fine -2 -> physical bit 1. The relative-move
+    # register still only ever receives the positive magnitude.
+    assert [v for (a, v) in fake.writes if a == REG_DIRECTION] == [0, 1]
+    assert (otc.REG_TARGET_POSITION, otc.HOMING_BACKOFF_STEP) in fake.writes
+    controller.close()
+
+
+def test_inverted_init_expects_direction_zero(monkeypatch):
+    # The fake reads 0 from the direction register; inverted expects 0, so init must
+    # NOT issue the non-inverted corrective write of 1.
+    controller, fake = _make_real_controller(monkeypatch, direction_inverted=True)
+    assert (REG_DIRECTION, 1) not in fake.writes
+    controller.close()
+
+
+def test_direction_inverted_falls_back_to_def_when_not_passed(monkeypatch):
+    monkeypatch.setattr(control._def, "OBJECTIVE_TURRET_DIRECTION_INVERTED", True)
+    controller, fake = _make_real_controller(monkeypatch, offset_pulses=0, calibrated_pulses={})
+    fake.writes.clear()
+    controller.move_to_objective("40x")  # slot 4 -> logical target 3*pp
+    assert fake.target_position_writes() == [-3 * controller.pulses_per_position]
+    controller.close()
+
+
+@pytest.mark.parametrize("bad_inverted", [1, "true", 0.0], ids=["int", "str", "float"])
+def test_non_bool_direction_inverted_raises(monkeypatch, bad_inverted):
+    # .ini parsing can yield an int/str; only a real boolean is accepted.
+    monkeypatch.setattr(otc, "_find_port", lambda serial_number: "FAKE_PORT")
+    monkeypatch.setattr(otc, "ModbusRTUClient", lambda **kwargs: _FakeModbus())
+    with pytest.raises(ValueError):
+        ObjectiveTurret4PosController(serial_number="SIM", stage=None, direction_inverted=bad_inverted)
+
+
+def test_default_not_inverted_keeps_current_behavior(monkeypatch):
+    # Regression guard: with the default (False), targets, direction writes and
+    # position readback are exactly the pre-inversion behavior.
+    controller, fake = _make_real_controller(monkeypatch, offset_pulses=0, calibrated_pulses={})
+    assert (REG_DIRECTION, 1) in fake.writes  # init still calibrates direction to 1
+    pp = controller.pulses_per_position
+    fake.writes.clear()
+    controller.move_to_objective("20x")
+    assert fake.target_position_writes() == [2 * pp]
+    assert controller.current_position_pulses == fake._position
+    controller.close()
+
+
+def test_sim_accepts_direction_inverted_kwarg():
+    sim = ObjectiveTurret4PosControllerSimulation(
+        serial_number="SIM-001",
+        positions=OBJECTIVE_TURRET_POSITIONS,
+        direction_inverted=True,
+    )
+    assert sim.is_open
+    sim.move_to_objective("10x")
+    assert sim.current_objective == "10x"
+    sim.close()


### PR DESCRIPTION
## Summary

Two commits improving the NiMotion 4-position objective turret controller:

**1. Per-slot calibration and gear backlash compensation** (`6918f4f`)
- `OBJECTIVE_TURRET_CALIBRATED_PULSES`: per-slot calibrated absolute pulse targets (slot -> pulses from homing zero). Calibrated slots are used verbatim; others fall back to the theoretical `(slot-1)*pulses_per_position + OBJECTIVE_TURRET_OFFSET_PULSES`.
- `OBJECTIVE_TURRET_BACKLASH_DEG`: when > 0, every slot change overshoots below the target and approaches from below, so the final approach direction is constant and gear backlash cancels out.
- Both validated at init so a bad machine .ini fails fast; defaults keep behavior identical.

**2. Software homing, DI1 origin switch, factory parameters** (`fffd0a5`)
- **Software homing** replaces the driver's built-in homing modes: velocity-mode sweep toward the sensor polling the DI level → decel-stop on trigger → back off until the switch releases → fine-step back to the trigger edge → `SET_ZERO` there. Repeatability ±5 pulses (hardware-measured 0); ends clamped at home with holding torque. Home timeout raised to 120 s.
- **DI1 permanently "origin switch" (3)** — the previous scheme (DI1 temporarily remapped to negative limit + homing method 17) faults FF0E on current drive firmware whenever a normal move passes the sensor.
- **Factory parameter set** auto-calibrated on connect: accel/decel 1000, max speed 200, min speed 16 (written before max — fixes a min/max write-order bug), motor currents sized so a fully loaded turret does not lose steps, microstep pinned to 16 (fail fast asking for a power cycle on mismatch).
- `modbus_rtu`: new `read_input_registers()` batch read so the homing sweep sees DI + position + alarm in one frame per poll (the ~50-pulse sensor window must not be crossable between polls).

## Deployment notes

- First connect on a real unit rewrites speed/current/DI parameters and saves EEPROM (one-time).
- Machines with per-slot calibration measured under the old driver-homing zero must re-measure (the zero reference moved slightly).

## Test plan

- [x] 66 tests pass (`tests/control/test_objective_turret_controller.py`, `tests/control/test_modbus_rtu.py`): calibration/backlash targeting, software-homing edge/sweep/timeout paths, factory-param write order, microstep-mismatch fail-fast
- [x] Homing repeatability verified on hardware in the source project (0-pulse deviation between runs)
- [ ] Bench test on production hardware: startup homing, slot-switching accuracy, slot re-calibration

🤖 Generated with [Claude Code](https://claude.com/claude-code)