### PR TITLE
refactor(camera): snapshot cached frame in reuse guard, document post-trigger contract

### DIFF
--- a/software/control/camera.py
+++ b/software/control/camera.py
@@ -385,19 +385,17 @@ class DefaultCamera(AbstractCamera):
 
         total_exposure_time_ms = self._exposure_time_ms + self._strobe_delay_us / 1000.0
 
-        # Only reuse the cached frame if it was captured at or after the most recent trigger and is
-        # still fresh. The trigger-timestamp guard prevents returning a pre-trigger frame in
-        # software/hardware trigger mode -- e.g. the laser-AF measure -> piezo move -> verify
-        # loop, where a stale pre-move frame would fail the cross-correlation check and revert
-        # a correct focus move. In continuous mode no per-read trigger is sent, so
-        # _last_trigger_timestamp stays old and every streamed frame passes this guard, keeping
-        # the previous fast-path behavior.
+        # Reuse the cached frame only if it is fresh AND was captured at or after the most recent
+        # trigger: a pre-trigger frame breaks trigger->read workflows (e.g. the laser-AF
+        # measure -> piezo move -> verify loop, where a stale pre-move frame reverts a correct
+        # focus move). In continuous mode no per-read trigger is sent, so every frame passes.
+        cached_frame = self._current_frame
         if (
-            self._current_frame
-            and self._current_frame.timestamp >= self._last_trigger_timestamp
-            and time.time() - self._current_frame.timestamp <= total_exposure_time_ms / 1000.0
+            cached_frame
+            and cached_frame.timestamp >= self._last_trigger_timestamp
+            and time.time() - cached_frame.timestamp <= total_exposure_time_ms / 1000.0
         ):
-            return self._current_frame
+            return cached_frame
 
         # The camera api isn't really fast, so it is easy to time out waiting for a frame and its processing.  So
         # for the timeout, we add a flat 100 ms to account for that.

--- a/software/squid/abc.py
+++ b/software/squid/abc.py
@@ -735,8 +735,14 @@ class AbstractCamera(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def read_camera_frame(self) -> Optional[CameraFrame]:
         """
-        This calls read_frame, but also fills in all the information such that you get a CameraFrame.  The
-        frame in the CameraFrame will have had _process_raw_frame called on it already.
+        Returns the latest frame as a full CameraFrame (read_frame delegates to this and returns
+        just the image data).  The frame in the CameraFrame will have had _process_raw_frame
+        called on it already.
+
+        In SOFTWARE/HARDWARE trigger modes, the returned frame must have been captured at or after
+        the most recent send_trigger() - implementations must never return a pre-trigger frame
+        (e.g. from a cached-frame fast path), since trigger->read callers rely on seeing the
+        post-trigger state.
 
         Might return None if getting a frame timed out, or another error occurred.
         """


### PR DESCRIPTION
Follow-up to #599 (two small non-behavioral improvements that were pushed to that branch after it merged, so they never landed):

- **`DefaultCamera.read_camera_frame`:** snapshot `self._current_frame` into a local before evaluating the reuse condition. The camera callback thread can reassign `_current_frame` between the condition's reads, so the truthiness check, timestamp comparisons, and returned object could otherwise refer to different frames. A single read makes the evaluation atomic with respect to the callback. Comment trimmed to the non-obvious rationale.
- **`AbstractCamera.read_camera_frame` docstring:** state the contract #599 enforces — in triggered modes, implementations must never return a pre-trigger frame (e.g. from a cached-frame fast path) — so future drivers with a frame-reuse fast path implement the same guard. Also fixes the docstring's backwards description of the `read_frame` relationship (`read_frame` delegates to `read_camera_frame`, not the other way around).

No behavior change. `tests/squid/test_camera.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
