### PR TITLE
fix(stage): tolerate a corrupted cache/last_coords.txt at startup

### DIFF
--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -4361,16 +4361,14 @@ class LiveControlWidget(QFrame):
 
         # Single-frame capture, for light sensitive samples where a free-running
         # live stream would bleach or damage the sample while settings are dialed in.
+        # Illumination is on for that one exposure only in software/hardware trigger
+        # mode; in continuous mode it stays on for up to two exposures.
         self.btn_snap = QPushButton("Snap")
         self.btn_snap.setCheckable(False)
         self.btn_snap.setDefault(False)
         self.btn_snap.setStyleSheet("background-color: #C2C2FF")
         self.btn_snap.setSizePolicy(sizePolicy)
-        self.btn_snap.setToolTip(
-            "Acquire a single frame with the current Live Configuration. "
-            "In software/hardware trigger mode the illumination is on for that one "
-            "exposure only; in continuous mode it stays on for up to two exposures."
-        )
+        self.btn_snap.setToolTip("View a single frame with the current Live Configuration, to reduce photobleaching.")
 
         # line 3: exposure time and analog gain associated with the current mode
         self.entry_exposureTime = QDoubleSpinBox()

--- a/software/squid/stage/utils.py
+++ b/software/squid/stage/utils.py
@@ -1,4 +1,5 @@
 from typing import Optional, Callable
+import math
 import os
 
 import squid.logging
@@ -10,27 +11,36 @@ import control.utils
 _log = squid.logging.get_logger(__package__)
 _DEFAULT_CACHE_PATH = "cache/last_coords.txt"
 
-"""
-Attempts to load a cached stage position and return it.
-"""
-
 
 def get_cached_position(cache_path=_DEFAULT_CACHE_PATH) -> Optional[Pos]:
+    """Load the stage position previously written by cache_position(), or None if there is none.
+
+    A cache file that cannot be read or parsed (truncated by a crash mid-write, edited by hand,
+    filled with garbage, ...) is treated exactly like a missing one: a warning is logged and None
+    is returned.  Callers use None to mean "no cached position", so a corrupted cache never
+    prevents the software from starting.
+    """
     if not os.path.isfile(cache_path):
         _log.debug(f"Cache file '{cache_path}' not found, no cached pos found.")
         return None
-    with open(cache_path, "r") as f:
-        for line in f:
-            try:
-                x, y, z = line.strip("\n").strip().split(",")
-                x = float(x)
-                y = float(y)
-                z = float(z)
-                return Pos(x_mm=x, y_mm=y, z_mm=z, theta_rad=None)
-            except RuntimeError as e:
-                raise e
-                pass
-    return None
+
+    contents = None
+    try:
+        with open(cache_path, "r") as f:
+            contents = f.read()
+        x, y, z = (float(v) for v in contents.strip().split(","))
+        if not all(math.isfinite(v) for v in (x, y, z)):
+            raise ValueError(f"non-finite coordinate in ({x}, {y}, {z})")
+    except (OSError, ValueError) as e:
+        # UnicodeDecodeError is a ValueError; unpacking the wrong number of fields is a ValueError too.
+        preview = f" contents={contents.strip()[:100]!r}" if contents is not None else ""
+        _log.warning(
+            f"Cached position file '{cache_path}' is unreadable or corrupted ({e}).{preview} "
+            "Ignoring it and continuing as if there is no cached position."
+        )
+        return None
+
+    return Pos(x_mm=x, y_mm=y, z_mm=z, theta_rad=None)
 
 
 """

--- a/software/squid/stage/utils.py
+++ b/software/squid/stage/utils.py
@@ -28,8 +28,9 @@ def get_cached_position(cache_path=_DEFAULT_CACHE_PATH) -> Optional[Pos]:
     try:
         with open(cache_path, "r") as f:
             # A valid cache is one short line, so cap the read: a stray large file at this path
-            # must not pull hundreds of MB into memory during startup.
-            contents = f.read(_MAX_CACHE_BYTES)
+            # must not pull hundreds of MB into memory during startup.  Read one byte past the cap
+            # so an oversized file is rejected below instead of parsed from its truncated prefix.
+            contents = f.read(_MAX_CACHE_BYTES + 1)
     except (OSError, UnicodeDecodeError) as e:
         _log.warning(
             f"Cached position file '{cache_path}' could not be read ({e}). "
@@ -38,6 +39,8 @@ def get_cached_position(cache_path=_DEFAULT_CACHE_PATH) -> Optional[Pos]:
         return None
 
     try:
+        if len(contents) > _MAX_CACHE_BYTES:
+            raise ValueError(f"file is larger than {_MAX_CACHE_BYTES} bytes")
         x, y, z = (float(v) for v in contents.strip().split(","))
         if not all(math.isfinite(v) for v in (x, y, z)):
             raise ValueError("non-finite coordinate")

--- a/software/squid/stage/utils.py
+++ b/software/squid/stage/utils.py
@@ -10,45 +10,49 @@ import control.utils
 
 _log = squid.logging.get_logger(__package__)
 _DEFAULT_CACHE_PATH = "cache/last_coords.txt"
+_MAX_CACHE_BYTES = 4096
 
 
 def get_cached_position(cache_path=_DEFAULT_CACHE_PATH) -> Optional[Pos]:
-    """Load the stage position previously written by cache_position(), or None if there is none.
+    """Load the stage position written by cache_position(), or None if there is no usable one.
 
     A cache file that cannot be read or parsed (truncated by a crash mid-write, edited by hand,
     filled with garbage, ...) is treated exactly like a missing one: a warning is logged and None
-    is returned.  Callers use None to mean "no cached position", so a corrupted cache never
-    prevents the software from starting.
+    is returned, so an unreadable cache cannot stop the software from starting.  A well-formed but
+    stale position is returned as-is; it is not range checked against the stage's axis limits.
     """
     if not os.path.isfile(cache_path):
         _log.debug(f"Cache file '{cache_path}' not found, no cached pos found.")
         return None
 
-    contents = None
     try:
         with open(cache_path, "r") as f:
-            contents = f.read()
+            # A valid cache is one short line, so cap the read: a stray large file at this path
+            # must not pull hundreds of MB into memory during startup.
+            contents = f.read(_MAX_CACHE_BYTES)
+    except (OSError, UnicodeDecodeError) as e:
+        _log.warning(
+            f"Cached position file '{cache_path}' could not be read ({e}). "
+            "Continuing as if there is no cached position."
+        )
+        return None
+
+    try:
         x, y, z = (float(v) for v in contents.strip().split(","))
         if not all(math.isfinite(v) for v in (x, y, z)):
-            raise ValueError(f"non-finite coordinate in ({x}, {y}, {z})")
-    except (OSError, ValueError) as e:
-        # UnicodeDecodeError is a ValueError; unpacking the wrong number of fields is a ValueError too.
-        preview = f" contents={contents.strip()[:100]!r}" if contents is not None else ""
+            raise ValueError("non-finite coordinate")
+    except ValueError as e:
         _log.warning(
-            f"Cached position file '{cache_path}' is unreadable or corrupted ({e}).{preview} "
-            "Ignoring it and continuing as if there is no cached position."
+            f"Cached position file '{cache_path}' is corrupted ({e}), contents={contents[:100].strip()!r}. "
+            "Continuing as if there is no cached position."
         )
         return None
 
     return Pos(x_mm=x, y_mm=y, z_mm=z, theta_rad=None)
 
 
-"""
-Write out the current x, y, z position, in mm, so we can use it later as a cached position.
-"""
-
-
 def cache_position(pos: Pos, stage_config: StageConfig, cache_path=_DEFAULT_CACHE_PATH):
+    """Write out the current x, y, z position, in mm, so we can use it later as a cached position."""
     if stage_config is not None:  # StageConfig not implemented for Prior stage
         x_min = stage_config.X_AXIS.MIN_POSITION
         x_max = stage_config.X_AXIS.MAX_POSITION
@@ -60,9 +64,13 @@ def cache_position(pos: Pos, stage_config: StageConfig, cache_path=_DEFAULT_CACH
             raise ValueError(
                 f"Position {pos} is not cacheable because it is outside of the min/max of at least one axis. x_range=({x_min}, {x_max}), y_range=({y_min}, {y_max}), z_range=({z_min}, {z_max})"
             )
-    with open(cache_path, "w") as f:
-        _log.debug(f"Writing position={pos} to cache path='{cache_path}'")
+    _log.debug(f"Writing position={pos} to cache path='{cache_path}'")
+    # Atomic write: a crash between truncating and writing would leave a partial file that
+    # get_cached_position() can only discard, losing the position it was meant to preserve.
+    tmp_path = f"{cache_path}.tmp"
+    with open(tmp_path, "w") as f:
         f.write(",".join([str(pos.x_mm), str(pos.y_mm), str(pos.z_mm)]))
+    os.replace(tmp_path, cache_path)
 
 
 def _move_to_loading_position_impl(stage: AbstractStage, is_wellplate: bool):

--- a/software/tests/squid/test_stage.py
+++ b/software/tests/squid/test_stage.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 import tempfile
 
@@ -34,6 +35,47 @@ def test_position_caching():
     p_read = squid.stage.utils.get_cached_position(cache_path=temp_cache_path)
 
     assert p_read == p
+
+
+def test_get_cached_position_returns_none_when_cache_file_is_missing(tmp_path):
+    assert squid.stage.utils.get_cached_position(cache_path=str(tmp_path / "missing.txt")) is None
+
+
+@pytest.mark.parametrize(
+    "contents",
+    [
+        "garbage",
+        "1.0,2.0",
+        "1.0,2.0,3.0,4.0",
+        "1.0,abc,3.0",
+        "",
+        "   \n",
+        "nan,2.0,3.0",
+        "1.0,inf,3.0",
+    ],
+    ids=["garbage", "too-few-fields", "too-many-fields", "bad-field", "empty", "whitespace", "nan", "inf"],
+)
+def test_get_cached_position_treats_corrupted_file_as_no_cache(tmp_path, caplog, contents):
+    """A corrupted cache must not raise (it would abort startup); it warns and behaves like a missing cache."""
+    cache_path = tmp_path / "last_coords.txt"
+    cache_path.write_text(contents)
+
+    with caplog.at_level(logging.WARNING, logger="squid"):
+        assert squid.stage.utils.get_cached_position(cache_path=str(cache_path)) is None
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings, "expected a warning about the corrupted cache file"
+    assert any(str(cache_path) in r.getMessage() for r in warnings)
+
+
+def test_get_cached_position_treats_undecodable_file_as_no_cache(tmp_path, caplog):
+    cache_path = tmp_path / "last_coords.txt"
+    cache_path.write_bytes(b"\xff\xfe\x00\x80 not text")
+
+    with caplog.at_level(logging.WARNING, logger="squid"):
+        assert squid.stage.utils.get_cached_position(cache_path=str(cache_path)) is None
+
+    assert any(r.levelno == logging.WARNING for r in caplog.records)
 
 
 # --- PI V-308 / C-414 focus stage --------------------------------------------

--- a/software/tests/squid/test_stage.py
+++ b/software/tests/squid/test_stage.py
@@ -68,6 +68,29 @@ def test_get_cached_position_treats_corrupted_file_as_no_cache(tmp_path, caplog,
     ), "expected a warning naming the corrupted cache file"
 
 
+def test_get_cached_position_rejects_a_file_larger_than_the_read_cap(tmp_path, caplog):
+    """A valid prefix padded past the read cap must be rejected, not parsed from the truncated prefix."""
+    cache_path = tmp_path / "last_coords.txt"
+    valid_prefix = "11.0,22.0,1.0"
+    padding = " " * (squid.stage.utils._MAX_CACHE_BYTES - len(valid_prefix))
+    cache_path.write_text(valid_prefix + padding + "garbage past the cap")
+
+    with caplog.at_level(logging.WARNING, logger="squid"):
+        assert squid.stage.utils.get_cached_position(cache_path=str(cache_path)) is None
+
+    assert any(
+        r.levelno == logging.WARNING and str(cache_path) in r.getMessage() for r in caplog.records
+    ), "expected a warning naming the oversized cache file"
+
+
+def test_get_cached_position_rejects_a_second_line(tmp_path):
+    """Only a single coordinate triple is a valid cache; extra lines mean the file is not ours."""
+    cache_path = tmp_path / "last_coords.txt"
+    cache_path.write_text("11.0,22.0,1.0\n44.0,55.0,2.0\n")
+
+    assert squid.stage.utils.get_cached_position(cache_path=str(cache_path)) is None
+
+
 def test_get_cached_position_warning_shows_the_corrupt_contents(tmp_path, caplog):
     """The warning must quote what was in the file, so a bad cache can be diagnosed from a log alone."""
     cache_path = tmp_path / "last_coords.txt"

--- a/software/tests/squid/test_stage.py
+++ b/software/tests/squid/test_stage.py
@@ -1,3 +1,4 @@
+import builtins
 import logging
 import pytest
 import tempfile
@@ -44,38 +45,75 @@ def test_get_cached_position_returns_none_when_cache_file_is_missing(tmp_path):
 @pytest.mark.parametrize(
     "contents",
     [
-        "garbage",
-        "1.0,2.0",
-        "1.0,2.0,3.0,4.0",
-        "1.0,abc,3.0",
-        "",
-        "   \n",
-        "nan,2.0,3.0",
-        "1.0,inf,3.0",
+        pytest.param(b"garbage", id="garbage"),
+        pytest.param(b"1.0,2.0", id="too-few-fields"),
+        pytest.param(b"1.0,2.0,3.0,4.0", id="too-many-fields"),
+        pytest.param(b"1.0,abc,3.0", id="bad-field"),
+        pytest.param(b"", id="empty"),
+        pytest.param(b"nan,2.0,3.0", id="nan"),
+        pytest.param(b"1.0,inf,3.0", id="inf"),
+        pytest.param(b"\xff\xfe\x00\x80 not text", id="undecodable"),
     ],
-    ids=["garbage", "too-few-fields", "too-many-fields", "bad-field", "empty", "whitespace", "nan", "inf"],
 )
 def test_get_cached_position_treats_corrupted_file_as_no_cache(tmp_path, caplog, contents):
     """A corrupted cache must not raise (it would abort startup); it warns and behaves like a missing cache."""
     cache_path = tmp_path / "last_coords.txt"
-    cache_path.write_text(contents)
+    cache_path.write_bytes(contents)
 
     with caplog.at_level(logging.WARNING, logger="squid"):
         assert squid.stage.utils.get_cached_position(cache_path=str(cache_path)) is None
 
-    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
-    assert warnings, "expected a warning about the corrupted cache file"
-    assert any(str(cache_path) in r.getMessage() for r in warnings)
+    assert any(
+        r.levelno == logging.WARNING and str(cache_path) in r.getMessage() for r in caplog.records
+    ), "expected a warning naming the corrupted cache file"
 
 
-def test_get_cached_position_treats_undecodable_file_as_no_cache(tmp_path, caplog):
+def test_get_cached_position_warning_shows_the_corrupt_contents(tmp_path, caplog):
+    """The warning must quote what was in the file, so a bad cache can be diagnosed from a log alone."""
     cache_path = tmp_path / "last_coords.txt"
-    cache_path.write_bytes(b"\xff\xfe\x00\x80 not text")
+    cache_path.write_text("1.0,not-a-number,3.0")
 
     with caplog.at_level(logging.WARNING, logger="squid"):
-        assert squid.stage.utils.get_cached_position(cache_path=str(cache_path)) is None
+        squid.stage.utils.get_cached_position(cache_path=str(cache_path))
 
-    assert any(r.levelno == logging.WARNING for r in caplog.records)
+    assert any("contents='1.0,not-a-number,3.0'" in r.getMessage() for r in caplog.records)
+
+
+class _WriteFailsFile:
+    """Wraps a real file object so opening (and truncating) succeeds but writing fails."""
+
+    def __init__(self, wrapped):
+        self._wrapped = wrapped
+
+    def __enter__(self):
+        self._wrapped.__enter__()
+        return self
+
+    def __exit__(self, *exc_info):
+        return self._wrapped.__exit__(*exc_info)
+
+    def write(self, _data):
+        raise OSError("simulated disk full")
+
+
+def test_cache_position_keeps_the_previous_position_when_the_write_fails(tmp_path, monkeypatch):
+    """An interrupted write must not leave a truncated cache behind - that is what corrupts the file."""
+    cache_path = str(tmp_path / "last_coords.txt")
+    stage_config = squid.config.get_stage_config()
+    already_cached = squid.abc.Pos(x_mm=11.0, y_mm=22.0, z_mm=1.0, theta_rad=None)
+    squid.stage.utils.cache_position(pos=already_cached, stage_config=stage_config, cache_path=cache_path)
+
+    real_open = builtins.open
+    monkeypatch.setattr(builtins, "open", lambda *args, **kwargs: _WriteFailsFile(real_open(*args, **kwargs)))
+    with pytest.raises(OSError):
+        squid.stage.utils.cache_position(
+            pos=squid.abc.Pos(x_mm=33.0, y_mm=44.0, z_mm=2.0, theta_rad=None),
+            stage_config=stage_config,
+            cache_path=cache_path,
+        )
+    monkeypatch.undo()
+
+    assert squid.stage.utils.get_cached_position(cache_path=cache_path) == already_cached
 
 
 # --- PI V-308 / C-414 focus stage --------------------------------------------


### PR DESCRIPTION
## Problem

`squid.stage.utils.get_cached_position()` only caught `RuntimeError`, which neither `float()` nor tuple unpacking ever raise. So if `cache/last_coords.txt` was corrupted — truncated by a crash mid-write, edited by hand, filled with garbage/binary — a `ValueError` (or `UnicodeDecodeError`) escaped straight out of `HighContentScreeningGui.__init__` and the software would not start until someone deleted the file manually.

## Fix

**Read side** — treat an unreadable or unparseable cache file exactly like a missing one: log a WARNING and return `None`, so the GUI falls through to its existing "no cached position" path (Z moves to the safety position) and startup continues. "Could not read the file" and "could not parse it" are reported separately, so a permission problem isn't described as corruption. Non-finite values (`nan`/`inf`) are rejected too, since `cache_position()` validates against the axis limits and can never write them. The read is capped at 4096 bytes so a stray large file at that path can't be pulled into memory during startup.

**Write side** — `cache_position()` truncated the cache in place before writing, which is what *produces* the partial files the read side now has to tolerate. It writes to a temp file and `os.replace()`s it into place instead, so an interrupted write leaves the last good position intact. This matches the existing pattern in `control/channel_sequence.py`.

A corrupt file is intentionally left in place rather than deleted; it is overwritten on the next clean exit, and the repeating warning is the right signal if the machine never exits cleanly.

## Scope note

`get_cached_position()` deliberately does **not** range-check a well-formed but stale position against the axis limits, and its docstring says so. A stale finite out-of-range X/Y would still cause a move timeout at startup; sharing the validation between the read and write sides needs `stage_config` threaded into the reader and is left as a follow-up.

Also out of scope, found while reviewing this: `control/_def.py` (two readers, at *import* time), `control/widgets.py:get_last_used_saving_path()`, and several other `cache/` readers have the same crash-on-corrupt-file shape with five different `except` tuples between them. A shared tolerant-read/atomic-write helper would make this structural rather than per-author, but it touches 6+ files and doesn't belong in a targeted fix.

## Tests

`tests/squid/test_stage.py`: corruption cases parametrized over bytes — garbage, too few / too many fields, a bad field, empty, `nan`, `inf`, and undecodable bytes — each asserting `None` is returned and a warning names the cache file; plus a test pinning the contents preview in the warning, and one covering an interrupted write (the previously-cached position must survive). Both behaviors were confirmed failing before the code changed.

```
python3 -m pytest tests/squid/test_stage.py tests/squid/test_stage_z_limit.py
48 passed, 1 skipped
```

Black clean at 120 columns.

## End-to-end check

Planted `this is not,a valid\x00position` in the cache and launched `main_hcs.py --simulation`:

```
WARNING - Cached position file 'cache/last_coords.txt' is corrupted (could not convert string to float: 'this is not'), contents='this is not,a valid\x00position'. Continuing as if there is no cached position.
INFO - Cache position is not exists.  Moving Z axis to safety position (gui_hcs.py:788)
```

Startup proceeded normally with no traceback. Round-tripping a position after the atomic-write change leaves no `.tmp` debris behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
