### PR TITLE
fix(camera): pace hardware triggers so long strobe delays can elapse

### DIFF
--- a/software/control/camera_andor.py
+++ b/software/control/camera_andor.py
@@ -503,11 +503,17 @@ class AndorCamera(AbstractCamera):
         elif self.get_acquisition_mode() == CameraAcquisitionMode.SOFTWARE_TRIGGER:
             try:
                 self._camera.SoftwareTrigger()
-                self._last_trigger_timestamp = time.time()
-                self._trigger_sent.set()
                 self._log.debug("trigger sent")
             except Exception as e:
                 raise CameraError(f"Failed to send software trigger: {e}")
+
+        # Mark the trigger as sent for hardware triggers too, so get_ready_for_trigger()
+        # paces callers (e.g. LiveController) until the frame arrives or the frame-time
+        # timeout elapses. Without this, hw triggers are re-sent faster than the strobe
+        # delay, and the MCU restarts its strobe countdown on every trigger, so the
+        # illumination never turns on.
+        self._last_trigger_timestamp = time.time()
+        self._trigger_sent.set()
 
     def get_ready_for_trigger(self) -> bool:
         if time.time() - self._last_trigger_timestamp > 1.5 * ((self.get_total_frame_time() + 4) / 1000.0):

--- a/software/control/camera_hamamatsu.py
+++ b/software/control/camera_hamamatsu.py
@@ -504,8 +504,13 @@ class HamamatsuCamera(AbstractCamera):
             if not self._camera.cap_firetrigger():
                 raise CameraError(f"Failed to send software trigger: {self._last_dcam_error_string()}")
 
-            self._last_trigger_timestamp = time.time()
-            self._trigger_sent.set()
+        # Mark the trigger as sent for hardware triggers too, so get_ready_for_trigger()
+        # paces callers (e.g. LiveController) until the frame arrives or the frame-time
+        # timeout elapses. Without this, hw triggers are re-sent faster than the strobe
+        # delay, and the MCU restarts its strobe countdown on every trigger - with a long
+        # strobe delay (Ultra Quiet readout, ~200 ms) the illumination never turns on.
+        self._last_trigger_timestamp = time.time()
+        self._trigger_sent.set()
 
     def get_ready_for_trigger(self) -> bool:
         # Not ready while streaming is stopped (e.g. inside _pause_streaming() during a

--- a/software/control/camera_photometrics.py
+++ b/software/control/camera_photometrics.py
@@ -416,10 +416,16 @@ class PhotometricsCamera(AbstractCamera):
         elif self.get_acquisition_mode() == CameraAcquisitionMode.SOFTWARE_TRIGGER:
             try:
                 self._camera.sw_trigger()
-                self._last_trigger_timestamp = time.time()
-                self._trigger_sent.set()
             except Exception as e:
                 raise CameraError(f"Failed to send software trigger: {e}")
+
+        # Mark the trigger as sent for hardware triggers too, so get_ready_for_trigger()
+        # paces callers (e.g. LiveController) until the frame arrives or the frame-time
+        # timeout elapses. Without this, hw triggers are re-sent faster than the strobe
+        # delay, and the MCU restarts its strobe countdown on every trigger, so the
+        # illumination never turns on.
+        self._last_trigger_timestamp = time.time()
+        self._trigger_sent.set()
 
     def get_ready_for_trigger(self) -> bool:
         if time.time() - self._last_trigger_timestamp > 1.5 * ((self.get_total_frame_time() + 4) / 1000.0):

--- a/software/control/camera_tucsen.py
+++ b/software/control/camera_tucsen.py
@@ -789,8 +789,14 @@ class TucsenCamera(AbstractCamera):
                 self._set_genicam_parameter("TriggerSoftwarePulse", 1, TUELEM_TYPE.TU_ElemCommand.value)
             else:
                 TUCAM_Cap_DoSoftwareTrigger(self._camera)
-            self._last_trigger_timestamp = time.time()
-            self._trigger_sent.set()
+
+        # Mark the trigger as sent for hardware triggers too, so get_ready_for_trigger()
+        # paces callers (e.g. LiveController) until the frame arrives or the frame-time
+        # timeout elapses. Without this, hw triggers are re-sent faster than the strobe
+        # delay, and the MCU restarts its strobe countdown on every trigger, so the
+        # illumination never turns on.
+        self._last_trigger_timestamp = time.time()
+        self._trigger_sent.set()
 
     def get_ready_for_trigger(self) -> bool:
         if time.time() - self._last_trigger_timestamp > 1.5 * ((self.get_total_frame_time() + 4) / 1000.0):


### PR DESCRIPTION
## Problem

Hamamatsu, Andor, Photometrics and Tucsen only set `_trigger_sent` / `_last_trigger_timestamp` inside the **software**-trigger branch of `send_trigger()`. So in hardware-trigger mode `get_ready_for_trigger()` never throttled anything, and `LiveController` re-sent triggers at the full requested fps.

The MCU restarts its strobe-delay countdown on every trigger command. Whenever the trigger period was shorter than the strobe delay, the countdown never finished and **the illumination never turned on** — e.g. ORCA-Fusion BT Ultra Quiet readout (~200 ms strobe delay) at >5 fps live.

## Fix

Set the bookkeeping after *both* trigger branches, matching what the FLIR and Toupcam drivers already do. Live view then self-throttles to the camera's actual frame time and the strobe fires on every frame.

Four drivers, +31/−8. No API or behaviour change for software-trigger mode.

## Testing

`tests/squid/test_camera.py` is unchanged by this commit: **7 failed / 2 passed both before and after**, i.e. identical to clean `master` — those failures are pre-existing on `master`, not introduced here. Likewise `black --check` already flags `camera_andor.py` on `master` before this change.

Cherry-picked onto current `master` (`56db6965`); applies cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)