### PR TITLE
fix(firmware): don't set illumination_is_on from the strobe ISR (next-channel bleed) — v1.5

### DIFF
--- a/firmware/controller/src/constants.h
+++ b/firmware/controller/src/constants.h
@@ -15,8 +15,13 @@
 // Version 1.4 = filter-wheel (W/W2) home resets xmin/xmax to full range (rotary
 //               axis has no travel end-stop); fixes intermittent post-home
 //               MOVETO_W CMD_EXECUTION_ERROR (home left xmin = L - C > offset)
+// Version 1.5 = strobe ISR no longer sets illumination_is_on at strobe start
+//               (only the host can set it; the ISR still clears it at strobe
+//               end), so a SET_ILLUMINATION arriving during a strobe can't
+//               light the next channel early (next-channel bleed in HW-triggered
+//               multi-channel acquisitions)
 #define FIRMWARE_VERSION_MAJOR 1
-#define FIRMWARE_VERSION_MINOR 4
+#define FIRMWARE_VERSION_MINOR 5
 
 #include "def/def_v1.h"
 

--- a/firmware/controller/src/constants.h
+++ b/firmware/controller/src/constants.h
@@ -15,11 +15,9 @@
 // Version 1.4 = filter-wheel (W/W2) home resets xmin/xmax to full range (rotary
 //               axis has no travel end-stop); fixes intermittent post-home
 //               MOVETO_W CMD_EXECUTION_ERROR (home left xmin = L - C > offset)
-// Version 1.5 = strobe ISR no longer sets illumination_is_on at strobe start
-//               (only the host can set it; the ISR still clears it at strobe
-//               end), so a SET_ILLUMINATION arriving during a strobe can't
-//               light the next channel early (next-channel bleed in HW-triggered
-//               multi-channel acquisitions)
+// Version 1.5 = strobe ISR no longer sets illumination_is_on (only the host
+//               can set it; the ISR still clears it at strobe end); fixes
+//               next-channel bleed in HW-triggered multi-channel acquisitions
 #define FIRMWARE_VERSION_MAJOR 1
 #define FIRMWARE_VERSION_MINOR 5
 

--- a/firmware/controller/src/functions.cpp
+++ b/firmware/controller/src/functions.cpp
@@ -503,20 +503,31 @@ void turn_off_all_ports()
   illumination_is_on = false;
 }
 
-// The strobe ISR drives only the port it latched (strobe_active_source). It
-// never SETS the host-commanded illumination_is_on flag; it only clears it at
-// strobe end when the strobe extinguished the host's own source (v1.3/v1.4
-// behaviour, kept so HW-triggered live view is strobe-only after the first
-// frame). Up to v1.4 the ISR also set the flag true at strobe start, which made
-// a SET_ILLUMINATION arriving while a strobe was still on (the host switching
-// to the next channel right after its exposure sleep) energize the new port
-// immediately via set_illumination() -> turn_on_illumination(); the strobe end
-// then turned off only the latched port and, seeing the source had changed,
-// left the flag true, so the next channel's laser stayed on through the current
-// frame's readout (next-channel bleed, gradient in the last-read rows). With
-// the flag settable only by the host, set_illumination() re-lights a port only
-// if the host explicitly turned illumination on, and a strobe can never be the
-// reason a second port is lit.
+// One strobe pulse for a camera channel, driven by ISR_strobeTimer().
+// strobe_begin() latches illumination_source so strobe_end() extinguishes
+// exactly the port it lit, even if the host switches channels mid-strobe (the
+// race that left e.g. 640 nm stuck HIGH, fixed in v1.3). strobe_begin() never
+// writes the host-owned illumination_is_on flag (v1.5, see constants.h), so a
+// SET_ILLUMINATION landing during a strobe cannot re-light a port.
+static inline void strobe_begin(int camera_channel)
+{
+  strobe_active_source[camera_channel] = illumination_source;
+  turn_on_illumination_source(strobe_active_source[camera_channel]);
+  strobe_output_level[camera_channel] = HIGH;
+}
+
+static inline void strobe_end(int camera_channel)
+{
+  turn_off_illumination_source(strobe_active_source[camera_channel]);
+  // Only clear illumination_is_on if the active source is still the one we
+  // strobed. If the host has switched channels and explicitly turned on the
+  // new source, leave the flag as the host set it.
+  if (illumination_source == strobe_active_source[camera_channel])
+    illumination_is_on = false;
+  strobe_output_level[camera_channel] = LOW;
+  control_strobe[camera_channel] = false;
+}
+
 void ISR_strobeTimer()
 {
   for (int camera_channel = 0; camera_channel < 4; camera_channel++)
@@ -529,51 +540,19 @@ void ISR_strobeTimer()
         // if the illumination on time is smaller than 30 ms, use delayMicroseconds to control the pulse length to avoid pulse length jitter
         if ( ((micros() - timestamp_trigger_rising_edge[camera_channel]) >= strobe_delay[camera_channel]) && strobe_output_level[camera_channel] == LOW )
         {
-          // Latch the source we turn on, so we turn off the same one below
-          // even if illumination_source changes during the pulse. Both ON and
-          // OFF helpers below take the latched source explicitly, so the pin
-          // toggled HIGH here is exactly the one toggled LOW after the delay.
-          strobe_active_source[camera_channel] = illumination_source;
-          turn_on_illumination_source(strobe_active_source[camera_channel]);
-          strobe_output_level[camera_channel] = HIGH;
+          strobe_begin(camera_channel);
           delayMicroseconds(illumination_on_time[camera_channel]);
-          turn_off_illumination_source(strobe_active_source[camera_channel]);
-          // The strobe just extinguished the host's own source: reflect that in
-          // the host flag (unchanged from v1.3/v1.4). If the host has switched
-          // to another source meanwhile, leave the flag as the host set it.
-          if (illumination_source == strobe_active_source[camera_channel])
-            illumination_is_on = false;
-          strobe_output_level[camera_channel] = LOW;
-          control_strobe[camera_channel] = false;
+          strobe_end(camera_channel);
         }
       }
       else
       {
         // start the strobe
         if ( ((micros() - timestamp_trigger_rising_edge[camera_channel]) >= strobe_delay[camera_channel]) && strobe_output_level[camera_channel] == LOW )
-        {
-          // Latch source before turning on, so the strobe-end branch below
-          // turns off the SAME port even if Python changes illumination_source
-          // between start and end (the race that left e.g. 640 nm stuck HIGH
-          // after switching to 405 nm during live HW-triggered acquisition).
-          // Both helpers take the latched source explicitly to make the ON/OFF
-          // pair symmetric.
-          strobe_active_source[camera_channel] = illumination_source;
-          turn_on_illumination_source(strobe_active_source[camera_channel]);
-          strobe_output_level[camera_channel] = HIGH;
-        }
+          strobe_begin(camera_channel);
         // end the strobe
         if (((micros() - timestamp_trigger_rising_edge[camera_channel]) >= strobe_delay[camera_channel] + illumination_on_time[camera_channel]) && strobe_output_level[camera_channel] == HIGH)
-        {
-          turn_off_illumination_source(strobe_active_source[camera_channel]);
-          // Only clear illumination_is_on if the active source is still the
-          // one we strobed. If Python has switched channels and explicitly
-          // turned on the new source, leave illumination_is_on as Python set it.
-          if (illumination_source == strobe_active_source[camera_channel])
-            illumination_is_on = false;
-          strobe_output_level[camera_channel] = LOW;
-          control_strobe[camera_channel] = false;
-        }
+          strobe_end(camera_channel);
       }
     }
   }

--- a/firmware/controller/src/functions.cpp
+++ b/firmware/controller/src/functions.cpp
@@ -503,6 +503,20 @@ void turn_off_all_ports()
   illumination_is_on = false;
 }
 
+// The strobe ISR drives only the port it latched (strobe_active_source). It
+// never SETS the host-commanded illumination_is_on flag; it only clears it at
+// strobe end when the strobe extinguished the host's own source (v1.3/v1.4
+// behaviour, kept so HW-triggered live view is strobe-only after the first
+// frame). Up to v1.4 the ISR also set the flag true at strobe start, which made
+// a SET_ILLUMINATION arriving while a strobe was still on (the host switching
+// to the next channel right after its exposure sleep) energize the new port
+// immediately via set_illumination() -> turn_on_illumination(); the strobe end
+// then turned off only the latched port and, seeing the source had changed,
+// left the flag true, so the next channel's laser stayed on through the current
+// frame's readout (next-channel bleed, gradient in the last-read rows). With
+// the flag settable only by the host, set_illumination() re-lights a port only
+// if the host explicitly turned illumination on, and a strobe can never be the
+// reason a second port is lit.
 void ISR_strobeTimer()
 {
   for (int camera_channel = 0; camera_channel < 4; camera_channel++)
@@ -520,11 +534,13 @@ void ISR_strobeTimer()
           // OFF helpers below take the latched source explicitly, so the pin
           // toggled HIGH here is exactly the one toggled LOW after the delay.
           strobe_active_source[camera_channel] = illumination_source;
-          illumination_is_on = true;
           turn_on_illumination_source(strobe_active_source[camera_channel]);
           strobe_output_level[camera_channel] = HIGH;
           delayMicroseconds(illumination_on_time[camera_channel]);
           turn_off_illumination_source(strobe_active_source[camera_channel]);
+          // The strobe just extinguished the host's own source: reflect that in
+          // the host flag (unchanged from v1.3/v1.4). If the host has switched
+          // to another source meanwhile, leave the flag as the host set it.
           if (illumination_source == strobe_active_source[camera_channel])
             illumination_is_on = false;
           strobe_output_level[camera_channel] = LOW;
@@ -543,7 +559,6 @@ void ISR_strobeTimer()
           // Both helpers take the latched source explicitly to make the ON/OFF
           // pair symmetric.
           strobe_active_source[camera_channel] = illumination_source;
-          illumination_is_on = true;
           turn_on_illumination_source(strobe_active_source[camera_channel]);
           strobe_output_level[camera_channel] = HIGH;
         }

--- a/firmware/controller/src/globals.h
+++ b/firmware/controller/src/globals.h
@@ -140,7 +140,12 @@ extern float illumination_intensity_factor;
 extern uint8_t led_matrix_r;
 extern uint8_t led_matrix_g;
 extern uint8_t led_matrix_b;
-// volatile: cleared at strobe end inside ISR, read by set_illumination() in main loop
+// Host-commanded illumination state: set true only by TURN_ON_ILLUMINATION.
+// Cleared by TURN_OFF_ILLUMINATION / watchdog / TURN_OFF_ALL_PORTS, and by the
+// strobe ISR at strobe end when the strobe extinguished the host's own source.
+// The ISR never sets it (it did up to v1.4, see ISR_strobeTimer());
+// set_illumination() uses it to decide whether to re-light the new source.
+// volatile: cleared inside the ISR, read/written in the main loop.
 extern volatile bool illumination_is_on;
 
 // Multi-port illumination control (supports up to 16 ports D1-D16)

--- a/firmware/controller/src/globals.h
+++ b/firmware/controller/src/globals.h
@@ -140,12 +140,10 @@ extern float illumination_intensity_factor;
 extern uint8_t led_matrix_r;
 extern uint8_t led_matrix_g;
 extern uint8_t led_matrix_b;
-// Host-commanded illumination state: set true only by TURN_ON_ILLUMINATION.
-// Cleared by TURN_OFF_ILLUMINATION / watchdog / TURN_OFF_ALL_PORTS, and by the
-// strobe ISR at strobe end when the strobe extinguished the host's own source.
-// The ISR never sets it (it did up to v1.4, see ISR_strobeTimer());
-// set_illumination() uses it to decide whether to re-light the new source.
-// volatile: cleared inside the ISR, read/written in the main loop.
+// Host-owned: set true only in turn_on_illumination(); the strobe ISR only
+// ever clears it (strobe_end(), when the strobe extinguished the host's own
+// source). volatile: cleared in the ISR, read by set_illumination() in the
+// main loop.
 extern volatile bool illumination_is_on;
 
 // Multi-port illumination control (supports up to 16 ports D1-D16)

--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -365,6 +365,13 @@ RESPONSE_BYTE_FIRMWARE_VERSION = 22  # Nibble-encoded: high=major, low=minor
 # Serial watchdog (illumination auto-shutoff safety)
 # Must match firmware constants in constants.h
 DEFAULT_WATCHDOG_TIMEOUT_MS = 5000  # 5 seconds (matches firmware)
+
+# Firmware < 1.5 lights the new source immediately if SET_ILLUMINATION arrives while
+# a strobe is still on (and < 1.3 can also strand the old source). On such firmware
+# the host waits out the last trigger's strobe window (strobe delay + exposure) plus
+# this margin before changing the illumination source; the margin absorbs USB/serial
+# jitter. Firmware >= 1.5 needs no spacing.
+STROBE_GUARD_MARGIN_MS = 5
 MAX_WATCHDOG_TIMEOUT_MS = 3600000  # 1 hour (matches firmware)
 WATCHDOG_TIMEOUT_S = DEFAULT_WATCHDOG_TIMEOUT_MS / 1000.0
 

--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -365,6 +365,8 @@ RESPONSE_BYTE_FIRMWARE_VERSION = 22  # Nibble-encoded: high=major, low=minor
 # Serial watchdog (illumination auto-shutoff safety)
 # Must match firmware constants in constants.h
 DEFAULT_WATCHDOG_TIMEOUT_MS = 5000  # 5 seconds (matches firmware)
+MAX_WATCHDOG_TIMEOUT_MS = 3600000  # 1 hour (matches firmware)
+WATCHDOG_TIMEOUT_S = DEFAULT_WATCHDOG_TIMEOUT_MS / 1000.0
 
 # Firmware < 1.5 lights the new source immediately if SET_ILLUMINATION arrives while
 # a strobe is still on (and < 1.3 can also strand the old source). On such firmware
@@ -372,8 +374,6 @@ DEFAULT_WATCHDOG_TIMEOUT_MS = 5000  # 5 seconds (matches firmware)
 # this margin before changing the illumination source; the margin absorbs USB/serial
 # jitter. Firmware >= 1.5 needs no spacing.
 STROBE_GUARD_MARGIN_MS = 5
-MAX_WATCHDOG_TIMEOUT_MS = 3600000  # 1 hour (matches firmware)
-WATCHDOG_TIMEOUT_S = DEFAULT_WATCHDOG_TIMEOUT_MS / 1000.0
 
 
 class VOLUMETRIC_IMAGING:

--- a/software/control/core/auto_focus_worker.py
+++ b/software/control/core/auto_focus_worker.py
@@ -90,6 +90,7 @@ class AutofocusWorker:
                     self.microcontroller.send_hardware_trigger(
                         control_illumination=True, illumination_on_time_us=self.camera.get_exposure_time() * 1000
                     )
+                    self.liveController.note_hardware_trigger_sent()
                     image = self.camera.read_frame()
             if image is None:
                 continue

--- a/software/control/core/live_controller.py
+++ b/software/control/core/live_controller.py
@@ -12,6 +12,7 @@ from squid.abc import CameraAcquisitionMode, AbstractCamera
 
 from control._def import *
 from control.core.config.utils import apply_confocal_override
+from control.lighting import ShutterControlMode
 from control.models import merge_channel_configs
 
 if TYPE_CHECKING:
@@ -95,6 +96,18 @@ class LiveController(QObject):
     def _is_led_matrix(self) -> bool:
         """Check if current configuration is LED matrix (source code 0-9)."""
         return 0 <= self._get_illumination_source() < 10
+
+    def _strobe_owns_light(self) -> bool:
+        """True when the hardware-trigger strobe gates the light for the current
+        configuration: an MCU-gated source (TTL laser shutter, or the MCU-driven
+        LED matrix) in HARDWARE trigger mode. The per-trigger strobe then turns
+        the light on and off; a software shutter (e.g. LDI PC mode) or an
+        external LED array still needs explicit turn_on/turn_off."""
+        if self.trigger_mode != TriggerMode.HARDWARE:
+            return False
+        if self._is_led_matrix():
+            return self.microscope.addons.sci_microscopy_led_array is None
+        return self.microscope.illumination_controller.shutter_control_mode == ShutterControlMode.TTL
 
     def get_intensity_cap_percent(self, channel_config: Optional["AcquisitionChannel"]) -> float:
         """Maximum allowed illumination intensity (percent) for a channel.
@@ -597,10 +610,19 @@ class LiveController(QObject):
             return
         self._log.info("setting microscope mode to " + configuration.name)
 
+        # When the strobe owns an MCU-gated light in hardware-trigger mode, don't
+        # toggle illumination around the switch (a leftover from software-triggered
+        # live view): the TURN_ON kept firmware illumination_is_on true, which is
+        # what let SET_ILLUMINATION re-light a port mid-strobe (next-channel bleed;
+        # see firmware v1.5). Only toggle when the host is deliberately holding the
+        # light on, or when the strobe can't gate it. Capture illumination_on now:
+        # turn_off_illumination() below clears it.
+        host_holds_light = self.illumination_on
+
         # temporarily stop live while changing mode
         if self.is_live is True:
             self._stop_existing_timer()
-            if self.control_illumination:
+            if self.control_illumination and (host_holds_light or not self._strobe_owns_light()):
                 # Turn off illumination BEFORE switching self.currentConfiguration.
                 # turn_off_illumination() reads self.currentConfiguration to determine which
                 # laser wavelength to turn off. If we switch first, we'd turn off the NEW
@@ -622,7 +644,8 @@ class LiveController(QObject):
 
         # restart live
         if self.is_live is True:
-            if self.control_illumination:
+            # Re-evaluated: _strobe_owns_light() depends on the (new) configuration.
+            if self.control_illumination and (host_holds_light or not self._strobe_owns_light()):
                 self.turn_on_illumination()
             self._start_new_timer()
         self._log.info("Done setting microscope mode.")

--- a/software/control/core/live_controller.py
+++ b/software/control/core/live_controller.py
@@ -67,6 +67,10 @@ class LiveController(QObject):
         # time.monotonic() at which the most recent hardware trigger's strobe window
         # (strobe delay + exposure + margin) is over; see note_hardware_trigger_sent().
         self._strobe_clear_at = 0.0
+        # Serializes trigger sends against _wait_for_strobe_clear(), so a timer-thread
+        # trigger in flight while set_microscope_mode() starts is flushed before the
+        # wait, and cannot start a new strobe during it.
+        self._hw_trigger_send_lock = threading.RLock()
 
         # Confocal mode state - when True, use confocal_override from acquisition configs
         self._confocal_mode: bool = False
@@ -107,6 +111,29 @@ class LiveController(QObject):
         illumination source: SET_ILLUMINATION arriving mid-strobe re-lights the new
         port immediately (and on < 1.3 can strand the old one)."""
         self._strobe_clear_at = time.monotonic() + (self.camera.get_total_frame_time() + STROBE_GUARD_MARGIN_MS) / 1e3
+
+    def _wait_for_strobe_clear(self):
+        """On firmware < 1.5 (which acts on SET_ILLUMINATION mid-strobe, see
+        note_hardware_trigger_sent()), sleep out whatever remains of the last
+        hardware trigger's strobe window. Gated on the firmware, not the current
+        trigger mode: a strobe can still be in flight right after leaving
+        HARDWARE mode. Call with the live timer already stopped; taking
+        _hw_trigger_send_lock flushes a trigger send already in flight on the
+        timer thread, and the loop re-checks in case one landed while we slept.
+
+        Any other code path that sends SET_ILLUMINATION during hardware-triggered
+        operation on old firmware needs the same care. The intensity-only
+        update_illumination() path is exempt: it never changes the source, and a
+        same-source re-light mid-strobe is harmless on every firmware version.
+        """
+        if self.microscope.low_level_drivers.microcontroller.firmware_version >= (1, 5):
+            return
+        with self._hw_trigger_send_lock:
+            while True:
+                delay_s = self._strobe_clear_at - time.monotonic()
+                if delay_s <= 0:
+                    return
+                time.sleep(delay_s)
 
     def _strobe_owns_light(self) -> bool:
         """True when the hardware-trigger strobe gates the light for the current
@@ -483,9 +510,10 @@ class LiveController(QObject):
             # CONTINUOUS free-runs, so there is no trigger to send.
             if self.trigger_mode in (TriggerMode.HARDWARE, TriggerMode.SOFTWARE):
                 self.trigger_ID = self.trigger_ID + 1
-                self.camera.send_trigger(self.camera.get_exposure_time())
-                if self.trigger_mode == TriggerMode.HARDWARE:
-                    self.note_hardware_trigger_sent()
+                with self._hw_trigger_send_lock:
+                    self.camera.send_trigger(self.camera.get_exposure_time())
+                    if self.trigger_mode == TriggerMode.HARDWARE:
+                        self.note_hardware_trigger_sent()
 
             got_frame = self.camera.read_frame() is not None
             if not got_frame:
@@ -546,9 +574,10 @@ class LiveController(QObject):
 
         self.trigger_ID = self.trigger_ID + 1
 
-        self.camera.send_trigger(self.camera.get_exposure_time())
-        if self.trigger_mode == TriggerMode.HARDWARE:
-            self.note_hardware_trigger_sent()
+        with self._hw_trigger_send_lock:
+            self.camera.send_trigger(self.camera.get_exposure_time())
+            if self.trigger_mode == TriggerMode.HARDWARE:
+                self.note_hardware_trigger_sent()
 
         if self.trigger_mode == TriggerMode.SOFTWARE:
             if self.control_illumination and self.illumination_on == False:
@@ -630,24 +659,18 @@ class LiveController(QObject):
             return
         self._log.info("setting microscope mode to " + configuration.name)
 
-        if self.trigger_mode == TriggerMode.HARDWARE:
-            firmware_version = self.microscope.low_level_drivers.microcontroller.firmware_version
-            if firmware_version < (1, 5):
-                # Pre-1.5 firmware acts on SET_ILLUMINATION mid-strobe (see
-                # note_hardware_trigger_sent()); wait until the last trigger's
-                # strobe window is over before touching the source.
-                delay_s = self._strobe_clear_at - time.monotonic()
-                if delay_s > 0:
-                    time.sleep(delay_s)
+        # Stop the live timer BEFORE waiting out the strobe window, so no new
+        # trigger can start a strobe behind the wait's back.
+        if self.is_live is True:
+            self._stop_existing_timer()
+        self._wait_for_strobe_clear()
 
         # Captured before turn_off_illumination() below clears it. Skip the toggle
         # when the strobe gates the light (see _strobe_owns_light(); firmware v1.5
         # next-channel bleed fix) unless the host is deliberately holding it on.
         host_holds_light = self.illumination_on
 
-        # temporarily stop live while changing mode
         if self.is_live is True:
-            self._stop_existing_timer()
             if self.control_illumination and (host_holds_light or not self._strobe_owns_light()):
                 # Turn off illumination BEFORE switching self.currentConfiguration.
                 # turn_off_illumination() reads self.currentConfiguration to determine which

--- a/software/control/core/live_controller.py
+++ b/software/control/core/live_controller.py
@@ -64,6 +64,10 @@ class LiveController(QObject):
 
         self.enable_channel_auto_filter_switching: bool = True
 
+        # time.monotonic() at which the most recent hardware trigger's strobe window
+        # (strobe delay + exposure + margin) is over; see note_hardware_trigger_sent().
+        self._strobe_clear_at = 0.0
+
         # Confocal mode state - when True, use confocal_override from acquisition configs
         self._confocal_mode: bool = False
 
@@ -97,6 +101,13 @@ class LiveController(QObject):
         """Check if current configuration is LED matrix (source code 0-9)."""
         return 0 <= self._get_illumination_source() < 10
 
+    def note_hardware_trigger_sent(self):
+        """Record when the strobe window of a just-sent hardware trigger will be over.
+        On firmware < 1.5, set_microscope_mode() waits this out before changing the
+        illumination source: SET_ILLUMINATION arriving mid-strobe re-lights the new
+        port immediately (and on < 1.3 can strand the old one)."""
+        self._strobe_clear_at = time.monotonic() + (self.camera.get_total_frame_time() + STROBE_GUARD_MARGIN_MS) / 1e3
+
     def _strobe_owns_light(self) -> bool:
         """True when the hardware-trigger strobe gates the light for the current
         configuration: an MCU-gated source (TTL laser shutter, or the MCU-driven
@@ -104,6 +115,11 @@ class LiveController(QObject):
         the light on and off; a software shutter (e.g. LDI PC mode) or an
         external LED array still needs explicit turn_on/turn_off."""
         if self.trigger_mode != TriggerMode.HARDWARE:
+            return False
+        # On firmware < 1.3 the strobe ISR doesn't latch its source; skipping the
+        # legacy TURN_OFF(old) would widen that firmware's stuck-port race, so
+        # keep today's toggle there.
+        if self.microscope.low_level_drivers.microcontroller.firmware_version < (1, 3):
             return False
         if self._is_led_matrix():
             return self.microscope.addons.sci_microscopy_led_array is None
@@ -468,6 +484,8 @@ class LiveController(QObject):
             if self.trigger_mode in (TriggerMode.HARDWARE, TriggerMode.SOFTWARE):
                 self.trigger_ID = self.trigger_ID + 1
                 self.camera.send_trigger(self.camera.get_exposure_time())
+                if self.trigger_mode == TriggerMode.HARDWARE:
+                    self.note_hardware_trigger_sent()
 
             got_frame = self.camera.read_frame() is not None
             if not got_frame:
@@ -529,6 +547,8 @@ class LiveController(QObject):
         self.trigger_ID = self.trigger_ID + 1
 
         self.camera.send_trigger(self.camera.get_exposure_time())
+        if self.trigger_mode == TriggerMode.HARDWARE:
+            self.note_hardware_trigger_sent()
 
         if self.trigger_mode == TriggerMode.SOFTWARE:
             if self.control_illumination and self.illumination_on == False:
@@ -609,6 +629,16 @@ class LiveController(QObject):
             self._log.error("set_microscope_mode() called with None configuration - this is a bug in the caller")
             return
         self._log.info("setting microscope mode to " + configuration.name)
+
+        if self.trigger_mode == TriggerMode.HARDWARE:
+            firmware_version = self.microscope.low_level_drivers.microcontroller.firmware_version
+            if firmware_version < (1, 5):
+                # Pre-1.5 firmware acts on SET_ILLUMINATION mid-strobe (see
+                # note_hardware_trigger_sent()); wait until the last trigger's
+                # strobe window is over before touching the source.
+                delay_s = self._strobe_clear_at - time.monotonic()
+                if delay_s > 0:
+                    time.sleep(delay_s)
 
         # Captured before turn_off_illumination() below clears it. Skip the toggle
         # when the strobe gates the light (see _strobe_owns_light(); firmware v1.5

--- a/software/control/core/live_controller.py
+++ b/software/control/core/live_controller.py
@@ -610,13 +610,9 @@ class LiveController(QObject):
             return
         self._log.info("setting microscope mode to " + configuration.name)
 
-        # When the strobe owns an MCU-gated light in hardware-trigger mode, don't
-        # toggle illumination around the switch (a leftover from software-triggered
-        # live view): the TURN_ON kept firmware illumination_is_on true, which is
-        # what let SET_ILLUMINATION re-light a port mid-strobe (next-channel bleed;
-        # see firmware v1.5). Only toggle when the host is deliberately holding the
-        # light on, or when the strobe can't gate it. Capture illumination_on now:
-        # turn_off_illumination() below clears it.
+        # Captured before turn_off_illumination() below clears it. Skip the toggle
+        # when the strobe gates the light (see _strobe_owns_light(); firmware v1.5
+        # next-channel bleed fix) unless the host is deliberately holding it on.
         host_holds_light = self.illumination_on
 
         # temporarily stop live while changing mode

--- a/software/control/core/live_controller.py
+++ b/software/control/core/live_controller.py
@@ -106,27 +106,32 @@ class LiveController(QObject):
         return 0 <= self._get_illumination_source() < 10
 
     def note_hardware_trigger_sent(self):
-        """Record when the strobe window of a just-sent hardware trigger will be over.
-        On firmware < 1.5, set_microscope_mode() waits this out before changing the
-        illumination source: SET_ILLUMINATION arriving mid-strobe re-lights the new
-        port immediately (and on < 1.3 can strand the old one)."""
+        """Record when this hardware trigger's strobe window ends, for
+        _wait_for_strobe_clear(). No-op outside HARDWARE trigger mode and on
+        firmware that tolerates mid-strobe SET_ILLUMINATION (see
+        STROBE_GUARD_MARGIN_MS in _def.py for the full firmware story)."""
+        if self.trigger_mode != TriggerMode.HARDWARE:
+            return
+        if self.microscope.low_level_drivers.microcontroller.illumination_change_safe_during_strobe():
+            return
         self._strobe_clear_at = time.monotonic() + (self.camera.get_total_frame_time() + STROBE_GUARD_MARGIN_MS) / 1e3
 
-    def _wait_for_strobe_clear(self):
-        """On firmware < 1.5 (which acts on SET_ILLUMINATION mid-strobe, see
-        note_hardware_trigger_sent()), sleep out whatever remains of the last
-        hardware trigger's strobe window. Gated on the firmware, not the current
-        trigger mode: a strobe can still be in flight right after leaving
-        HARDWARE mode. Call with the live timer already stopped; taking
-        _hw_trigger_send_lock flushes a trigger send already in flight on the
-        timer thread, and the loop re-checks in case one landed while we slept.
+    def send_camera_trigger(self, illumination_time: Optional[float] = None):
+        """Send a camera trigger under _hw_trigger_send_lock, recording the strobe
+        window of hardware triggers. Camera triggers in live view and acquisitions
+        should go through here so _wait_for_strobe_clear() sees them."""
+        with self._hw_trigger_send_lock:
+            self.camera.send_trigger(illumination_time)
+            self.note_hardware_trigger_sent()
 
-        Any other code path that sends SET_ILLUMINATION during hardware-triggered
-        operation on old firmware needs the same care. The intensity-only
-        update_illumination() path is exempt: it never changes the source, and a
-        same-source re-light mid-strobe is harmless on every firmware version.
-        """
-        if self.microscope.low_level_drivers.microcontroller.firmware_version >= (1, 5):
+    def _wait_for_strobe_clear(self):
+        """Sleep out whatever remains of the last hardware trigger's strobe window
+        (see STROBE_GUARD_MARGIN_MS). Gated on the firmware, not the current
+        trigger mode: a strobe can still be in flight right after leaving HARDWARE
+        mode. Call with the live timer already stopped; taking
+        _hw_trigger_send_lock flushes a trigger send already in flight on the
+        timer thread, and the loop re-checks in case one landed while we slept."""
+        if self.microscope.low_level_drivers.microcontroller.illumination_change_safe_during_strobe():
             return
         with self._hw_trigger_send_lock:
             while True:
@@ -143,10 +148,9 @@ class LiveController(QObject):
         external LED array still needs explicit turn_on/turn_off."""
         if self.trigger_mode != TriggerMode.HARDWARE:
             return False
-        # On firmware < 1.3 the strobe ISR doesn't latch its source; skipping the
-        # legacy TURN_OFF(old) would widen that firmware's stuck-port race, so
-        # keep today's toggle there.
-        if self.microscope.low_level_drivers.microcontroller.firmware_version < (1, 3):
+        # Pre-latch firmware: skipping the legacy TURN_OFF(old) would widen that
+        # firmware's stuck-port race, so keep today's toggle there.
+        if not self.microscope.low_level_drivers.microcontroller.strobe_isr_latches_source():
             return False
         if self._is_led_matrix():
             return self.microscope.addons.sci_microscopy_led_array is None
@@ -314,6 +318,9 @@ class LiveController(QObject):
         if self.currentConfiguration is None:
             self._log.warning("update_illumination() called with no currentConfiguration")
             return
+        # Intensity-only updates need no strobe-window guard: the source doesn't
+        # change, and a same-source re-light mid-strobe is harmless on every
+        # firmware version (see _wait_for_strobe_clear()).
         illumination_source = self._get_illumination_source()
         intensity = self.currentConfiguration.illumination_intensity
         intensity_cap = self.get_intensity_cap_percent(self.currentConfiguration)
@@ -510,10 +517,7 @@ class LiveController(QObject):
             # CONTINUOUS free-runs, so there is no trigger to send.
             if self.trigger_mode in (TriggerMode.HARDWARE, TriggerMode.SOFTWARE):
                 self.trigger_ID = self.trigger_ID + 1
-                with self._hw_trigger_send_lock:
-                    self.camera.send_trigger(self.camera.get_exposure_time())
-                    if self.trigger_mode == TriggerMode.HARDWARE:
-                        self.note_hardware_trigger_sent()
+                self.send_camera_trigger(self.camera.get_exposure_time())
 
             got_frame = self.camera.read_frame() is not None
             if not got_frame:
@@ -574,10 +578,7 @@ class LiveController(QObject):
 
         self.trigger_ID = self.trigger_ID + 1
 
-        with self._hw_trigger_send_lock:
-            self.camera.send_trigger(self.camera.get_exposure_time())
-            if self.trigger_mode == TriggerMode.HARDWARE:
-                self.note_hardware_trigger_sent()
+        self.send_camera_trigger(self.camera.get_exposure_time())
 
         if self.trigger_mode == TriggerMode.SOFTWARE:
             if self.control_illumination and self.illumination_on == False:
@@ -659,8 +660,8 @@ class LiveController(QObject):
             return
         self._log.info("setting microscope mode to " + configuration.name)
 
-        # Stop the live timer BEFORE waiting out the strobe window, so no new
-        # trigger can start a strobe behind the wait's back.
+        # Temporarily stop live while changing mode; the timer stops BEFORE the
+        # strobe-window wait so no new trigger can start a strobe behind its back.
         if self.is_live is True:
             self._stop_existing_timer()
         self._wait_for_strobe_clear()
@@ -670,13 +671,12 @@ class LiveController(QObject):
         # next-channel bleed fix) unless the host is deliberately holding it on.
         host_holds_light = self.illumination_on
 
-        if self.is_live is True:
-            if self.control_illumination and (host_holds_light or not self._strobe_owns_light()):
-                # Turn off illumination BEFORE switching self.currentConfiguration.
-                # turn_off_illumination() reads self.currentConfiguration to determine which
-                # laser wavelength to turn off. If we switch first, we'd turn off the NEW
-                # channel's laser instead of the OLD channel's laser (which is still on).
-                self.turn_off_illumination()
+        if self.is_live and self.control_illumination and (host_holds_light or not self._strobe_owns_light()):
+            # Turn off illumination BEFORE switching self.currentConfiguration.
+            # turn_off_illumination() reads self.currentConfiguration to determine which
+            # laser wavelength to turn off. If we switch first, we'd turn off the NEW
+            # channel's laser instead of the OLD channel's laser (which is still on).
+            self.turn_off_illumination()
 
         self.currentConfiguration = configuration
 

--- a/software/control/core/multi_point_worker.py
+++ b/software/control/core/multi_point_worker.py
@@ -1469,6 +1469,8 @@ class MultiPointWorker:
                 # TODO(imo): This used to use the "reset_image_ready_flag=False" on the read_frame, but oinly the toupcam camera implementation had the
                 #  "reset_image_ready_flag" arg, so this is broken for all other cameras.  Also this used to do some other funky stuff like setting internal camera flags.
                 #   I am pretty sure this is broken!
+                # NL5 drives the illumination on this path (no MCU strobe), so
+                # there is no strobe window to record.
                 self.microscope.addons.nl5.start_acquisition()
         # This is some large timeout that we use just so as to not block forever
         with self._timing.get_timer("_ready_for_next_trigger.wait"):
@@ -1514,11 +1516,7 @@ class MultiPointWorker:
             )
             self._current_capture_info = current_capture_info
         with self._timing.get_timer("send_trigger"):
-            self.camera.send_trigger(illumination_time=camera_illumination_time)
-            if self.liveController.trigger_mode == TriggerMode.HARDWARE:
-                # Lets set_microscope_mode() space the next channel's SET_ILLUMINATION
-                # past this trigger's strobe window on firmware < 1.5.
-                self.liveController.note_hardware_trigger_sent()
+            self.liveController.send_camera_trigger(camera_illumination_time)
 
         with self._timing.get_timer("exposure_time_done_sleep_hw or wait_for_image_sw"):
             if self.liveController.trigger_mode == TriggerMode.HARDWARE:
@@ -1567,9 +1565,7 @@ class MultiPointWorker:
                     self.wait_till_operation_is_completed()
 
                 # read camera frame
-                self.camera.send_trigger(illumination_time=self.camera.get_exposure_time())
-                if self.liveController.trigger_mode == TriggerMode.HARDWARE:
-                    self.liveController.note_hardware_trigger_sent()
+                self.liveController.send_camera_trigger(self.camera.get_exposure_time())
                 image = self.camera.read_frame()
                 if image is None:
                     self._log.warning("self.camera.read_frame() returned None")

--- a/software/control/core/multi_point_worker.py
+++ b/software/control/core/multi_point_worker.py
@@ -1515,6 +1515,10 @@ class MultiPointWorker:
             self._current_capture_info = current_capture_info
         with self._timing.get_timer("send_trigger"):
             self.camera.send_trigger(illumination_time=camera_illumination_time)
+            if self.liveController.trigger_mode == TriggerMode.HARDWARE:
+                # Lets set_microscope_mode() space the next channel's SET_ILLUMINATION
+                # past this trigger's strobe window on firmware < 1.5.
+                self.liveController.note_hardware_trigger_sent()
 
         with self._timing.get_timer("exposure_time_done_sleep_hw or wait_for_image_sw"):
             if self.liveController.trigger_mode == TriggerMode.HARDWARE:
@@ -1564,6 +1568,8 @@ class MultiPointWorker:
 
                 # read camera frame
                 self.camera.send_trigger(illumination_time=self.camera.get_exposure_time())
+                if self.liveController.trigger_mode == TriggerMode.HARDWARE:
+                    self.liveController.note_hardware_trigger_sent()
                 image = self.camera.read_frame()
                 if image is None:
                     self._log.warning("self.camera.read_frame() returned None")

--- a/software/control/microcontroller.py
+++ b/software/control/microcontroller.py
@@ -1702,6 +1702,18 @@ class Microcontroller:
         """
         return self.firmware_version >= (1, 0)
 
+    def strobe_isr_latches_source(self) -> bool:
+        """Firmware >= 1.3: the strobe ISR latches its source at strobe start and
+        always extinguishes the port it lit (#549), so a channel switch during a
+        strobe can no longer strand the old port."""
+        return self.firmware_version >= (1, 3)
+
+    def illumination_change_safe_during_strobe(self) -> bool:
+        """Firmware >= 1.5: the strobe ISR no longer sets illumination_is_on, so
+        SET_ILLUMINATION arriving mid-strobe cannot re-light a port and no
+        host-side spacing (STROBE_GUARD_MARGIN_MS) is needed."""
+        return self.firmware_version >= (1, 5)
+
     def get_button_and_switch_state(self):
         return self.button_and_switch_state
 

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -730,6 +730,7 @@ class Microscope:
             self.low_level_drivers.microcontroller.send_hardware_trigger(
                 control_illumination=True, illumination_on_time_us=self.camera.get_exposure_time() * 1000
             )
+            self.live_controller.note_hardware_trigger_sent()
 
         try:
             # read a frame from camera

--- a/software/tests/control/test_live_controller_hw_illumination.py
+++ b/software/tests/control/test_live_controller_hw_illumination.py
@@ -1,0 +1,121 @@
+"""set_microscope_mode() must not hold illumination continuously on in hardware-trigger mode.
+
+In HARDWARE trigger mode the MCU strobe gates the light (TTL / LED matrix), so the
+live-restart path's turn_off/turn_on pair is a leftover from software-triggered live
+view. It kept firmware `illumination_is_on` true across channel switches, which is
+what let SET_ILLUMINATION re-light a port mid-strobe (see firmware v1.5).
+
+The pair must still run when:
+- the trigger mode is not HARDWARE (software/continuous live),
+- the host explicitly holds illumination on (manual toggle),
+- the light is not MCU-gated (software shutter, e.g. LDI PC mode), where this
+  call is the only thing that turns the lamp on.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import tests.control.gui_test_stubs  # noqa: F401 - ensures GUI modules import cleanly
+import control.microscope
+from control._def import TriggerMode
+from control.core.config import ConfigRepository
+from control.core.live_controller import LiveController
+from control.lighting import ShutterControlMode
+from control.models.acquisition_config import AcquisitionChannel, CameraSettings, IlluminationSettings
+
+ILLUMINATION_YAML = """\
+version: 1
+controller_port_mapping:
+  D1: 11
+  D2: 12
+  USB1: 0
+channels:
+  - name: Fluorescence 405 nm Ex
+    type: epi_illumination
+    controller_port: D1
+    wavelength_nm: 405
+  - name: Fluorescence 488 nm Ex
+    type: epi_illumination
+    controller_port: D2
+    wavelength_nm: 488
+"""
+
+
+def _channel(name):
+    return AcquisitionChannel(
+        name=name,
+        display_color="#FFFFFF",
+        camera=1,
+        illumination_settings=IlluminationSettings(illumination_channel=name, intensity=50.0),
+        camera_settings=CameraSettings(exposure_time_ms=10.0, gain_mode=0.0),
+    )
+
+
+@pytest.fixture
+def scope(tmp_path):
+    (tmp_path / "machine_configs").mkdir()
+    (tmp_path / "machine_configs" / "illumination_channel_config.yaml").write_text(ILLUMINATION_YAML)
+    microscope = control.microscope.Microscope.build_from_global_config(True)
+    microscope.config_repo = ConfigRepository(base_path=tmp_path)
+    yield microscope
+    microscope.close()
+
+
+@pytest.fixture
+def live(scope):
+    controller = LiveController(microscope=scope, camera=scope.camera)
+    controller.is_live = True
+    controller.currentConfiguration = _channel("Fluorescence 405 nm Ex")
+    controller._stop_existing_timer = MagicMock()
+    controller._start_new_timer = MagicMock()
+    controller.turn_on_illumination = MagicMock()
+    controller.turn_off_illumination = MagicMock()
+    return controller
+
+
+def _switch(live):
+    live.set_microscope_mode(_channel("Fluorescence 488 nm Ex"))
+
+
+def test_hardware_trigger_channel_switch_does_not_toggle_illumination(live):
+    live.trigger_mode = TriggerMode.HARDWARE
+    _switch(live)
+    live.turn_off_illumination.assert_not_called()
+    live.turn_on_illumination.assert_not_called()
+    live._start_new_timer.assert_called_once()
+
+
+def test_software_trigger_channel_switch_still_toggles_illumination(live):
+    live.trigger_mode = TriggerMode.SOFTWARE
+    _switch(live)
+    live.turn_off_illumination.assert_called_once()
+    live.turn_on_illumination.assert_called_once()
+
+
+def test_hardware_trigger_keeps_toggling_when_host_holds_illumination_on(live):
+    """Manual continuous illumination (user toggle) must survive a channel switch:
+    the old source must be turned off and the new one on."""
+    live.trigger_mode = TriggerMode.HARDWARE
+    live.illumination_on = True
+    _switch(live)
+    live.turn_off_illumination.assert_called_once()
+    live.turn_on_illumination.assert_called_once()
+
+
+def test_hardware_trigger_keeps_toggling_with_software_shutter(live, scope):
+    """With a software shutter (e.g. LDI PC mode) the strobe cannot gate the light,
+    so this call is the only thing that turns the lamp on."""
+    live.trigger_mode = TriggerMode.HARDWARE
+    scope.illumination_controller.shutter_control_mode = ShutterControlMode.Software
+    _switch(live)
+    live.turn_off_illumination.assert_called_once()
+    live.turn_on_illumination.assert_called_once()
+
+
+def test_not_live_never_toggles(live):
+    live.is_live = False
+    live.trigger_mode = TriggerMode.SOFTWARE
+    _switch(live)
+    live.turn_off_illumination.assert_not_called()
+    live.turn_on_illumination.assert_not_called()

--- a/software/tests/control/test_live_controller_hw_illumination.py
+++ b/software/tests/control/test_live_controller_hw_illumination.py
@@ -78,44 +78,40 @@ def _switch(live):
     live.set_microscope_mode(_channel("Fluorescence 488 nm Ex"))
 
 
+def _assert_toggled(live, expected: bool):
+    assert live.turn_off_illumination.call_count == (1 if expected else 0)
+    assert live.turn_on_illumination.call_count == (1 if expected else 0)
+
+
 def test_hardware_trigger_channel_switch_does_not_toggle_illumination(live):
     live.trigger_mode = TriggerMode.HARDWARE
     _switch(live)
-    live.turn_off_illumination.assert_not_called()
-    live.turn_on_illumination.assert_not_called()
+    _assert_toggled(live, False)
     live._start_new_timer.assert_called_once()
 
 
 def test_software_trigger_channel_switch_still_toggles_illumination(live):
     live.trigger_mode = TriggerMode.SOFTWARE
     _switch(live)
-    live.turn_off_illumination.assert_called_once()
-    live.turn_on_illumination.assert_called_once()
+    _assert_toggled(live, True)
 
 
 def test_hardware_trigger_keeps_toggling_when_host_holds_illumination_on(live):
-    """Manual continuous illumination (user toggle) must survive a channel switch:
-    the old source must be turned off and the new one on."""
     live.trigger_mode = TriggerMode.HARDWARE
     live.illumination_on = True
     _switch(live)
-    live.turn_off_illumination.assert_called_once()
-    live.turn_on_illumination.assert_called_once()
+    _assert_toggled(live, True)
 
 
 def test_hardware_trigger_keeps_toggling_with_software_shutter(live, scope):
-    """With a software shutter (e.g. LDI PC mode) the strobe cannot gate the light,
-    so this call is the only thing that turns the lamp on."""
     live.trigger_mode = TriggerMode.HARDWARE
     scope.illumination_controller.shutter_control_mode = ShutterControlMode.Software
     _switch(live)
-    live.turn_off_illumination.assert_called_once()
-    live.turn_on_illumination.assert_called_once()
+    _assert_toggled(live, True)
 
 
 def test_not_live_never_toggles(live):
     live.is_live = False
     live.trigger_mode = TriggerMode.SOFTWARE
     _switch(live)
-    live.turn_off_illumination.assert_not_called()
-    live.turn_on_illumination.assert_not_called()
+    _assert_toggled(live, False)

--- a/software/tests/control/test_live_controller_hw_illumination.py
+++ b/software/tests/control/test_live_controller_hw_illumination.py
@@ -12,6 +12,7 @@ The pair must still run when:
   call is the only thing that turns the lamp on.
 """
 
+import time
 from unittest.mock import MagicMock
 
 import pytest
@@ -130,8 +131,6 @@ def test_not_live_never_toggles(live):
 
 
 def test_note_hardware_trigger_records_strobe_window(live):
-    import time
-
     live.trigger_mode = TriggerMode.HARDWARE
     before = time.monotonic()
     live.note_hardware_trigger_sent()
@@ -140,16 +139,12 @@ def test_note_hardware_trigger_records_strobe_window(live):
 
 
 def _elapsed_switch(live):
-    import time
-
     start = time.monotonic()
     _switch(live)
     return time.monotonic() - start
 
 
 def test_set_microscope_mode_waits_out_strobe_window_on_old_firmware(live, scope):
-    import time
-
     live.trigger_mode = TriggerMode.HARDWARE
     scope.low_level_drivers.microcontroller.firmware_version = (1, 4)
     live._strobe_clear_at = time.monotonic() + 0.15
@@ -157,8 +152,6 @@ def test_set_microscope_mode_waits_out_strobe_window_on_old_firmware(live, scope
 
 
 def test_set_microscope_mode_does_not_wait_on_v1_5_firmware(live, scope):
-    import time
-
     live.trigger_mode = TriggerMode.HARDWARE
     scope.low_level_drivers.microcontroller.firmware_version = (1, 5)
     live._strobe_clear_at = time.monotonic() + 5.0
@@ -168,8 +161,6 @@ def test_set_microscope_mode_does_not_wait_on_v1_5_firmware(live, scope):
 def test_set_microscope_mode_waits_even_after_leaving_hardware_mode(live, scope):
     # A strobe from a just-sent HW trigger can still be in flight after switching
     # trigger modes; the wait is gated on firmware, not the current mode.
-    import time
-
     live.trigger_mode = TriggerMode.SOFTWARE
     scope.low_level_drivers.microcontroller.firmware_version = (1, 4)
     live._strobe_clear_at = time.monotonic() + 0.15
@@ -180,3 +171,26 @@ def test_set_microscope_mode_does_not_wait_with_no_pending_strobe(live, scope):
     live.trigger_mode = TriggerMode.SOFTWARE
     scope.low_level_drivers.microcontroller.firmware_version = (1, 4)
     assert _elapsed_switch(live) < 1.0
+
+
+def test_note_hardware_trigger_noop_on_safe_firmware(live, scope):
+    live.trigger_mode = TriggerMode.HARDWARE
+    scope.low_level_drivers.microcontroller.firmware_version = (1, 5)
+    live.note_hardware_trigger_sent()
+    assert live._strobe_clear_at == 0.0
+
+
+def test_send_camera_trigger_records_window_only_in_hardware_mode(live):
+    live.camera = MagicMock()
+    live.camera.get_exposure_time.return_value = 10.0
+    live.camera.get_total_frame_time.return_value = 20.0
+
+    live.trigger_mode = TriggerMode.HARDWARE
+    live.send_camera_trigger(10.0)
+    live.camera.send_trigger.assert_called_once_with(10.0)
+    assert live._strobe_clear_at > time.monotonic()
+
+    live._strobe_clear_at = 0.0
+    live.trigger_mode = TriggerMode.SOFTWARE
+    live.send_camera_trigger(10.0)
+    assert live._strobe_clear_at == 0.0

--- a/software/tests/control/test_live_controller_hw_illumination.py
+++ b/software/tests/control/test_live_controller_hw_illumination.py
@@ -18,7 +18,7 @@ import pytest
 
 import tests.control.gui_test_stubs  # noqa: F401 - ensures GUI modules import cleanly
 import control.microscope
-from control._def import TriggerMode
+from control._def import STROBE_GUARD_MARGIN_MS, TriggerMode
 from control.core.config import ConfigRepository
 from control.core.live_controller import LiveController
 from control.lighting import ShutterControlMode
@@ -110,8 +110,64 @@ def test_hardware_trigger_keeps_toggling_with_software_shutter(live, scope):
     _assert_toggled(live, True)
 
 
+def test_pre_1_3_firmware_keeps_legacy_toggle(live, scope):
+    # < 1.3 the ISR doesn't latch its source; the legacy TURN_OFF(old) narrows that
+    # firmware's stuck-port race, so the toggle must survive there.
+    live.trigger_mode = TriggerMode.HARDWARE
+    scope.low_level_drivers.microcontroller.firmware_version = (1, 2)
+    _switch(live)
+    _assert_toggled(live, True)
+
+
 def test_not_live_never_toggles(live):
     live.is_live = False
     live.trigger_mode = TriggerMode.SOFTWARE
     _switch(live)
     _assert_toggled(live, False)
+
+
+# --- strobe-window guard (firmware < 1.5) ---
+
+
+def test_note_hardware_trigger_records_strobe_window(live):
+    import time
+
+    live.trigger_mode = TriggerMode.HARDWARE
+    before = time.monotonic()
+    live.note_hardware_trigger_sent()
+    expected = before + (live.camera.get_total_frame_time() + STROBE_GUARD_MARGIN_MS) / 1e3
+    assert abs(live._strobe_clear_at - expected) < 0.05
+
+
+def _elapsed_switch(live):
+    import time
+
+    start = time.monotonic()
+    _switch(live)
+    return time.monotonic() - start
+
+
+def test_set_microscope_mode_waits_out_strobe_window_on_old_firmware(live, scope):
+    import time
+
+    live.trigger_mode = TriggerMode.HARDWARE
+    scope.low_level_drivers.microcontroller.firmware_version = (1, 4)
+    live._strobe_clear_at = time.monotonic() + 0.15
+    assert _elapsed_switch(live) >= 0.15
+
+
+def test_set_microscope_mode_does_not_wait_on_v1_5_firmware(live, scope):
+    import time
+
+    live.trigger_mode = TriggerMode.HARDWARE
+    scope.low_level_drivers.microcontroller.firmware_version = (1, 5)
+    live._strobe_clear_at = time.monotonic() + 5.0
+    assert _elapsed_switch(live) < 1.0
+
+
+def test_set_microscope_mode_does_not_wait_in_software_trigger_mode(live):
+    import time
+
+    live.trigger_mode = TriggerMode.SOFTWARE
+    live._strobe_clear_at = time.monotonic() + 5.0
+    assert _elapsed_switch(live) < 1.0

--- a/software/tests/control/test_live_controller_hw_illumination.py
+++ b/software/tests/control/test_live_controller_hw_illumination.py
@@ -165,9 +165,18 @@ def test_set_microscope_mode_does_not_wait_on_v1_5_firmware(live, scope):
     assert _elapsed_switch(live) < 1.0
 
 
-def test_set_microscope_mode_does_not_wait_in_software_trigger_mode(live):
+def test_set_microscope_mode_waits_even_after_leaving_hardware_mode(live, scope):
+    # A strobe from a just-sent HW trigger can still be in flight after switching
+    # trigger modes; the wait is gated on firmware, not the current mode.
     import time
 
     live.trigger_mode = TriggerMode.SOFTWARE
-    live._strobe_clear_at = time.monotonic() + 5.0
+    scope.low_level_drivers.microcontroller.firmware_version = (1, 4)
+    live._strobe_clear_at = time.monotonic() + 0.15
+    assert _elapsed_switch(live) >= 0.15
+
+
+def test_set_microscope_mode_does_not_wait_with_no_pending_strobe(live, scope):
+    live.trigger_mode = TriggerMode.SOFTWARE
+    scope.low_level_drivers.microcontroller.firmware_version = (1, 4)
     assert _elapsed_switch(live) < 1.0

--- a/software/tests/control/test_multipoint_strobe_guard.py
+++ b/software/tests/control/test_multipoint_strobe_guard.py
@@ -1,0 +1,54 @@
+"""The worker must report every hardware trigger to the LiveController so
+set_microscope_mode() can wait out the strobe window on firmware < 1.5."""
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from control import utils
+from control._def import TriggerMode
+from control.core.multi_point_worker import MultiPointWorker
+
+
+class _FakeCamera:
+    def __init__(self):
+        self.triggers = 0
+
+    def get_exposure_time(self):
+        return 2.0
+
+    def get_strobe_time(self):
+        return 1.0
+
+    def get_total_frame_time(self):
+        return 3.0
+
+    def get_ready_for_trigger(self):
+        return True
+
+    def send_trigger(self, illumination_time=None):
+        self.triggers += 1
+
+
+def test_acquire_camera_image_notes_hw_trigger():
+    w = MultiPointWorker.__new__(MultiPointWorker)
+    w._log = MagicMock()
+    w._timing = utils.TimingManager("test timing")
+    w._ready_for_next_trigger = threading.Event()
+    w._ready_for_next_trigger.set()
+    w._backpressure = SimpleNamespace(should_throttle=lambda: False)
+    w.liveController = SimpleNamespace(trigger_mode=TriggerMode.HARDWARE, note_hardware_trigger_sent=MagicMock())
+    w.stage = SimpleNamespace(get_pos=lambda: "pos")
+    w.use_piezo = False
+    w.z_piezo_um = None
+    w.time_point = 0
+    w._current_capture_info = None
+    w._select_config = lambda config: None
+    w.camera = _FakeCamera()
+
+    w.acquire_camera_image(
+        SimpleNamespace(name="ch", id=0), file_ID="f", current_path="/tmp", k=0, region_id=0, fov=0, config_idx=0
+    )
+
+    assert w.camera.triggers == 1
+    w.liveController.note_hardware_trigger_sent.assert_called_once()

--- a/software/tests/control/test_multipoint_strobe_guard.py
+++ b/software/tests/control/test_multipoint_strobe_guard.py
@@ -1,5 +1,5 @@
-"""The worker must report every hardware trigger to the LiveController so
-set_microscope_mode() can wait out the strobe window on firmware < 1.5."""
+"""The worker must send camera triggers through LiveController.send_camera_trigger()
+so the strobe window is recorded for set_microscope_mode()'s pre-1.5-firmware wait."""
 
 import threading
 from types import SimpleNamespace
@@ -11,14 +11,8 @@ from control.core.multi_point_worker import MultiPointWorker
 
 
 class _FakeCamera:
-    def __init__(self):
-        self.triggers = 0
-
     def get_exposure_time(self):
         return 2.0
-
-    def get_strobe_time(self):
-        return 1.0
 
     def get_total_frame_time(self):
         return 3.0
@@ -26,18 +20,15 @@ class _FakeCamera:
     def get_ready_for_trigger(self):
         return True
 
-    def send_trigger(self, illumination_time=None):
-        self.triggers += 1
 
-
-def test_acquire_camera_image_notes_hw_trigger():
+def test_acquire_camera_image_triggers_via_live_controller():
     w = MultiPointWorker.__new__(MultiPointWorker)
     w._log = MagicMock()
     w._timing = utils.TimingManager("test timing")
     w._ready_for_next_trigger = threading.Event()
     w._ready_for_next_trigger.set()
     w._backpressure = SimpleNamespace(should_throttle=lambda: False)
-    w.liveController = SimpleNamespace(trigger_mode=TriggerMode.HARDWARE, note_hardware_trigger_sent=MagicMock())
+    w.liveController = SimpleNamespace(trigger_mode=TriggerMode.HARDWARE, send_camera_trigger=MagicMock())
     w.stage = SimpleNamespace(get_pos=lambda: "pos")
     w.use_piezo = False
     w.z_piezo_um = None
@@ -50,5 +41,4 @@ def test_acquire_camera_image_notes_hw_trigger():
         SimpleNamespace(name="ch", id=0), file_ID="f", current_path="/tmp", k=0, region_id=0, fov=0, config_idx=0
     )
 
-    assert w.camera.triggers == 1
-    w.liveController.note_hardware_trigger_sent.assert_called_once()
+    w.liveController.send_camera_trigger.assert_called_once_with(2.0)


### PR DESCRIPTION
## Problem

In hardware-triggered multi-channel acquisitions, a frame can carry a faint copy of the **next** channel's signal: a gradient that is strongest in the rows read out last (top of the image on a vertically flipped camera), sometimes uniform, intermittent. Reported on a Squid+ with a Kinetix in level-trigger mode (same exposure on every channel), where it was reproducible enough to look like "channel mixing".

## Root cause

`ISR_strobeTimer()` set `illumination_is_on = true` at strobe start. The host's acquisition loop (`MultiPointWorker.acquire_camera_image`) sleeps exactly `exposure + strobe_delay` after writing the trigger and then immediately sends `SET_ILLUMINATION` for the next channel. The strobe ends `exposure + strobe_delay` after the trigger *arrives*, so the margin between the two is USB/loop jitter, on the order of a millisecond, in either direction. When `SET_ILLUMINATION` lands while the strobe is still on, `set_illumination()` sees the flag and calls `turn_on_illumination()` → the next channel's port is energized immediately. The v1.3 strobe end (#549) then turns off only the *latched* port and, seeing the source has changed, leaves the flag true — so the next channel's laser stays on through the current frame's readout, the inter-frame gap and the next frame's reset sweep, until its own strobe end.

Before v1.3 the same race had the opposite outcome (the strobe end turned off the *new* source and stranded the old one); v1.3 fixed the stranding but preserved the accidental re-light.

## Fix

The ISR no longer **sets** the flag. It still **clears** it at strobe end when the strobe extinguished the host's own source (unchanged from v1.3/v1.4), so:

- **Acquisition (HW trigger):** the flag is never true (the worker never sends TURN_ON in HW mode) → `SET_ILLUMINATION` during a strobe is DAC/source-only, no re-light; the strobe end turns off the latched port. Bleed gone.
- **#549 live channel switch** (`TURN_OFF(old)` → strobe start → `SET_ILLUMINATION(new)` → `TURN_ON(new)` → strobe end): identical to v1.4 — the latched old port is extinguished, the host-commanded new port stays on until its own strobe end.
- **HW live intensity changes:** identical to v1.4 — the first strobe end clears the host flag, later `SET_ILLUMINATION`s are DAC-only. (A "never touch the flag" variant was considered and rejected: it would leave the flag true after a live channel switch, and every intensity-slider tick would then re-light the laser continuously until the next strobe end.)
- Software-trigger, continuous, multi-port and the `<= 30 ms` `delayMicroseconds` branch: unchanged.

Behavioural change is two deleted `illumination_is_on = true;` writes (both strobe-start branches). A follow-up commit folds the byte-identical strobe begin/end sequences of the two ISR branches into `strobe_begin()`/`strobe_end()` helpers so the invariant (begin never writes the host flag; end owns the guarded clear) is structural rather than comment-enforced — behavior-identical. Plus the version bump 1.4 → 1.5.

## Host side (same fix, second half)

`LiveController.set_microscope_mode()`'s live-restart path unconditionally toggled illumination around a channel switch — a leftover from 2020 software-triggered live view, and the one remaining path that holds `illumination_is_on` true across a switch in hardware-trigger mode. It now skips the toggle when the strobe owns an MCU-gated light (`_strobe_owns_light()`), and keeps it for software trigger, for a host-held manual toggle, and for sources the strobe can't gate (software shutter / SciMicroscopy LED array, where this call is the only light switch). Covered by `tests/control/test_live_controller_hw_illumination.py`.

Per Copilot's review, the skip is firmware-gated: `_strobe_owns_light()` requires the MCU to report **firmware >= (1, 3)** (on an unlatched <= 1.2 ISR, dropping the legacy `TURN_OFF(old)` would widen that firmware's stuck-port race), so older controllers keep today's behaviour byte-for-byte. Additionally, on **firmware < (1, 5)** `set_microscope_mode()` waits out the last hardware trigger's strobe window (`strobe delay + exposure + STROBE_GUARD_MARGIN_MS`) before changing the illumination source — `SET_ILLUMINATION` can then never land mid-strobe, which removes the trigger condition of both old-firmware races in live view and acquisitions (trigger times recorded via `note_hardware_trigger_sent()` at every HW trigger site). v1.5+ controllers skip the wait entirely; in acquisitions it is normally absorbed by the existing wait-for-frame. An adversarial review of the guard hardened it further: the live timer is stopped before the wait, trigger sends and the wait share `_hw_trigger_send_lock` (flushing an in-flight timer-thread send) and the wait loops until the window has actually passed; the wait is gated on firmware only, not the current trigger mode (a strobe can still be in flight right after leaving HARDWARE mode); and `note_hardware_trigger_sent()` also covers `Microscope.acquire_image` and the contrast-AF worker. On pre-1.5 firmware a live channel switch may block the GUI thread for up to one frame time — accepted as the cost of correctness there. The intensity-only `update_illumination()` path is deliberately unguarded (it never changes the source; a same-source re-light mid-strobe is harmless).

## Testing

- [x] `pio run -e teensy41` — builds clean (warnings pre-existing in `TMC4361A.cpp` / Teensy core), `firmware.hex` produced
- [x] `pio test -e native` — 80/80
- [x] `pytest tests/control/test_firmware_protocol.py tests/control/test_firmware_sim_serial.py tests/control/test_microcontroller.py` — 47 passed, 1 pre-existing skip
- [x] `pytest tests/control/test_live_controller_hw_illumination.py tests/control/test_intensity_cap.py tests/control/test_channel_sequence.py tests/control/test_LiveControlWidget_offset.py` — 62 passed; `black --check` clean
- [ ] **Hardware verification required** (the ISR isn't covered by the native tests, as with #549): (1) the #549 repro — HW-triggered live, switch 640 → 405, confirm 640 nm goes dark; (2) a 2-channel HW-triggered acquisition at ~100 ms exposure over ~100 FOVs, confirm no next-channel gradient in either channel; (3) HW live, drag the intensity slider, confirm the laser is only on during strobes.

## Not in this PR (follow-ups)

- `FirmwareSimSerial` still reports 1.3 (was not bumped for 1.4 either); nothing in Python is gated above 1.0.
- Pre-existing, unrelated to this change: `SET_STROBE_DELAY` landing mid-strobe moves the in-flight strobe end; `TURN_ON` mid-strobe with a changed source lights two ports until strobe end; an edge-mode retrigger while the strobe is HIGH postpones its end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
