### PR TITLE
perf(xlight): skip emission filter wheel command when already at position

### DIFF
--- a/software/control/serial_peripherals.py
+++ b/software/control/serial_peripherals.py
@@ -342,6 +342,14 @@ class XLight:
             raise ValueError(
                 f"Invalid emission filter position {position}, must be 1-{XLIGHT_EMISSION_FILTER_POSITIONS}"
             )
+        # Skip the serial write and the wheel settle sleep when the wheel is already at the
+        # requested position. This is called on every channel switch during multipoint
+        # acquisitions, so re-sending an unchanged position would otherwise cost
+        # sleep_time_for_wheel (250 ms by default) per channel. The cached position is only
+        # assigned after a command has been sent, so the first call always reaches the hardware.
+        cached_position = getattr(self, "emission_wheel_pos", None)
+        if not extraction and cached_position is not None and str(cached_position) == str(position):
+            return self.emission_wheel_pos
         position_to_write = str(position)
         position_to_read = str(position)
         if extraction:
@@ -356,6 +364,13 @@ class XLight:
             self.serial_connection.write("B" + position_to_write + "\r")
             time.sleep(self.sleep_time_for_wheel)
             self.emission_wheel_pos = position
+
+        if extraction:
+            # An extraction move ("m" suffix) leaves the wheel in a special state, so force the
+            # next plain set_emission_filter at this position to reach the hardware.
+            result = self.emission_wheel_pos
+            self.emission_wheel_pos = None
+            return result
 
         return self.emission_wheel_pos
 

--- a/software/control/serial_peripherals.py
+++ b/software/control/serial_peripherals.py
@@ -256,6 +256,8 @@ class XLight:
         self.slider_position = 0
         self.illumination_iris = 0
         self.emission_iris = 0
+        self.emission_wheel_pos = None
+        self._emission_wheel_extracted = False
 
         # Auto-detect protocol: try V3 (115200) first, then V1/V2 (9600)
         self.protocol_version = self._connect_and_detect(SN)
@@ -337,21 +339,19 @@ class XLight:
         if self.disable_emission_filter_wheel:
             self.log.info("Emission filter wheel disabled, skipping set_emission_filter")
             return -1
+        position_str = str(position)
         valid_positions = [str(i + 1) for i in range(XLIGHT_EMISSION_FILTER_POSITIONS)]
-        if str(position) not in valid_positions:
+        if position_str not in valid_positions:
             raise ValueError(
                 f"Invalid emission filter position {position}, must be 1-{XLIGHT_EMISSION_FILTER_POSITIONS}"
             )
-        # Skip the serial write and the wheel settle sleep when the wheel is already at the
-        # requested position. This is called on every channel switch during multipoint
-        # acquisitions, so re-sending an unchanged position would otherwise cost
-        # sleep_time_for_wheel (250 ms by default) per channel. The cached position is only
-        # assigned after a command has been sent, so the first call always reaches the hardware.
-        cached_position = getattr(self, "emission_wheel_pos", None)
-        if not extraction and cached_position is not None and str(cached_position) == str(position):
+        # This runs on every channel switch during multipoint acquisitions; skip the serial write
+        # and the sleep_time_for_wheel settle (250 ms by default) when the wheel is already there.
+        # Compared as str because callers pass the position as both int (configs) and str (widgets).
+        if not extraction and not self._emission_wheel_extracted and str(self.emission_wheel_pos) == position_str:
             return self.emission_wheel_pos
-        position_to_write = str(position)
-        position_to_read = str(position)
+        position_to_write = position_str
+        position_to_read = position_str
         if extraction:
             position_to_write += "m"
 
@@ -365,13 +365,9 @@ class XLight:
             time.sleep(self.sleep_time_for_wheel)
             self.emission_wheel_pos = position
 
-        if extraction:
-            # An extraction move ("m" suffix) leaves the wheel in a special state, so force the
-            # next plain set_emission_filter at this position to reach the hardware.
-            result = self.emission_wheel_pos
-            self.emission_wheel_pos = None
-            return result
-
+        # An extraction move ("m" suffix) leaves the wheel in a special state; remember that so the
+        # next plain call at this position still reaches the hardware.
+        self._emission_wheel_extracted = extraction
         return self.emission_wheel_pos
 
     def get_emission_filter(self):


### PR DESCRIPTION
## Problem

Multipoint acquisition is significantly slower on recent builds. On a machine with an X-Light spinning disk, every channel switch pays a serial write to the emission filter wheel **plus an unconditional `sleep_time_for_wheel` settle sleep (250 ms by default)** — even when the wheel is already at the requested position, which is the common case (all channels typically request the same position, so the wheel never physically moves).

The cost lands on the acquisition thread as the first step of `acquire_camera_image` (`_select_config` → `LiveController.update_illumination` → `XLight.set_emission_filter`), *before* the pipelined frame wait, so it cannot overlap with camera readout:

- **+0.25 s × channels × z-levels per FOV** — e.g. 5 channels, NZ=1: **+1.25 s per FOV**, ~+2 min per 96-FOV plate, ~+10 min per 500 FOVs.
- That is 7–10× the entire per-channel exposure + readout budget (~24–37 ms on a Kinetix).

Older builds did not pay this: `XLight.__init__` defaulted `disable_emission_filter_wheel=True` (and the old per-channel call site indexed `XLIGHT_EMISSION_FILTER_MAPPING` — keyed by wavelength — with `illumination_source`, so it raised KeyError into a bare except). When the wheel was re-enabled by default and `update_illumination` switched to the per-channel `emission_filter_position` config value, the unconditional write + settle sleep started executing on every channel switch.

## Fix

Cache the wheel position in `XLight.set_emission_filter` and skip the serial write + settle sleep when the wheel is already at the requested position:

- Positions are compared as strings, so `1` and `"1"` both hit the cache.
- `emission_wheel_pos` is only assigned after a command has been sent, so the **first call after startup always reaches the hardware**.
- **Extraction moves (`"m"` suffix) always execute and invalidate the cache**, so a subsequent plain set at the same position re-commands the wheel.
- Setups that genuinely switch emission filters per channel still pay the settle sleep — but only on actual moves.

## Impact

On the affected machine (5 channels, all at position 1): per-FOV channel loop drops from ~1.4–1.5 s back to ~0.3–0.45 s. Since the current acquisition pipeline is otherwise ~40–120 ms/channel faster than older builds (pipelined frame wait, off-thread saving), acquisitions should now be faster than they ever were.

## Testing

- `python -m py_compile control/serial_peripherals.py` → OK.
- Logic exercised with a stubbed serial connection: first call writes + sleeps; repeated same-position calls skip (int/str tolerant); position changes write; extraction always writes and invalidates the cache; post-extraction same-position call re-commands; fresh instance always writes first. One write + one sleep per real wheel command.
- Diagnosis and per-channel time budget verified against both the old and new trees; end-of-run `TimingManager` report shows the 250 ms gap inside `acquire_camera_image` (no timer wraps `_select_config`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
