### PR TITLE
feat(live): add a Snap button for single-frame capture

### DIFF
--- a/software/control/core/core.py
+++ b/software/control/core/core.py
@@ -88,6 +88,9 @@ class QtStreamHandler(QObject):
     def set_display_fps(self, fps):
         self._handler.set_display_fps(fps)
 
+    def force_next_display(self):
+        self._handler.force_next_display()
+
     def set_save_fps(self, fps):
         self._handler.set_save_fps(fps)
 

--- a/software/control/core/core.py
+++ b/software/control/core/core.py
@@ -63,7 +63,12 @@ class QtStreamHandler(QObject):
     packet_image_to_write = Signal(np.ndarray, int, float)
     signal_new_frame_received = Signal()
 
-    def __init__(self, display_resolution_scaling=1, accept_new_frame_fn: Callable[[], bool] = lambda: True):
+    def __init__(
+        self,
+        display_resolution_scaling=1,
+        accept_new_frame_fn: Callable[[], bool] = lambda: True,
+        force_display_fn: Callable[[], bool] = lambda: False,
+    ):
         super().__init__()
 
         functions = StreamHandlerFunctions(
@@ -71,6 +76,7 @@ class QtStreamHandler(QObject):
             packet_image_to_write=self.packet_image_to_write.emit,
             signal_new_frame_received=self.signal_new_frame_received.emit,
             accept_new_frame=accept_new_frame_fn,
+            force_display=force_display_fn,
         )
         self._handler = StreamHandler(
             handler_functions=functions, display_resolution_scaling=display_resolution_scaling
@@ -87,9 +93,6 @@ class QtStreamHandler(QObject):
 
     def set_display_fps(self, fps):
         self._handler.set_display_fps(fps)
-
-    def force_next_display(self):
-        self._handler.force_next_display()
 
     def set_save_fps(self, fps):
         self._handler.set_save_fps(fps)

--- a/software/control/core/live_controller.py
+++ b/software/control/core/live_controller.py
@@ -39,9 +39,8 @@ class LiveController(QObject):
         self.currentConfiguration: Optional[AcquisitionChannel] = None
         self.trigger_mode: Optional[TriggerMode] = TriggerMode.SOFTWARE  # @@@ change to None
         self.is_live = False
-        # True only for the duration of a single snap(). The stream handler gates
-        # frames on live/snapping, so a snapped frame needs this to reach the display.
-        self.is_snapping = False
+        # True only for the duration of a single snap(); see should_display_frames().
+        self._is_snapping = False
         self.control_illumination = control_illumination
         self.illumination_on = False
         self.use_internal_timer_for_hardware_trigger = (
@@ -440,25 +439,19 @@ class LiveController(QObject):
         # is_snapping (which gates those callbacks) until they have actually run.
         frame_propagated = threading.Event()
         callback_id = self.camera.add_frame_callback(lambda _frame: frame_propagated.set())
-        self.is_snapping = True
+        self._is_snapping = True
         got_frame = False
         try:
-            if self.trigger_mode == TriggerMode.HARDWARE:
-                # The microcontroller strobes the illumination for the exposure, so
-                # don't also turn it on here.
+            # In HARDWARE mode the microcontroller strobes the illumination for the
+            # exposure, so don't also turn it on here. In CONTINUOUS mode it stays on
+            # for one frame period plus whatever is left of the in-flight frame, i.e.
+            # up to two exposures worth of light.
+            if self.trigger_mode != TriggerMode.HARDWARE and self.control_illumination and not self.illumination_on:
+                self.turn_on_illumination()
+            # CONTINUOUS free-runs, so there is no trigger to send.
+            if self.trigger_mode in (TriggerMode.HARDWARE, TriggerMode.SOFTWARE):
                 self.trigger_ID = self.trigger_ID + 1
                 self.camera.send_trigger(self.camera.get_exposure_time())
-            elif self.trigger_mode == TriggerMode.SOFTWARE:
-                if self.control_illumination and not self.illumination_on:
-                    self.turn_on_illumination()
-                self.trigger_ID = self.trigger_ID + 1
-                self.camera.send_trigger(self.camera.get_exposure_time())
-            else:
-                # CONTINUOUS: the camera free-runs, so there is no trigger to send.
-                # Illumination is on for one frame period plus whatever is left of the
-                # in-flight frame, i.e. up to two exposures worth of light.
-                if self.control_illumination and not self.illumination_on:
-                    self.turn_on_illumination()
 
             got_frame = self.camera.read_frame() is not None
             if not got_frame:
@@ -473,9 +466,18 @@ class LiveController(QObject):
             if got_frame:
                 frame_propagated.wait(1.0)
             self.camera.remove_frame_callback(callback_id)
-            self.is_snapping = False
+            self._is_snapping = False
             if not was_streaming:
                 self.camera.stop_streaming()
+
+    @property
+    def is_snapping(self) -> bool:
+        """True only while snap() is acquiring its single frame."""
+        return self._is_snapping
+
+    def should_display_frames(self) -> bool:
+        """True when camera frames are meant to reach the display (live or snap)."""
+        return self.is_live or self._is_snapping
 
     def _trigger_acquisition_timer_fn(self):
         if self.trigger_acquisition():

--- a/software/control/core/live_controller.py
+++ b/software/control/core/live_controller.py
@@ -429,7 +429,10 @@ class LiveController(QObject):
         was_streaming = self.camera.get_is_streaming()
         if not was_streaming:
             self.camera.start_streaming()
-        self.camera.enable_callbacks(True)  # in case it's disabled e.g. by the laser AF controller
+        # Callbacks may be disabled e.g. by the laser AF controller; the snapped frame
+        # reaches the display through them, so enable them for the duration of the snap.
+        callbacks_were_enabled = self.camera.get_callbacks_enabled()
+        self.camera.enable_callbacks(True)
 
         if self.for_displacement_measurement:
             self.microscope.low_level_drivers.microcontroller.set_pin_level(MCU_PINS.AF_LASER, 1)
@@ -466,6 +469,7 @@ class LiveController(QObject):
             if got_frame:
                 frame_propagated.wait(1.0)
             self.camera.remove_frame_callback(callback_id)
+            self.camera.enable_callbacks(callbacks_were_enabled)
             self._is_snapping = False
             if not was_streaming:
                 self.camera.stop_streaming()

--- a/software/control/core/live_controller.py
+++ b/software/control/core/live_controller.py
@@ -39,6 +39,9 @@ class LiveController(QObject):
         self.currentConfiguration: Optional[AcquisitionChannel] = None
         self.trigger_mode: Optional[TriggerMode] = TriggerMode.SOFTWARE  # @@@ change to None
         self.is_live = False
+        # True only for the duration of a single snap(). The stream handler gates
+        # frames on live/snapping, so a snapped frame needs this to reach the display.
+        self.is_snapping = False
         self.control_illumination = control_illumination
         self.illumination_on = False
         self.use_internal_timer_for_hardware_trigger = (
@@ -405,6 +408,74 @@ class LiveController(QObject):
             # if controlling the laser displacement measurement camera
             if self.for_displacement_measurement:
                 self.microscope.low_level_drivers.microcontroller.set_pin_level(MCU_PINS.AF_LASER, 0)
+
+    def snap(self):
+        """Acquire exactly one frame using the current live configuration.
+
+        Same trigger/illumination path as live, but the illumination is turned off
+        as soon as the frame has been read, so a light-sensitive sample only sees a
+        single exposure instead of a free-running stream. The frame reaches the
+        display through the normal camera callbacks.
+
+        Does nothing while live is running - the sample is already being exposed.
+
+        Returns True if a frame was captured.
+        """
+        if self.is_live:
+            self._log.debug("snap() called while live is running, ignoring.")
+            return False
+
+        self._check_laser_engine_warn_only()
+
+        was_streaming = self.camera.get_is_streaming()
+        if not was_streaming:
+            self.camera.start_streaming()
+        self.camera.enable_callbacks(True)  # in case it's disabled e.g. by the laser AF controller
+
+        if self.for_displacement_measurement:
+            self.microscope.low_level_drivers.microcontroller.set_pin_level(MCU_PINS.AF_LASER, 1)
+
+        # read_frame() returns as soon as the frame is stored, which can be just
+        # before the callbacks that put it on screen run. This event lets us hold
+        # is_snapping (which gates those callbacks) until they have actually run.
+        frame_propagated = threading.Event()
+        callback_id = self.camera.add_frame_callback(lambda _frame: frame_propagated.set())
+        self.is_snapping = True
+        got_frame = False
+        try:
+            if self.trigger_mode == TriggerMode.HARDWARE:
+                # The microcontroller strobes the illumination for the exposure, so
+                # don't also turn it on here.
+                self.trigger_ID = self.trigger_ID + 1
+                self.camera.send_trigger(self.camera.get_exposure_time())
+            elif self.trigger_mode == TriggerMode.SOFTWARE:
+                if self.control_illumination and not self.illumination_on:
+                    self.turn_on_illumination()
+                self.trigger_ID = self.trigger_ID + 1
+                self.camera.send_trigger(self.camera.get_exposure_time())
+            else:
+                # CONTINUOUS: the camera free-runs, so there is no trigger to send.
+                # Illumination is on for one frame period plus whatever is left of the
+                # in-flight frame, i.e. up to two exposures worth of light.
+                if self.control_illumination and not self.illumination_on:
+                    self.turn_on_illumination()
+
+            got_frame = self.camera.read_frame() is not None
+            if not got_frame:
+                self._log.warning("Snap timed out waiting for a frame.")
+            return got_frame
+        finally:
+            # Light off first, then let the frame finish its trip to the display.
+            if self.control_illumination and self.illumination_on:
+                self.turn_off_illumination()
+            if self.for_displacement_measurement:
+                self.microscope.low_level_drivers.microcontroller.set_pin_level(MCU_PINS.AF_LASER, 0)
+            if got_frame:
+                frame_propagated.wait(1.0)
+            self.camera.remove_frame_callback(callback_id)
+            self.is_snapping = False
+            if not was_streaming:
+                self.camera.stop_streaming()
 
     def _trigger_acquisition_timer_fn(self):
         if self.trigger_acquisition():

--- a/software/control/core/stream_handler.py
+++ b/software/control/core/stream_handler.py
@@ -16,6 +16,11 @@ class StreamHandlerFunctions:
     packet_image_to_write: Callable[[np.ndarray, int, float], None]
     signal_new_frame_received: Callable[[], None]
     accept_new_frame: Callable[[], bool]
+    # True to exempt the frame from display-fps throttling. Used by single-frame
+    # captures (snap), where dropping the one frame that was acquired because it
+    # arrived too soon after the previous one would leave the user staring at a
+    # stale image.
+    force_display: Callable[[], bool] = lambda: False
 
 
 NoOpStreamHandlerFunctions = StreamHandlerFunctions(
@@ -23,6 +28,7 @@ NoOpStreamHandlerFunctions = StreamHandlerFunctions(
     packet_image_to_write=lambda a, i, f: None,
     signal_new_frame_received=lambda: None,
     accept_new_frame=lambda: True,
+    force_display=lambda: False,
 )
 
 
@@ -60,15 +66,6 @@ class StreamHandler:
     def set_display_fps(self, fps):
         self.fps_display = fps
 
-    def force_next_display(self):
-        """Exempt the next frame from display-fps throttling.
-
-        Used by single-frame captures (snap), where dropping the one frame that
-        was acquired because it arrived too soon after the previous one would
-        leave the user staring at a stale image.
-        """
-        self.timestamp_last_display = 0
-
     def set_save_fps(self, fps):
         self.fps_save = fps
 
@@ -104,7 +101,7 @@ class StreamHandler:
 
         # send image to display
         time_now = time.time()
-        if time_now - self.timestamp_last_display >= 1 / self.fps_display:
+        if self._fns.force_display() or time_now - self.timestamp_last_display >= 1 / self.fps_display:
             self._fns.image_to_display(
                 utils.crop_image(
                     image,

--- a/software/control/core/stream_handler.py
+++ b/software/control/core/stream_handler.py
@@ -60,6 +60,15 @@ class StreamHandler:
     def set_display_fps(self, fps):
         self.fps_display = fps
 
+    def force_next_display(self):
+        """Exempt the next frame from display-fps throttling.
+
+        Used by single-frame captures (snap), where dropping the one frame that
+        was acquired because it arrived too soon after the previous one would
+        leave the user staring at a stale image.
+        """
+        self.timestamp_last_display = 0
+
     def set_save_fps(self, fps):
         self.fps_save = fps
 

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -848,7 +848,8 @@ class HighContentScreeningGui(QMainWindow):
 
     def load_objects(self, is_simulation):
         self.streamHandler = core.QtStreamHandler(
-            accept_new_frame_fn=lambda: self.liveController.is_live or self.liveController.is_snapping
+            accept_new_frame_fn=lambda: self.liveController.should_display_frames(),
+            force_display_fn=lambda: self.liveController.is_snapping,
         )
         self.autofocusController = QtAutoFocusController(
             self.camera, self.stage, self.liveController, self.microcontroller, self.nl5
@@ -1512,6 +1513,7 @@ class HighContentScreeningGui(QMainWindow):
         self.liveControlWidget.signal_newAnalogGain.connect(self.cameraSettingWidget.set_analog_gain)
         if not self.live_only_mode:
             self.liveControlWidget.signal_start_live.connect(self.onStartLive)
+            self.liveControlWidget.signal_show_live_view.connect(self.onShowLiveView)
         self.liveControlWidget.update_camera_settings()
 
         self.connectSlidePositionController()
@@ -2689,9 +2691,12 @@ class HighContentScreeningGui(QMainWindow):
             self.log.debug("Warning/error widget: disconnected logging handler")
 
     def onStartLive(self):
-        self.imageDisplayTabs.setCurrentIndex(0)
+        self.onShowLiveView()
         if self.alignmentWidget is not None:
             self.alignmentWidget.enable()
+
+    def onShowLiveView(self):
+        self.imageDisplayTabs.setCurrentIndex(0)
 
     def move_from_click_image(self, click_x, click_y, image_width, image_height):
         if not self.navigationWidget.get_click_to_move_enabled():

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -847,7 +847,9 @@ class HighContentScreeningGui(QMainWindow):
             self.addDockWidget(Qt.LeftDockWidgetArea, self.jupyter_dock)
 
     def load_objects(self, is_simulation):
-        self.streamHandler = core.QtStreamHandler(accept_new_frame_fn=lambda: self.liveController.is_live)
+        self.streamHandler = core.QtStreamHandler(
+            accept_new_frame_fn=lambda: self.liveController.is_live or self.liveController.is_snapping
+        )
         self.autofocusController = QtAutoFocusController(
             self.camera, self.stage, self.liveController, self.microcontroller, self.nl5
         )

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -4317,12 +4317,25 @@ class LiveControlWidget(QFrame):
         self.dropdown_modeSelection.setCurrentText(self.currentConfiguration.name)
         self.dropdown_modeSelection.setSizePolicy(sizePolicy)
 
-        self.btn_live = QPushButton("Start Live")
+        self.btn_live = QPushButton("Start")
         self.btn_live.setCheckable(True)
         self.btn_live.setChecked(False)
         self.btn_live.setDefault(False)
         self.btn_live.setStyleSheet("background-color: #C2C2FF")
         self.btn_live.setSizePolicy(sizePolicy)
+        self.btn_live.setToolTip("Start/stop continuous live imaging with the current Live Configuration.")
+
+        # Single-frame capture, for light sensitive samples where a free-running
+        # live stream would bleach or damage the sample while settings are dialed in.
+        self.btn_snap = QPushButton("Snap")
+        self.btn_snap.setCheckable(False)
+        self.btn_snap.setDefault(False)
+        self.btn_snap.setStyleSheet("background-color: #C2C2FF")
+        self.btn_snap.setSizePolicy(sizePolicy)
+        self.btn_snap.setToolTip(
+            "Acquire a single frame with the current Live Configuration. "
+            "Illumination is on for that one exposure only."
+        )
 
         # line 3: exposure time and analog gain associated with the current mode
         self.entry_exposureTime = QDoubleSpinBox()
@@ -4398,7 +4411,10 @@ class LiveControlWidget(QFrame):
         self.btn_autolevel.setChecked(autolevel)
 
         # Determine the maximum width needed
-        self.entry_illuminationIntensity.setMinimumWidth(self.btn_live.sizeHint().width())
+        # Keep the illumination entry aligned with the Start/Snap pair above it.
+        self.entry_illuminationIntensity.setMinimumWidth(
+            self.btn_live.sizeHint().width() + self.btn_snap.sizeHint().width()
+        )
         self.btn_autolevel.setMinimumWidth(self.btn_autolevel.sizeHint().width())
 
         max_width = max(self.btn_autolevel.minimumWidth(), self.entry_illuminationIntensity.minimumWidth())
@@ -4415,6 +4431,7 @@ class LiveControlWidget(QFrame):
         self.dropdown_modeSelection.activated[str].connect(self.select_new_microscope_mode_by_name)
         self.dropdown_triggerManu.currentIndexChanged.connect(self.update_trigger_mode)
         self.btn_live.clicked.connect(self.toggle_live)
+        self.btn_snap.clicked.connect(self.snap)
         self.entry_exposureTime.valueChanged.connect(self.update_config_exposure_time)
         self.entry_analogGain.valueChanged.connect(self.update_config_analog_gain)
         self.entry_illuminationIntensity.valueChanged.connect(self.update_config_illumination_intensity)
@@ -4428,7 +4445,12 @@ class LiveControlWidget(QFrame):
         grid_line1 = QHBoxLayout()
         grid_line1.addWidget(QLabel("Live Configuration"))
         grid_line1.addWidget(self.dropdown_modeSelection, 2)
-        grid_line1.addWidget(self.btn_live, 1)
+        # Start and Snap share the space the single live button used to occupy.
+        live_buttons = QHBoxLayout()
+        live_buttons.setContentsMargins(0, 0, 0, 0)
+        live_buttons.addWidget(self.btn_live, 1)
+        live_buttons.addWidget(self.btn_snap, 1)
+        grid_line1.addLayout(live_buttons, 1)
 
         grid_line2 = QHBoxLayout()
         grid_line2.addWidget(QLabel("Exposure Time"))
@@ -4538,11 +4560,31 @@ class LiveControlWidget(QFrame):
     def toggle_live(self, pressed):
         if pressed:
             self.liveController.start_live()
-            self.btn_live.setText("Stop Live")
+            self.btn_live.setText("Stop")
             self.signal_start_live.emit()
         else:
             self.liveController.stop_live()
-            self.btn_live.setText("Start Live")
+            self.btn_live.setText("Start")
+        # Snapping while live is meaningless - the sample is already being exposed.
+        self.btn_snap.setEnabled(not pressed)
+
+    def snap(self):
+        """Acquire and display one frame with the current live configuration."""
+        if self.liveController.is_live:
+            return
+        # Bring the live view forward so the snapped frame is actually visible.
+        self.signal_start_live.emit()
+        self.btn_snap.setEnabled(False)
+        QApplication.setOverrideCursor(Qt.WaitCursor)
+        try:
+            # A snap is a single frame - it must not be dropped by display throttling.
+            self.streamHandler.force_next_display()
+            self.liveController.snap()
+        except Exception:
+            self._log.exception("Snap failed")
+        finally:
+            QApplication.restoreOverrideCursor()
+            self.btn_snap.setEnabled(True)
 
     def toggle_autolevel(self, autolevel_on):
         self.btn_autolevel.setChecked(autolevel_on)

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -4337,7 +4337,8 @@ class LiveControlWidget(QFrame):
         self.btn_snap.setSizePolicy(sizePolicy)
         self.btn_snap.setToolTip(
             "Acquire a single frame with the current Live Configuration. "
-            "Illumination is on for that one exposure only."
+            "In software/hardware trigger mode the illumination is on for that one "
+            "exposure only; in continuous mode it stays on for up to two exposures."
         )
 
         # line 3: exposure time and analog gain associated with the current mode

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -4228,6 +4228,9 @@ class LiveControlWidget(QFrame):
     signal_autoLevelSetting = Signal(bool)
     signal_live_configuration = Signal(object)
     signal_start_live = Signal()
+    # Request that the display bring the live view forward, without implying that
+    # live has started (also emitted for a single-frame snap).
+    signal_show_live_view = Signal()
 
     def __init__(
         self,
@@ -4573,18 +4576,14 @@ class LiveControlWidget(QFrame):
         if self.liveController.is_live:
             return
         # Bring the live view forward so the snapped frame is actually visible.
-        self.signal_start_live.emit()
-        self.btn_snap.setEnabled(False)
+        self.signal_show_live_view.emit()
         QApplication.setOverrideCursor(Qt.WaitCursor)
         try:
-            # A snap is a single frame - it must not be dropped by display throttling.
-            self.streamHandler.force_next_display()
             self.liveController.snap()
         except Exception:
             self._log.exception("Snap failed")
         finally:
             QApplication.restoreOverrideCursor()
-            self.btn_snap.setEnabled(True)
 
     def toggle_autolevel(self, autolevel_on):
         self.btn_autolevel.setChecked(autolevel_on)


### PR DESCRIPTION
## Why

Light sensitive samples bleach while the user dials in exposure and gain, because the only way to see the effect of a setting is to run live. This splits the live button in the Live View control panel into **Start** and **Snap**, so a single frame can be acquired without a free-running stream.

The existing "Snap Images" in the acquisition tabs is a different thing — it runs a full single-FOV acquisition through `MultiPointController` and writes to disk. This is just "show me one frame with the current Live Configuration".

## UI

- `Start Live` → `Start`, and the toggled label `Stop Live` → `Stop`.
- `Snap` sits immediately to its right, sharing the exact space the single live button used to occupy, so the row's proportions are unchanged.
- `Snap` is disabled while live is running, and re-enabled on stop.

## Implementation

`LiveController.snap()` takes the same trigger/illumination path as live, but for a single frame:

- **Software trigger**: illumination on → one trigger → read the frame → illumination off immediately.
- **Hardware trigger**: the MCU strobes the light for that one exposure, so no software illumination.
- **Continuous**: there is no trigger to send, so the light is on for one frame period plus whatever is left of the in-flight frame. That is as short as that mode gets, and it is called out in a comment.

Camera streaming state and the AF-laser pin are restored on every path, including failure.

Two things stood in the way of the frame reaching the screen:

1. The stream handler drops frames unless live is running (`accept_new_frame_fn`), so snap raises `is_snapping` for its duration. That flag is held until the display callback has actually run — `read_frame()` returns just before the callbacks fire, so clearing it immediately would race and lose the frame.
2. The display is throttled to the display FPS, which would silently swallow a snap taken soon after the previous frame. `StreamHandler.force_next_display()` exempts the snapped frame from that throttle.

## Testing

On the simulated microscope: three consecutive snaps each delivered exactly one frame to the display, illumination off after each, and `snap()` is a no-op while live. Existing widget and live-control tests pass (180). Verified on hardware in a customer build (Squid+, ToupCam, software trigger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
