### PR TITLE
fix: focus map KeyError on loaded coordinates, stage move timeouts 38-300x too long, focus-map double move

### DIFF
--- a/software/control/core/scan_coordinates.py
+++ b/software/control/core/scan_coordinates.py
@@ -641,7 +641,7 @@ class ScanCoordinates:
     def get_region_shape(self, region_id):
         if not self.validate_region(region_id):
             return None
-        # Regions added without a shape (e.g. loaded from a csv) are treated as bounding boxes
+        # Regions registered without a shape (widget code that writes the dicts directly) are bounding boxes
         return self.region_shapes.get(region_id, "Square")
 
     def get_scan_bounds(self):

--- a/software/control/core/scan_coordinates.py
+++ b/software/control/core/scan_coordinates.py
@@ -641,7 +641,8 @@ class ScanCoordinates:
     def get_region_shape(self, region_id):
         if not self.validate_region(region_id):
             return None
-        return self.region_shapes[region_id]
+        # Regions added without a shape (e.g. loaded from a csv) are treated as bounding boxes
+        return self.region_shapes.get(region_id, "Square")
 
     def get_scan_bounds(self):
         """Get bounds of all scan regions with margin"""
@@ -735,7 +736,7 @@ class ScanCoordinatesSiLA2(ScanCoordinates):
                                 + row * wellplate_settings["well_spacing_mm"]
                                 + control._def.WELLPLATE_OFFSET_Y_mm
                             )
-                            self.region_centers[self._index_to_row(row) + str(col + 1)] = (x_mm, y_mm)
+                            self.region_centers[self._index_to_row(row) + str(col + 1)] = [x_mm, y_mm]
                 else:
                     x_mm = (
                         wellplate_settings["a1_x_mm"]
@@ -747,7 +748,7 @@ class ScanCoordinatesSiLA2(ScanCoordinates):
                         + start_row_index * wellplate_settings["well_spacing_mm"]
                         + control._def.WELLPLATE_OFFSET_Y_mm
                     )
-                    self.region_centers[start_row + start_col] = (x_mm, y_mm)
+                    self.region_centers[start_row + start_col] = [x_mm, y_mm]
             else:
                 raise ValueError(f"Invalid well format: {desc}. Expected format is 'A1' or 'A1:B2' for ranges.")
 

--- a/software/control/microcontroller.py
+++ b/software/control/microcontroller.py
@@ -25,13 +25,7 @@ from control._def import *
 _log = squid.logging.get_logger("microcontroller")
 
 # Mapping of execution status bytes to human-readable names for logging
-_CMD_EXECUTION_STATUS_NAMES = {
-    CMD_EXECUTION_STATUS.COMPLETED_WITHOUT_ERRORS: "COMPLETED_WITHOUT_ERRORS",
-    CMD_EXECUTION_STATUS.IN_PROGRESS: "IN_PROGRESS",
-    CMD_EXECUTION_STATUS.CMD_CHECKSUM_ERROR: "CMD_CHECKSUM_ERROR",
-    CMD_EXECUTION_STATUS.CMD_INVALID: "CMD_INVALID",
-    CMD_EXECUTION_STATUS.CMD_EXECUTION_ERROR: "CMD_EXECUTION_ERROR",
-}
+_CMD_EXECUTION_STATUS_NAMES = {value: name for name, value in vars(CMD_EXECUTION_STATUS).items() if name.isupper()}
 
 # Mapping of command type bytes to human-readable names for logging
 _CMD_NAMES = {
@@ -617,9 +611,6 @@ class Microcontroller:
     # The micro has an update time it tries to keep to.  This must be > that time.  As of 2025-04-28, it's 10ms
     # on the micro.  So 0.1 is 10x that.
     STALE_READ_TIMEOUT = 0.1
-    # Position updates arrive continuously, so a gap this long means the link is down rather than
-    # the firmware being stuck mid-command.  Only used to word timeout messages.
-    QUIET_MCU_TIMEOUT = 1.0
 
     def __init__(self, serial_device: AbstractCephlaMicroSerial, reset_and_initialize=True):
         self.log = squid.logging.get_logger(self.__class__.__name__)
@@ -704,14 +695,8 @@ class Microcontroller:
     def _warn_if_reads_stale(self):
         if self._is_simulated:
             return
-        now = time.time()
-        last_read = float(
-            self._last_successful_read_time
-        )  # Just in case it gets update, capture it for printing below.
-        if now - last_read > Microcontroller.STALE_READ_TIMEOUT:
-            self.log.warning(
-                f"Read thread is stale, it has been {now - last_read} [s] since a valid packet. Last cmd id from the mcu was {self._cmd_id_mcu}, our last sent cmd id was {self._cmd_id}"
-            )
+        if time.time() - self._last_successful_read_time > Microcontroller.STALE_READ_TIMEOUT:
+            self.log.warning(f"Read thread is stale. {self._mcu_state()}")
 
     def close(self):
         self.stop_heartbeat()
@@ -1489,9 +1474,7 @@ class Microcontroller:
                 safely only in this case. If False (default), log at ERROR
                 (operator attention warranted) and the motor state is uncertain.
         """
-        cmd_type = self.last_command[1] if self.last_command is not None else -1
-        cmd_name = _CMD_NAMES.get(cmd_type, f"UNKNOWN({cmd_type})")
-        msg = f"[MCU] Command {self._cmd_id} ({cmd_name}) aborted: {reason}"
+        msg = f"[MCU] Command {self._cmd_id} ({self._last_command_name()}) aborted: {reason}"
         if recoverable:
             self.log.warning(msg)
         else:
@@ -1599,10 +1582,9 @@ class Microcontroller:
                     if self.mcu_cmd_execution_in_progress:
                         self.mcu_cmd_execution_in_progress = False
                         elapsed_ms = (time.time() - self.last_command_send_timestamp) * 1000
-                        cmd_type = self.last_command[1] if self.last_command is not None else -1
-                        cmd_name = _CMD_NAMES.get(cmd_type, f"UNKNOWN({cmd_type})")
                         self.log.debug(
-                            f"[MCU] <<< command {self._cmd_id} ({cmd_name}) complete (took {elapsed_ms:.1f}ms)"
+                            f"[MCU] <<< command {self._cmd_id} ({self._last_command_name()}) complete"
+                            f" (took {elapsed_ms:.1f}ms)"
                         )
                 elif (
                     self.mcu_cmd_execution_in_progress
@@ -1747,29 +1729,23 @@ class Microcontroller:
             if self.last_command_aborted_error is not None:
                 raise self.last_command_aborted_error
 
-    def _mcu_state(self) -> str:
-        """Describe what the mcu last told us, for timeout/abort messages.
-
-        A firmware that never finishes a move keeps reporting IN_PROGRESS for whatever command id it
-        last received, which matches none of the recovery branches in the read loop: no ack timeout
-        (the ids match), no resend, no abort.  Every later blocking command then times out too, so say
-        so explicitly instead of leaving a bare "timed out" for the operator to interpret.
-        """
+    def _last_command_name(self) -> str:
         cmd_type = self.last_command[1] if self.last_command is not None else -1
-        cmd_name = _CMD_NAMES.get(cmd_type, f"UNKNOWN({cmd_type})")
+        return _CMD_NAMES.get(cmd_type, f"UNKNOWN({cmd_type})")
+
+    def _mcu_state(self) -> str:
+        """Describe the last thing the mcu told us, for wait-timeout and stale-read messages."""
         status_name = _CMD_EXECUTION_STATUS_NAMES.get(self._cmd_execution_status, self._cmd_execution_status)
-        since_read_s = time.time() - float(self._last_successful_read_time)
+        since_read_s = time.time() - self._last_successful_read_time
         state = (
-            f"Sent cmd {self._cmd_id} ({cmd_name}); mcu reports cmd {self._cmd_id_mcu} status={status_name}; "
-            f"{since_read_s:.1f} [s] since a valid packet."
+            f"Sent cmd {self._cmd_id} ({self._last_command_name()}); mcu reports cmd {self._cmd_id_mcu}"
+            f" status={status_name}; {since_read_s:.1f} [s] since a valid packet."
         )
-        if since_read_s > Microcontroller.QUIET_MCU_TIMEOUT:
+        if since_read_s > Microcontroller.STALE_READ_TIMEOUT:
             return state + " The mcu has gone quiet - check the serial connection."
-        if (
-            self._cmd_id_mcu == self._cmd_id
-            and self._cmd_execution_status == CMD_EXECUTION_STATUS.IN_PROGRESS
-            and not self._is_simulated
-        ):
+        if self._cmd_id_mcu == self._cmd_id and self._cmd_execution_status == CMD_EXECUTION_STATUS.IN_PROGRESS:
+            # Matches none of the read loop's recovery branches (ids match, so no ack-timeout resend; no
+            # error status, so no abort), and every later blocking command will hit the same wall.
             return state + (
                 " The mcu is still talking but reports this command as in progress, so the firmware never"
                 " finished a move and every command after it will time out too. Home the stage to clear it."

--- a/software/control/microcontroller.py
+++ b/software/control/microcontroller.py
@@ -24,6 +24,15 @@ from control._def import *
 # We have a few top level functions here, so we have this module level log instance.  Classes should make their own!
 _log = squid.logging.get_logger("microcontroller")
 
+# Mapping of execution status bytes to human-readable names for logging
+_CMD_EXECUTION_STATUS_NAMES = {
+    CMD_EXECUTION_STATUS.COMPLETED_WITHOUT_ERRORS: "COMPLETED_WITHOUT_ERRORS",
+    CMD_EXECUTION_STATUS.IN_PROGRESS: "IN_PROGRESS",
+    CMD_EXECUTION_STATUS.CMD_CHECKSUM_ERROR: "CMD_CHECKSUM_ERROR",
+    CMD_EXECUTION_STATUS.CMD_INVALID: "CMD_INVALID",
+    CMD_EXECUTION_STATUS.CMD_EXECUTION_ERROR: "CMD_EXECUTION_ERROR",
+}
+
 # Mapping of command type bytes to human-readable names for logging
 _CMD_NAMES = {
     CMD_SET.MOVE_X: "MOVE_X",
@@ -608,6 +617,9 @@ class Microcontroller:
     # The micro has an update time it tries to keep to.  This must be > that time.  As of 2025-04-28, it's 10ms
     # on the micro.  So 0.1 is 10x that.
     STALE_READ_TIMEOUT = 0.1
+    # Position updates arrive continuously, so a gap this long means the link is down rather than
+    # the firmware being stuck mid-command.  Only used to word timeout messages.
+    QUIET_MCU_TIMEOUT = 1.0
 
     def __init__(self, serial_device: AbstractCephlaMicroSerial, reset_and_initialize=True):
         self.log = squid.logging.get_logger(self.__class__.__name__)
@@ -1730,10 +1742,39 @@ class Microcontroller:
             self._received_packet_cv.wait_for(lambda: not still_busy(), timeout=timeout_limit_s)
 
             if still_busy():
-                raise TimeoutError(f"Current mcu operation timed out after {timeout_limit_s} [s].")
+                raise TimeoutError(f"Current mcu operation timed out after {timeout_limit_s} [s]. {self._mcu_state()}")
 
             if self.last_command_aborted_error is not None:
                 raise self.last_command_aborted_error
+
+    def _mcu_state(self) -> str:
+        """Describe what the mcu last told us, for timeout/abort messages.
+
+        A firmware that never finishes a move keeps reporting IN_PROGRESS for whatever command id it
+        last received, which matches none of the recovery branches in the read loop: no ack timeout
+        (the ids match), no resend, no abort.  Every later blocking command then times out too, so say
+        so explicitly instead of leaving a bare "timed out" for the operator to interpret.
+        """
+        cmd_type = self.last_command[1] if self.last_command is not None else -1
+        cmd_name = _CMD_NAMES.get(cmd_type, f"UNKNOWN({cmd_type})")
+        status_name = _CMD_EXECUTION_STATUS_NAMES.get(self._cmd_execution_status, self._cmd_execution_status)
+        since_read_s = time.time() - float(self._last_successful_read_time)
+        state = (
+            f"Sent cmd {self._cmd_id} ({cmd_name}); mcu reports cmd {self._cmd_id_mcu} status={status_name}; "
+            f"{since_read_s:.1f} [s] since a valid packet."
+        )
+        if since_read_s > Microcontroller.QUIET_MCU_TIMEOUT:
+            return state + " The mcu has gone quiet - check the serial connection."
+        if (
+            self._cmd_id_mcu == self._cmd_id
+            and self._cmd_execution_status == CMD_EXECUTION_STATUS.IN_PROGRESS
+            and not self._is_simulated
+        ):
+            return state + (
+                " The mcu is still talking but reports this command as in progress, so the firmware never"
+                " finished a move and every command after it will time out too. Home the stage to clear it."
+            )
+        return state
 
     @staticmethod
     def _int_to_payload(signed_int, number_of_bytes) -> int:

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -160,7 +160,8 @@ def load_coordinate_regions_from_dataframe(scan_coordinates, df):
     the acquisition moves Z per FOV; otherwise FOVs are (x, y). Region centers are
     stored as mutable [x, y] lists without z — nothing reads a center z, and a
     mutable list keeps them consistent with the ScanCoordinates.add_* builders
-    (and append-safe for any future center-z writer).
+    (and append-safe for any future center-z writer). Every loaded region is
+    registered with shape "Manual" so containment checks use its bounding box.
 
     All parsing/conversion happens before scan_coordinates is mutated, so a bad
     row raises without clearing or partially overwriting existing regions.
@@ -222,6 +223,11 @@ def load_coordinate_regions_from_dataframe(scan_coordinates, df):
     scan_coordinates.clear_regions()
     scan_coordinates.region_fov_coordinates.update(region_fov_coords)
     scan_coordinates.region_centers.update(region_centers)
+    # Loaded coordinates are an arbitrary fov list, like a manually drawn region. Without a shape,
+    # enabling the focus map (generate_grid -> region_contains_coordinate -> get_region_shape)
+    # raised KeyError on the region id.
+    for region_id in region_fov_coords:
+        scan_coordinates.region_shapes[region_id] = "Manual"
 
     return region_fov_coords, z_dropped
 
@@ -10909,7 +10915,11 @@ class FocusMapWidget(QFrame):
             return
         current = self.point_combo.currentIndex()
         next_index = (current + 1) % len(self.focus_points)
+        # setCurrentIndex fires currentIndexChanged -> goto_selected_point, so block it and move once
+        # explicitly.  Otherwise every click ran two full x/y/z moves (and one move for a single point).
+        self.point_combo.blockSignals(True)
         self.point_combo.setCurrentIndex(next_index)
+        self.point_combo.blockSignals(False)
         self.goto_selected_point()
 
     def goto_selected_point(self):

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -223,11 +223,7 @@ def load_coordinate_regions_from_dataframe(scan_coordinates, df):
     scan_coordinates.clear_regions()
     scan_coordinates.region_fov_coordinates.update(region_fov_coords)
     scan_coordinates.region_centers.update(region_centers)
-    # Loaded coordinates are an arbitrary fov list, like a manually drawn region. Without a shape,
-    # enabling the focus map (generate_grid -> region_contains_coordinate -> get_region_shape)
-    # raised KeyError on the region id.
-    for region_id in region_fov_coords:
-        scan_coordinates.region_shapes[region_id] = "Manual"
+    scan_coordinates.region_shapes.update(dict.fromkeys(region_fov_coords, "Manual"))
 
     return region_fov_coords, z_dropped
 
@@ -10915,8 +10911,7 @@ class FocusMapWidget(QFrame):
             return
         current = self.point_combo.currentIndex()
         next_index = (current + 1) % len(self.focus_points)
-        # setCurrentIndex fires currentIndexChanged -> goto_selected_point, so block it and move once
-        # explicitly.  Otherwise every click ran two full x/y/z moves (and one move for a single point).
+        # setCurrentIndex emits currentIndexChanged -> goto_selected_point; block it so we move once, not twice.
         self.point_combo.blockSignals(True)
         self.point_combo.setCurrentIndex(next_index)
         self.point_combo.blockSignals(False)

--- a/software/squid/stage/cephla.py
+++ b/software/squid/stage/cephla.py
@@ -16,8 +16,10 @@ class CephlaStage(AbstractStage):
         # We arbitrarily guess that if a move takes 3x the naive "infinite acceleration" time, then it
         # probably timed out.  But always use a minimum timeout of at least 3 seconds.
         #
-        # Also protect against divide by zero.
-        return max((3, 3 * abs(distance) / min(0.1, abs(max_speed))))
+        # The max(0.1, ...) protects against divide by zero.  It used to be min(0.1, ...), which pinned
+        # the divisor at 0.1 [mm/s] no matter how fast the axis is and made every timeout 38x (z) to
+        # 300x (x/y) longer than intended - a wedged controller froze the gui for minutes.
+        return max((3, 3 * abs(distance) / max(0.1, abs(max_speed))))
 
     def __init__(self, microcontroller: control.microcontroller.Microcontroller, stage_config: StageConfig):
         super().__init__(stage_config)

--- a/software/squid/stage/cephla.py
+++ b/software/squid/stage/cephla.py
@@ -16,9 +16,7 @@ class CephlaStage(AbstractStage):
         # We arbitrarily guess that if a move takes 3x the naive "infinite acceleration" time, then it
         # probably timed out.  But always use a minimum timeout of at least 3 seconds.
         #
-        # The max(0.1, ...) protects against divide by zero.  It used to be min(0.1, ...), which pinned
-        # the divisor at 0.1 [mm/s] no matter how fast the axis is and made every timeout 38x (z) to
-        # 300x (x/y) longer than intended - a wedged controller froze the gui for minutes.
+        # The max(0.1, ...) protects against divide by zero.
         return max((3, 3 * abs(distance) / max(0.1, abs(max_speed))))
 
     def __init__(self, microcontroller: control.microcontroller.Microcontroller, stage_config: StageConfig):

--- a/software/tests/control/core/test_scan_coordinates.py
+++ b/software/tests/control/core/test_scan_coordinates.py
@@ -8,6 +8,8 @@ from control.core.scan_coordinates import (
     RemovedScanCoordinateRegion,
     ClearedScanCoordinates,
 )
+from control.core.core import FocusMap
+from control.core.core import FocusMap
 from control.microscope import Microscope
 
 
@@ -155,3 +157,23 @@ def test_sort_coordinates_keeps_non_well_region_names():
     sc.sort_coordinates()
 
     assert list(sc.region_centers.keys()) == ["A1", "B1", "current", "my region"]
+
+
+def test_focus_grid_and_shape_for_loaded_coordinates():
+    """Coordinates loaded from a csv are an arbitrary fov list, with no well shape to fall back on."""
+    scope = Microscope.build_from_global_config(simulated=True)
+    sc = ScanCoordinates(scope.objective_store, scope.stage, scope.camera)
+
+    # Mimic load_coordinate_regions_from_dataframe()
+    sc.region_fov_coordinates = {"loaded": [(20.0 + 0.5 * i, 20.0 + 0.5 * j) for i in range(4) for j in range(4)]}
+    sc.region_centers = {"loaded": [20.75, 20.75]}
+    sc.region_shapes = {"loaded": "Manual"}
+
+    # Enabling the focus map widget generates a grid over every region
+    grid = FocusMap().generate_grid_coordinates(sc, rows=3, cols=3)
+    assert len(grid["loaded"]) == 9
+
+    # A region registered without any shape is treated as a bounding box instead of raising
+    del sc.region_shapes["loaded"]
+    assert sc.get_region_shape("loaded") == "Square"
+    assert sc.region_contains_coordinate("loaded", 20.75, 20.75)

--- a/software/tests/control/core/test_scan_coordinates.py
+++ b/software/tests/control/core/test_scan_coordinates.py
@@ -9,7 +9,6 @@ from control.core.scan_coordinates import (
     ClearedScanCoordinates,
 )
 from control.core.core import FocusMap
-from control.core.core import FocusMap
 from control.microscope import Microscope
 
 
@@ -159,21 +158,14 @@ def test_sort_coordinates_keeps_non_well_region_names():
     assert list(sc.region_centers.keys()) == ["A1", "B1", "current", "my region"]
 
 
-def test_focus_grid_and_shape_for_loaded_coordinates():
-    """Coordinates loaded from a csv are an arbitrary fov list, with no well shape to fall back on."""
-    scope = Microscope.build_from_global_config(simulated=True)
-    sc = ScanCoordinates(scope.objective_store, scope.stage, scope.camera)
+def test_focus_grid_for_region_registered_without_a_shape():
+    """Widget code that writes the region dicts directly may leave no shape; the focus map grid
+    (generate_grid -> region_contains_coordinate -> get_region_shape) used to raise KeyError on it."""
+    sc = _make_scan_coordinates("Unidirectional", ["loaded"])
+    sc.region_fov_coordinates["loaded"] = [(20.0 + 0.5 * i, 20.0 + 0.5 * j) for i in range(4) for j in range(4)]
+    assert "loaded" not in sc.region_shapes
 
-    # Mimic load_coordinate_regions_from_dataframe()
-    sc.region_fov_coordinates = {"loaded": [(20.0 + 0.5 * i, 20.0 + 0.5 * j) for i in range(4) for j in range(4)]}
-    sc.region_centers = {"loaded": [20.75, 20.75]}
-    sc.region_shapes = {"loaded": "Manual"}
-
-    # Enabling the focus map widget generates a grid over every region
     grid = FocusMap().generate_grid_coordinates(sc, rows=3, cols=3)
-    assert len(grid["loaded"]) == 9
 
-    # A region registered without any shape is treated as a bounding box instead of raising
-    del sc.region_shapes["loaded"]
+    assert len(grid["loaded"]) == 9
     assert sc.get_region_shape("loaded") == "Square"
-    assert sc.region_contains_coordinate("loaded", 20.75, 20.75)

--- a/software/tests/control/test_microcontroller.py
+++ b/software/tests/control/test_microcontroller.py
@@ -269,3 +269,56 @@ def test_abort_current_command_recoverable_logs_at_warning(caplog):
             assert all(r.levelno == logging.ERROR for r in fatal_records)
     finally:
         micro.close()
+
+
+def test_mcu_state_names_a_command_the_firmware_reports_as_still_in_progress():
+    """A firmware that never finishes a move keeps answering IN_PROGRESS for the current command id,
+    which matches none of the read loop's recovery branches; the timeout text must say so."""
+    micro = get_test_micro()
+    try:
+        micro.move_z_to_usteps(100)
+        micro.wait_till_operation_is_completed()
+        # The simulator always completes commands, so stage the stuck-firmware state by hand.
+        micro._cmd_id_mcu = micro._cmd_id
+        micro._cmd_execution_status = control._def.CMD_EXECUTION_STATUS.IN_PROGRESS
+        micro._last_successful_read_time = time.time()
+
+        state = micro._mcu_state()
+
+        assert f"Sent cmd {micro._cmd_id} (MOVETO_Z)" in state
+        assert f"mcu reports cmd {micro._cmd_id} status=IN_PROGRESS" in state
+        assert "Home the stage to clear it" in state
+        assert "gone quiet" not in state
+    finally:
+        micro.close()
+
+
+def test_mcu_state_reports_a_quiet_link_instead_of_a_stuck_command():
+    micro = get_test_micro()
+    try:
+        micro.move_z_to_usteps(100)
+        micro.wait_till_operation_is_completed()
+        micro._cmd_id_mcu = micro._cmd_id
+        micro._cmd_execution_status = control._def.CMD_EXECUTION_STATUS.IN_PROGRESS
+        micro._last_successful_read_time = time.time() - 5.0
+
+        state = micro._mcu_state()
+
+        assert "5.0 [s] since a valid packet" in state
+        assert "gone quiet - check the serial connection" in state
+        assert "Home the stage" not in state
+    finally:
+        micro.close()
+
+
+def test_wait_timeout_error_includes_mcu_state():
+    micro = get_test_micro()
+    try:
+        micro.move_z_to_usteps(100)
+        micro.wait_till_operation_is_completed()
+        micro.is_busy = lambda: True  # pin the wait in the busy state so it has to time out
+
+        with pytest.raises(TimeoutError, match=r"timed out after 0.05 \[s\].*Sent cmd \d+ \(MOVETO_Z\)"):
+            micro.wait_till_operation_is_completed(0.05)
+    finally:
+        micro.close()

--- a/software/tests/control/test_widgets.py
+++ b/software/tests/control/test_widgets.py
@@ -2769,6 +2769,18 @@ def test_load_regions_with_z_column_builds_3tuples_and_list_centers():
     assert fovs == sc.region_fov_coordinates
 
 
+def test_load_regions_registers_manual_shape_for_every_region():
+    # Enabling the focus map calls get_region_shape() on every region; a loaded region
+    # with no shape raised KeyError.
+    sc = _scan_coordinates_for_test()
+    df = pd.DataFrame({"region": ["A1", "A1", "left"], "x (mm)": [10.0, 10.5, 20.0], "y (mm)": [10.0, 10.0, 20.0]})
+
+    control.widgets.load_coordinate_regions_from_dataframe(sc, df)
+
+    assert sc.region_shapes == {"A1": "Manual", "left": "Manual"}
+    assert sc.get_region_shape("left") == "Manual"
+
+
 def test_load_regions_without_z_column_builds_2tuples():
     sc = _scan_coordinates_for_test()
     df = pd.DataFrame({"region": ["A1"], "x (mm)": [10.0], "y (mm)": [10.0]})

--- a/software/tests/control/test_widgets.py
+++ b/software/tests/control/test_widgets.py
@@ -2778,7 +2778,6 @@ def test_load_regions_registers_manual_shape_for_every_region():
     control.widgets.load_coordinate_regions_from_dataframe(sc, df)
 
     assert sc.region_shapes == {"A1": "Manual", "left": "Manual"}
-    assert sc.get_region_shape("left") == "Manual"
 
 
 def test_load_regions_without_z_column_builds_2tuples():

--- a/software/tests/control/test_widgets.py
+++ b/software/tests/control/test_widgets.py
@@ -9,13 +9,20 @@ import numpy as np
 import pandas as pd
 import pytest
 from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QComboBox
 
 import control._def
 import control.microscope
 import control.widgets
 from control.core import core as core_module
 from control.core.scan_coordinates import ScanCoordinates
-from control.widgets import check_ram_available_with_error_dialog, NDViewerTab, RecordingWidget, SurfacePlotWidget
+from control.widgets import (
+    check_ram_available_with_error_dialog,
+    FocusMapWidget,
+    NDViewerTab,
+    RecordingWidget,
+    SurfacePlotWidget,
+)
 from squid.abc import CameraFrame, CameraFrameFormat
 from squid.config import CameraPixelFormat
 
@@ -2915,3 +2922,36 @@ def test_save_load_round_trip_preserves_z():
     control.widgets.load_coordinate_regions_from_dataframe(sc, df)
 
     assert sc.region_fov_coordinates["A1"] == [(10.0, 10.0, 3.25), (10.5, 10.0, 3.25)]
+
+
+class _FocusMapNavigationStub:
+    """FocusMapWidget-ish object exposing just what goto_next_point / goto_selected_point use."""
+
+    def __init__(self, focus_points):
+        self.enabled = True
+        self.focus_points = focus_points
+        self.stage = MagicMock()
+        self.point_combo = QComboBox()
+        for region_id, x, y, z in focus_points:
+            self.point_combo.addItem(f"{region_id} ({x}, {y}, {z})")
+        # Mirrors FocusMapWidget.make_connections()
+        self.point_combo.currentIndexChanged.connect(self.goto_selected_point)
+
+    goto_next_point = FocusMapWidget.goto_next_point
+    goto_selected_point = FocusMapWidget.goto_selected_point
+
+
+def test_focus_map_goto_next_point_moves_stage_once_per_click(qtbot):
+    """Regression: setCurrentIndex emitted currentIndexChanged -> goto_selected_point, and then
+    goto_next_point called goto_selected_point again, so every click ran two full x/y/z moves."""
+    points = [("A1", 1.0, 2.0, 3.0), ("A1", 4.0, 5.0, 6.0), ("B2", 7.0, 8.0, 9.0)]
+    widget = _FocusMapNavigationStub(points)
+
+    for _, x, y, z in points[1:] + points[:1]:  # three clicks: 1, 2, then wrap back to 0
+        widget.stage.reset_mock()
+
+        widget.goto_next_point()
+
+        widget.stage.move_x_to.assert_called_once_with(x)
+        widget.stage.move_y_to.assert_called_once_with(y)
+        widget.stage.move_z_to.assert_called_once_with(z)

--- a/software/tests/squid/test_stage.py
+++ b/software/tests/squid/test_stage.py
@@ -379,3 +379,14 @@ def test_combined_stage_homes_z_before_xy(monkeypatch):
     combined.home(x=True, y=True, z=True, theta=False, blocking=False)
 
     assert calls == [("z", True), ("xy", False)]
+
+
+def test_calc_move_timeout_scales_with_axis_speed():
+    """Regression: the divisor was min(0.1, speed) instead of max(0.1, speed), which pinned it at
+    0.1 mm/s and made every timeout 38x (z) to 300x (x/y) longer than the intended 3x naive move time."""
+    timeout = squid.stage.cephla.CephlaStage._calc_move_timeout
+
+    assert timeout(60.0, 30.0) == pytest.approx(6.0)  # 3 * 60 mm / 30 mm/s
+    assert timeout(-60.0, 30.0) == pytest.approx(6.0)  # direction does not matter
+    assert timeout(0.5, 2.0) == 3.0  # short moves get the 3 s floor
+    assert timeout(1.0, 0.0) == pytest.approx(30.0)  # zero speed falls back to 0.1 mm/s instead of dividing by zero


### PR DESCRIPTION
## Summary

Fixes from a debugging session on a Waypoint Bio instrument (patch by Patrick Kaifosh, Waypoint Bio, rebased onto current master here), for two problems hit while acquiring from a loaded coordinate CSV with the focus map enabled:

1. **`KeyError: 'manual0'` when enabling the focus map on CSV-loaded coordinates.** The loader populated `region_centers` / `region_fov_coordinates` but never `region_shapes`; focus-map grid generation → `region_contains_coordinate` → `get_region_shape` indexed the missing key.
2. **GUI froze for 63 s / 160 s / 320 s on MCU "timeouts".** `CephlaStage._calc_move_timeout` had `min(0.1, max_speed)` where `max(...)` was intended (since d9fb440b, 2024-12), pinning the divisor at 0.1 mm/s so every move timeout was 38× (Z) to 300× (X/Y) longer than designed. The underlying trigger on that instrument was firmware-side (a Z backlash pre-move that never satisfied `check_position()`, leaving the MCU reporting `IN_PROGRESS` forever — see below), but the oversized timeouts turned it into a minutes-long freeze with a bare "timed out" message.

## Changes

- `squid/stage/cephla.py`: `min` → `max` in `_calc_move_timeout`. With default config: X 60 mm → 6 s, Z → 3 s floor, X home ≈ 51 s, Z home ≈ 27 s (firmware homes at 0.8×/0.5× max speed, so margins are 3–10×).
- `control/microcontroller.py`: wait-timeout (and stale-read) messages now include the sent command id/name, the MCU's reported id/status, and time since the last valid packet, and distinguish "MCU still talking but stuck `IN_PROGRESS` → home the stage to clear it" from "MCU gone quiet → check serial". Status names are derived from `CMD_EXECUTION_STATUS`; a `_last_command_name()` helper replaces four copies of the same lookup.
- `control/widgets.py`: `load_coordinate_regions_from_dataframe` registers every loaded region with shape `"Manual"` (bounding-box containment, like a drawn region). `FocusMapWidget.goto_next_point` blocks `currentIndexChanged` around `setCurrentIndex` — every click was running two full X/Y/Z move sequences.
- `control/core/scan_coordinates.py`: `get_region_shape` falls back to `"Square"` for regions registered without a shape (widget code that writes the dicts directly, e.g. `cell_was_changed`'s rename); `ScanCoordinatesSiLA2` stores centers as lists like the base class.
- Tests: shapeless-region grid generation in `test_scan_coordinates.py`; loader shape registration in `test_widgets.py`.

Parts of the original patch that were dropped on rebase because master already covers them: the `update_fov_z_level` tuple fix (function removed in #608), the `sort_coordinates` non-well-name fallback (already handled by `_parse_well_key`), and the `coord[:2]` save path (#608 now saves z explicitly).

## Verification

- `tests/control/test_microcontroller.py`, `tests/control/core`, `tests/squid/test_stage*.py`, `tests/control/test_widgets.py`, `test_MultiPointController/Worker*`: all pass except `test_multi_point_controller_image_count_calculation` / `_mosaic_ram_estimate`, which fail identically on master with this machine's config (pre-existing).
- Simulated end-to-end: CSV load → focus-map grid (9 points/region) → `region_contains_coordinate` → `sort_coordinates`.
- Timeout values checked directly for moves, homing, and the divide-by-zero guard.

## Not addressed here (deliberately)

- **Firmware root cause.** `check_position()` in `firmware/controller/src/operations.cpp` only clears `*_commanded_movement_in_progress` when the driver position exactly equals the target and `!isRunning`; when that never happens the MCU reports `IN_PROGRESS` for the current id indefinitely, which matches none of the host read loop's recovery branches. A move watchdog there (set `CMD_EXECUTION_ERROR` after N s) would stop one stalled move from wedging the link, but it means reflashing the Teensy.
- **Heartbeat vs. blocking moves.** The 2.5 s watchdog heartbeat shares the single `_cmd_id` / busy flag with moves, so a move's wait can return when the heartbeat acks rather than when the axis arrives. Proper fix is per-command completion tracking.
- **Loaded coordinates vanish on record-tab switch** (`gui_hcs.onTabChanged` clears regions unconditionally and the #608 guard in `update_coordinates` then returns without restoring). Reproduced in simulation; separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
