### PR TITLE
PyQt6 / napari 0.7 migration + review fixes (continuation of #606)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Windows script files must check out with CRLF regardless of the cloner's
+# core.autocrlf setting. cmd.exe can misparse a multi-line parenthesized block
+# (`if errorlevel 1 ( ... )`) in a .bat stored with LF endings, and the failure
+# looks like a syntax error rather than a line-ending problem.
+*.bat text eol=crlf
+*.ps1 text eol=crlf

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,12 +65,13 @@ jobs:
         # Own invocation: the full-application GUI test leaves Qt/thread state
         # behind that deterministically segfaults later Qt tests (e.g.
         # test_channel_sequence) when run in the same pytest process.
-        # Step-scoped pyqt5 pin: without it, pytest-qt picks PySide6 for qtbot
-        # while the app code (qtpy) uses PyQt5, and the mixed bindings fail
-        # with a QObject double-init error.
+        # Step-scoped pyqt6 pin: keeps pytest-qt's qtbot on the same binding as
+        # the app code (qtpy, QT_API=pyqt6). Mixed bindings fail with a QObject
+        # double-init error, and pointing this at a binding that is not installed
+        # (e.g. pyqt5, removed by setup_22.04.sh) aborts pytest at startup.
         run: python3 -m pytest tests/control/test_HighContentScreeningGui.py
         working-directory: ./software
         env:
-          QT_API: pyqt5
-          PYTEST_QT_API: pyqt5
+          QT_API: pyqt6
+          PYTEST_QT_API: pyqt6
           SQUID_PYTEST_HARD_EXIT: "1"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,9 @@ jobs:
         # Python GC — the same crash main_hcs.py avoids with os._exit()). The
         # conftest hook hard-exits with pytest's real status once the session
         # is complete, so real test failures still fail the step.
-        run: python3 -m pytest --ignore=tests/control/test_HighContentScreeningGui.py
+        # Full-application GUI tests are excluded here and run below, one per
+        # process: see the comments on those steps.
+        run: python3 -m pytest --ignore=tests/control/test_HighContentScreeningGui.py --ignore=tests/control/test_performance_mode.py
         working-directory: ./software
         env:
           SQUID_PYTEST_HARD_EXIT: "1"
@@ -70,6 +72,21 @@ jobs:
         # double-init error, and pointing this at a binding that is not installed
         # (e.g. pyqt5, removed by setup_22.04.sh) aborts pytest at startup.
         run: python3 -m pytest tests/control/test_HighContentScreeningGui.py
+        working-directory: ./software
+        env:
+          QT_API: pyqt6
+          PYTEST_QT_API: pyqt6
+          SQUID_PYTEST_HARD_EXIT: "1"
+      - name: Run the performance-mode GUI test in its own process
+        # Also constructs the full HCS GUI. Destroying that GUI segfaults (the
+        # destructor-order crash noted above; reproducible by flushing
+        # DeferredDelete events right after the test). pytest-qt deleteLater()s
+        # the window at teardown, and a later test's event-loop activity flushes
+        # that deferred delete — test_squid_laser_engine's cross-thread signal
+        # test did, taking the whole pytest process down at 67%. Each full-GUI
+        # test file must therefore be the last thing its process does: own
+        # step, own process, hard exit.
+        run: python3 -m pytest tests/control/test_performance_mode.py
         working-directory: ./software
         env:
           QT_API: pyqt6

--- a/software/Python 3.14 Compatibility Check.md
+++ b/software/Python 3.14 Compatibility Check.md
@@ -6,14 +6,14 @@
 | numpy | Wheels for 3.14 since v2.3+ |
 | scipy | Supported |
 | pandas | Supported |
-| pydantic (v2) | Supported -- but **pydantic v1** (used by old napari) is **NOT** |
+| pydantic (v2) | Supported. (pydantic v1 is not, but nothing in our stack needs it: napari 0.5.x already ran on pydantic 2.x) |
 | Pillow | Supported |
 | matplotlib | Supported |
 | PyYAML | Supported |
 | filelock | Supported |
 | platformdirs | Supported |
 | scikit-image | Wheels for 3.14 since v0.26 |
-| napari (latest) | Supported -- requires PyQt6, not PyQt5 |
+| napari (latest) | Supported -- ships both `[pyqt5]` and `[pyqt6]` extras (0.7.x and 0.9.x); we use PyQt6 |
 | opencv-python-headless | Uses stable ABI (cp37-abi3), works |
 | opencv-contrib-python-headless | Same stable ABI, works |
 | torch (PyTorch) | Supported since ~2.13 |
@@ -23,12 +23,13 @@
 | imageio | Supported |
 | pyqtgraph | Pure Python, likely works |
 | qtpy | Pure Python abstraction layer, works |
+| PyQt5 | Installs on 3.14: PyQt5 5.15.11 wheels are `cp38-abi3` and PyQt5-sip 12.19.0 ships cp314 wheels. Not a blocker -- we moved to PyQt6 for other reasons |
 
 ## Blocked / Incompatible
-| Package | Issue |
-|---------|-------|
-| **PyQt5** | **No Python 3.14 support -- this is the main blocker** |
-| **pydantic v1** | Explicitly incompatible with 3.14 (the `__slots__` error) |
+None confirmed in the pip stack. Earlier drafts listed PyQt5 and pydantic v1 here; both were wrong
+(see the Supported table). The likely blockers are the old pins pulled in by unmaintained packages:
+aicsimageio 4.14 pins `tifffile<2023.3.15`, `zarr<2.16`, `lxml<5`; basicpy pins `scipy<1.13`
+(peng-lab/BaSiCPy#173). Whether those old releases have 3.14 wheels has not been checked.
 
 ## Uncertain / Likely OK but unconfirmed
 | Package | Notes |
@@ -49,10 +50,10 @@
 
 ## Bottom Line
 
-The **two hard blockers** are **PyQt5** and **pydantic v1** (via old napari). Migrating to Python 3.14 would require:
-1. Switching from PyQt5 to PyQt6 (non-trivial API changes)
-2. Upgrading napari to a version that uses pydantic v2
-3. Verifying all hardware vendor SDKs have 3.14 builds
+No confirmed hard blocker in the pip stack. The PyQt6 + napari 0.7 migration in this PR removes the
+Qt-side uncertainty; what remains before a 3.14 move is:
+1. Confirming 3.14 wheels (or dropping) the pinned-back packages aicsimageio and basicpy pull in
+2. Verifying all hardware vendor SDKs have 3.14 builds
 
 **Recommendation: Stay on Python 3.10** for production use. It's the sweet spot where everything works.
 

--- a/software/Python 3.14 Compatibility Check.md
+++ b/software/Python 3.14 Compatibility Check.md
@@ -1,0 +1,66 @@
+# Python 3.14 Compatibility -- Squid Dependencies
+
+## Supported (confirmed)
+| Package | Notes |
+|---------|-------|
+| numpy | Wheels for 3.14 since v2.3+ |
+| scipy | Supported |
+| pandas | Supported |
+| pydantic (v2) | Supported -- but **pydantic v1** (used by old napari) is **NOT** |
+| Pillow | Supported |
+| matplotlib | Supported |
+| PyYAML | Supported |
+| filelock | Supported |
+| platformdirs | Supported |
+| scikit-image | Wheels for 3.14 since v0.26 |
+| napari (latest) | Supported -- requires PyQt6, not PyQt5 |
+| opencv-python-headless | Uses stable ABI (cp37-abi3), works |
+| opencv-contrib-python-headless | Same stable ABI, works |
+| torch (PyTorch) | Supported since ~2.13 |
+| dask | Active releases in 2026 |
+| zarr | Supported |
+| tifffile | Supported |
+| imageio | Supported |
+| pyqtgraph | Pure Python, likely works |
+| qtpy | Pure Python abstraction layer, works |
+
+## Blocked / Incompatible
+| Package | Issue |
+|---------|-------|
+| **PyQt5** | **No Python 3.14 support -- this is the main blocker** |
+| **pydantic v1** | Explicitly incompatible with 3.14 (the `__slots__` error) |
+
+## Uncertain / Likely OK but unconfirmed
+| Package | Notes |
+|---------|-------|
+| pyserial | Pure Python, last release 2020 -- probably works but untested |
+| pyvisa | Likely works |
+| hidapi | Cython extension -- no 3.14 wheels confirmed |
+| GitPython | Marked as NOT supporting 3.14 on pyreadiness.org |
+| aicsimageio | Unclear, niche package |
+| basicpy | Unclear |
+| ome-zarr | Unclear |
+| pydantic-xml | Likely works if pydantic v2 is used |
+| pyreadline3 | Windows-specific, unclear |
+| qtconsole | Depends on Qt backend |
+| lxml / lxml_html_clean | C extension -- needs checking |
+| mcp | Unclear |
+| Hardware drivers (PySpin, pyAndorSDK3, ids_peak, pyvcam, pm16) | Vendor-specific, unlikely to have 3.14 builds yet |
+
+## Bottom Line
+
+The **two hard blockers** are **PyQt5** and **pydantic v1** (via old napari). Migrating to Python 3.14 would require:
+1. Switching from PyQt5 to PyQt6 (non-trivial API changes)
+2. Upgrading napari to a version that uses pydantic v2
+3. Verifying all hardware vendor SDKs have 3.14 builds
+
+**Recommendation: Stay on Python 3.10** for production use. It's the sweet spot where everything works.
+
+## Sources
+- [Python 3.14 Readiness](https://pyreadiness.org/3.14/)
+- [NumPy 2.3.0 Release Notes](https://numpy.org/devdocs/release/2.3.0-notes.html)
+- [PyQt5 on PyPI](https://pypi.org/project/PyQt5/)
+- [napari Installation](https://napari.org/stable/getting_started/installation.html)
+- [PyTorch torch.compile Python 3.14 support](https://dev-discuss.pytorch.org/t/torch-compile-support-for-python-3-14-completed/3276)
+- [Pydantic v1 Python 3.14 issue](https://github.com/pydantic/pydantic/issues/12618)
+- [Anaconda Python 3.14 overview](https://www.anaconda.com/blog/python-3-14-what-data-scientists-developers-need-know)

--- a/software/control/console.py
+++ b/software/control/console.py
@@ -1,7 +1,7 @@
 import os
 
 # set QT_API environment variable
-os.environ["QT_API"] = "pyqt5"
+os.environ["QT_API"] = "pyqt6"
 
 import qtpy
 from qtpy.QtWidgets import QApplication, QMainWindow, QWidget, QVBoxLayout, QPushButton, QLabel

--- a/software/control/core/core.py
+++ b/software/control/core/core.py
@@ -4,7 +4,7 @@ import sys
 import tempfile
 
 # qt libraries
-os.environ["QT_API"] = "pyqt5"
+os.environ["QT_API"] = "pyqt6"
 import qtpy
 import pyqtgraph as pg
 from qtpy.QtCore import *
@@ -1677,9 +1677,6 @@ class NavigationViewer(QFrame):
         rows,
         cols,
     ):
-        if isinstance(sample_format, QVariant):
-            sample_format = sample_format.value()
-
         if sample_format == "glass slide":
             if IS_HCS:
                 sample = "4 glass slide"

--- a/software/control/core/job_processing.py
+++ b/software/control/core/job_processing.py
@@ -917,9 +917,22 @@ class JobRunner(multiprocessing.Process):
         if self.is_alive():
             self.terminate()
             self.join(timeout=1.0)
-        # Clean up multiprocessing primitives to avoid semaphore leaks
+        # Clean up multiprocessing primitives to avoid semaphore leaks.
+        #
+        # cancel_join_thread() must come first. A Queue feeds the underlying pipe from a
+        # background thread; if we terminated the worker above while it still had unread
+        # data queued, that thread stays blocked in a pipe write that no longer has a
+        # reader, and join_thread() then waits on it forever. This deadlocks reliably on
+        # Windows, where the pipe is a named pipe whose write blocks once the buffer fills
+        # and the child is gone (on Linux a small payload fits the buffer, so the write
+        # completes and the hang is usually not observed).
+        #
+        # Discarding those bytes is correct here: we are shutting the runner down and
+        # dropping both queues, so nothing will ever read them.
+        self._input_queue.cancel_join_thread()
         self._input_queue.close()
         self._input_queue.join_thread()
+        self._output_queue.cancel_join_thread()
         self._output_queue.close()
         self._output_queue.join_thread()
         # Clear references to allow garbage collection of Event and Value semaphores

--- a/software/control/core_PDAF.py
+++ b/software/control/core_PDAF.py
@@ -1,7 +1,7 @@
 # set QT_API environment variable
 import os
 
-os.environ["QT_API"] = "pyqt5"
+os.environ["QT_API"] = "pyqt6"
 
 # qt libraries
 from qtpy.QtCore import *

--- a/software/control/core_displacement_measurement.py
+++ b/software/control/core_displacement_measurement.py
@@ -1,7 +1,7 @@
 # set QT_API environment variable
 import os
 
-os.environ["QT_API"] = "pyqt5"
+os.environ["QT_API"] = "pyqt6"
 import qtpy
 
 # qt libraries

--- a/software/control/core_usbspectrometer.py
+++ b/software/control/core_usbspectrometer.py
@@ -1,7 +1,7 @@
 # set QT_API environment variable
 import os
 
-os.environ["QT_API"] = "pyqt5"
+os.environ["QT_API"] = "pyqt6"
 import qtpy
 
 # qt libraries

--- a/software/control/core_volumetric_imaging.py
+++ b/software/control/core_volumetric_imaging.py
@@ -1,7 +1,7 @@
 # set QT_API environment variable
 import os
 
-os.environ["QT_API"] = "pyqt5"
+os.environ["QT_API"] = "pyqt6"
 import qtpy
 
 # qt libraries
@@ -173,8 +173,8 @@ class ImageArrayDisplayWindow(QMainWindow):
         self.setCentralWidget(self.widget)
 
         # set window size
-        desktopWidget = QDesktopWidget()
-        width = min(desktopWidget.height() * 0.9, 1000)  # @@@TO MOVE@@@#
+        screen_height = QApplication.primaryScreen().size().height()
+        width = int(min(screen_height * 0.9, 1000))  # @@@TO MOVE@@@#
         height = width
         self.setFixedSize(width, height)
 

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -2876,6 +2876,14 @@ class HighContentScreeningGui(QMainWindow):
             except Exception:
                 self.log.exception(f"Error closing multipoint controller during {context}")
 
+        # Stop the Slack notifier's worker thread. It is a plain daemon thread, so
+        # without this it outlives the window (and, in the test suite, the test).
+        if self.slackNotifier is not None:
+            try:
+                self.slackNotifier.close()
+            except Exception:
+                self.log.exception(f"Error closing Slack notifier during {context}")
+
         # Clean up NDViewer
         if self.ndviewerTab is not None:
             try:

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -15,7 +15,7 @@ from control.core.scan_coordinates import (
     ClearedScanCoordinates,
 )
 
-os.environ["QT_API"] = "pyqt5"
+os.environ["QT_API"] = "pyqt6"
 import re
 import time
 from enum import Enum, auto
@@ -1426,8 +1426,7 @@ class HighContentScreeningGui(QMainWindow):
         We want our main window to fit on the primary screen, so grab the users primary screen and return
         something slightly smaller than that.
         """
-        desktop_info = QDesktopWidget()
-        primary_screen_size = desktop_info.screen(desktop_info.primaryScreen()).size()
+        primary_screen_size = QApplication.primaryScreen().size()
 
         height_min = int(0.9 * primary_screen_size.height())
         width_min = int(0.96 * primary_screen_size.width())
@@ -2386,9 +2385,6 @@ class HighContentScreeningGui(QMainWindow):
             self.toggleWellSelector(False)
 
     def onWellplateChanged(self, format_):
-        if isinstance(format_, QVariant):
-            format_ = format_.value()
-
         # TODO(imo): Not sure why glass slide is so special here?  It seems like it's just a "1 well plate".
         if format_ == "glass slide":
             self.toggleWellSelector(False)

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -1872,14 +1872,20 @@ class HighContentScreeningGui(QMainWindow):
                 slot = conn[1]
                 connection_type = conn[2] if len(conn) > 2 else None
                 if keep_connected:
+                    # Plain connect() does not raise on an existing connection — it adds a
+                    # second one, so every performance-mode toggle would stack another
+                    # connection on the widgets that stay connected and the slot would run
+                    # N times per emit. Disconnect first so this is idempotent. (Qt's
+                    # UniqueConnection can't be OR'd with the requested connection type
+                    # under PyQt6, where Qt.ConnectionType is a plain Enum.)
                     try:
-                        if connection_type is not None:
-                            signal.connect(slot, connection_type)
-                        else:
-                            signal.connect(slot)
+                        signal.disconnect(slot)
                     except TypeError:
-                        # Connection might already exist, which is fine
-                        pass
+                        pass  # not connected yet
+                    if connection_type is not None:
+                        signal.connect(slot, connection_type)
+                    else:
+                        signal.connect(slot)
                 else:
                     try:
                         signal.disconnect(slot)

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -1818,33 +1818,42 @@ class HighContentScreeningGui(QMainWindow):
             self.updateNapariConnections()
 
     def updateNapariConnections(self):
-        # Update Napari connections based on performance mode. Live widget connections are preserved
+        # Update Napari connections based on performance mode.
         # Connection tuples can be:
         #   (signal, slot) - uses default Qt.AutoConnection
         #   (signal, slot, connection_type) - uses specified connection type (e.g., Qt.QueuedConnection)
+        #
+        # The live widget is always kept connected. In performance mode the mosaic's
+        # data feed is ALSO kept connected: its canvas still builds during acquisition,
+        # but rendering is deferred while its tab is hidden and flushed once when the run
+        # finishes (see UnifiedMosaicWidget.showEvent and toggleAcquisitionStart). Only
+        # the remaining napari views (e.g. multichannel) are disconnected in performance mode.
         for widget_name, connections in self.napari_connections.items():
-            if widget_name != "napariLiveWidget":  # Always keep the live widget connected
-                widget = getattr(self, widget_name, None)
-                if widget:
-                    for conn in connections:
-                        signal = conn[0]
-                        slot = conn[1]
-                        connection_type = conn[2] if len(conn) > 2 else None
-                        if self.performance_mode:
-                            try:
-                                signal.disconnect(slot)
-                            except TypeError:
-                                # Connection might not exist, which is fine
-                                pass
+            if widget_name == "napariLiveWidget":  # always kept connected (wired at init)
+                continue
+            keep_connected = (not self.performance_mode) or widget_name == "unifiedMosaicWidget"
+            widget = getattr(self, widget_name, None)
+            if not widget:
+                continue
+            for conn in connections:
+                signal = conn[0]
+                slot = conn[1]
+                connection_type = conn[2] if len(conn) > 2 else None
+                if keep_connected:
+                    try:
+                        if connection_type is not None:
+                            signal.connect(slot, connection_type)
                         else:
-                            try:
-                                if connection_type is not None:
-                                    signal.connect(slot, connection_type)
-                                else:
-                                    signal.connect(slot)
-                            except TypeError:
-                                # Connection might already exist, which is fine
-                                pass
+                            signal.connect(slot)
+                    except TypeError:
+                        # Connection might already exist, which is fine
+                        pass
+                else:
+                    try:
+                        signal.disconnect(slot)
+                    except TypeError:
+                        # Connection might not exist, which is fine
+                        pass
 
     def toggleNapariTabs(self):
         # Enable/disable Napari tabs based on performance mode
@@ -2497,12 +2506,28 @@ class HighContentScreeningGui(QMainWindow):
                 self.live_scan_grid_was_on = False
             # NOTE: RAM monitor widget is connected via multipointController.signal_acquisition_start
             # which fires AFTER the memory monitor is created (see make_connections)
+
+            # Performance mode: keep the mosaic/multichannel napari tabs hidden and
+            # disabled for the duration of the run so the mosaic canvas builds without
+            # rendering (deferred), avoiding the per-tile GL stalls. A previous run's
+            # completion may have re-enabled/shown them, so re-apply the hidden state here.
+            if self.performance_mode:
+                self.toggleNapariTabs()
         else:
             self.log.info("FINISHED ACQUISITION")
             if self.live_scan_grid_was_on:
                 self.toggle_live_scan_grid(on=True)
                 self.live_scan_grid_was_on = False
             # NOTE: RAM monitor widget is disconnected via multipointController.acquisition_finished
+
+            # Performance mode: render the assembled mosaic once, now that the run is
+            # done. Re-enable the napari tabs and switch to the mosaic view; becoming
+            # visible flushes the single deferred refresh (UnifiedMosaicWidget.showEvent).
+            if self.performance_mode:
+                for i in range(self.imageDisplayTabs.count()):
+                    self.imageDisplayTabs.setTabEnabled(i, True)
+                if self.unifiedMosaicWidget is not None:
+                    self.imageDisplayTabs.setCurrentWidget(self.unifiedMosaicWidget)
 
         # click to move off during acquisition
         self.navigationWidget.set_click_to_move(not acquisition_started)

--- a/software/control/single_instance.py
+++ b/software/control/single_instance.py
@@ -11,7 +11,7 @@ import os
 
 # Pin the Qt binding before importing qtpy, matching the convention used by
 # every other Qt-using module in this codebase.
-os.environ["QT_API"] = "pyqt5"
+os.environ["QT_API"] = "pyqt6"
 
 import getpass
 from typing import NamedTuple, Optional

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -14814,7 +14814,7 @@ class SampleSettingsWidget(QFrame):
             json.dump(data, f)
 
 
-from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 from mpl_toolkits.mplot3d import proj3d
 from scipy.interpolate import griddata

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -31,7 +31,7 @@ from squid.stage.utils import move_to_loading_position, move_to_scanning_positio
 from squid.config import CameraPixelFormat
 
 # set QT_API environment variable
-os.environ["QT_API"] = "pyqt5"
+os.environ["QT_API"] = "pyqt6"
 
 # qt libraries
 import qtpy
@@ -4170,7 +4170,7 @@ class LiveControlWidget(QFrame):
         self.entry_displayFPS.valueChanged.connect(self.streamHandler.set_display_fps)
         self.slider_resolutionScaling.valueChanged.connect(self.streamHandler.set_display_resolution_scaling)
         self.slider_resolutionScaling.valueChanged.connect(self.liveController.set_display_resolution_scaling)
-        self.dropdown_modeSelection.activated[str].connect(self.select_new_microscope_mode_by_name)
+        self.dropdown_modeSelection.textActivated.connect(self.select_new_microscope_mode_by_name)
         self.dropdown_triggerManu.currentIndexChanged.connect(self.update_trigger_mode)
         self.btn_live.clicked.connect(self.toggle_live)
         self.entry_exposureTime.valueChanged.connect(self.update_config_exposure_time)

--- a/software/control/widgets_mosaic.py
+++ b/software/control/widgets_mosaic.py
@@ -135,6 +135,13 @@ class UnifiedMosaicWidget(QWidget):
 
         self.mode = _load_last_view_mode()
         self.layers_initialized = False
+        # Deferred-redraw flag. Painting this napari/vispy canvas while its tab is
+        # hidden fails on PyQt6 (the hidden QOpenGLWidget has an incomplete
+        # framebuffer → GL_INVALID_FRAMEBUFFER_OPERATION, which corrupts the shared
+        # GL program and cascades into "Cannot SIZE object N" on later frames). Tile
+        # numpy data is still written while hidden (so saves stay correct); only the
+        # GL refresh is deferred and flushed in showEvent once the tab is visible.
+        self._pending_refresh = False
         self.mosaic_dtype = None
         self.viewer_pixel_size_mm = None
 
@@ -282,11 +289,38 @@ class UnifiedMosaicWidget(QWidget):
         if PLATE_BOUNDARIES_LAYER in self.viewer.layers:
             self.viewer.layers.remove(self.viewer.layers[PLATE_BOUNDARIES_LAYER])
         if canvas_changed and self.mode == DisplayMode.PLATE:
-            self._fit_view_to_plate()
+            if self._display_active():
+                self._fit_view_to_plate()
+            else:
+                self._pending_refresh = True
 
     def _image_layers(self):
         """Iterate napari image layers, skipping shape/boundary overlays."""
         return [lyr for lyr in self.viewer.layers if lyr.name not in NON_IMAGE_LAYERS and hasattr(lyr, "data")]
+
+    def _display_active(self) -> bool:
+        """Whether the mosaic canvas is on-screen and safe to repaint.
+
+        A napari/vispy canvas embedded in a hidden QTabWidget page cannot be
+        painted on PyQt6 (the hidden QOpenGLWidget has no valid framebuffer), so
+        callers defer GL refreshes to showEvent when this returns False.
+        """
+        return self.isVisible()
+
+    def showEvent(self, event):
+        """Flush any GL refreshes that were deferred while the tab was hidden.
+
+        Tile data written while hidden is already in each layer's array; here we
+        repaint once the framebuffer is valid so the tab shows the latest mosaic.
+        """
+        super().showEvent(event)
+        if self._pending_refresh:
+            self._pending_refresh = False
+            for lyr in self._image_layers():
+                lyr.refresh()
+            if self.mode == DisplayMode.PLATE:
+                self._draw_plate_boundaries()
+            self.resetView()
 
     def enable_shape_drawing(self, enable):
         """Set Manual-ROI drawing on/off. Idempotent: the upstream signal
@@ -535,8 +569,11 @@ class UnifiedMosaicWidget(QWidget):
 
             layer = self.viewer.layers[channel_name]
             blit_tiles_to_canvas(layer.data, [(image, y_px, x_px)])
-            layer.refresh()
-            self._draw_plate_boundaries()
+            if self._display_active():
+                layer.refresh()
+                self._draw_plate_boundaries()
+            else:
+                self._pending_refresh = True
             # The fit-the-whole-plate camera reset only fires when the canvas
             # is (re)allocated — in setPlateLayout when slot dims/coverage
             # change and in _create_channel_layer when a layer is created.
@@ -556,6 +593,8 @@ class UnifiedMosaicWidget(QWidget):
         mosaic_height = int(math.ceil((self.viewer_extents[1] - self.viewer_extents[0]) / self.viewer_pixel_size_mm))
         mosaic_width = int(math.ceil((self.viewer_extents[3] - self.viewer_extents[2]) / self.viewer_pixel_size_mm))
 
+        display_active = self._display_active()
+
         if layer.data.shape[:2] != (mosaic_height, mosaic_width):
             y_offset = int(math.floor((prev_top_left[0] - self.top_left_coordinate[0]) / self.viewer_pixel_size_mm))
             x_offset = int(math.floor((prev_top_left[1] - self.top_left_coordinate[1]) / self.viewer_pixel_size_mm))
@@ -567,14 +606,20 @@ class UnifiedMosaicWidget(QWidget):
                 x_end = min(x_offset + lyr.data.shape[1], new_data.shape[1])
                 new_data[y_offset:y_end, x_offset:x_end] = lyr.data[: y_end - y_offset, : x_end - x_offset]
                 lyr.data = new_data
-            self.resetView()
             # Keep ROI vertices anchored to their stage-coordinate positions after the shift.
             self._update_shape_layer_position()
+            if display_active:
+                self.resetView()
 
         y_pos = int(math.floor((tl_y_mm - self.top_left_coordinate[0]) / self.viewer_pixel_size_mm))
         x_pos = int(math.floor((tl_x_mm - self.top_left_coordinate[1]) / self.viewer_pixel_size_mm))
         blit_tiles_to_canvas(layer.data, [(image, y_pos, x_pos)])
-        layer.refresh()
+        # Painting a hidden tab's canvas fails on PyQt6 (see _display_active); defer
+        # the GL refresh to showEvent. The tile is already in layer.data either way.
+        if display_active:
+            layer.refresh()
+        else:
+            self._pending_refresh = True
 
     def _create_channel_layer(self, channel_name, reference_image):
         """Create a new napari image layer for a channel.
@@ -613,9 +658,13 @@ class UnifiedMosaicWidget(QWidget):
         layer.mouse_double_click_callbacks.append(self._on_double_click)
         # Fit the view when the first plate-sized canvas is created so the user
         # immediately sees the full plate; subsequent tiles preserve any
-        # pan/zoom they've made since.
+        # pan/zoom they've made since. Deferred to showEvent when the tab is
+        # hidden — painting a hidden canvas fails on PyQt6 (see _display_active).
         if self.mode == DisplayMode.PLATE and self.num_rows > 0 and self.num_cols > 0:
-            self._fit_view_to_plate()
+            if self._display_active():
+                self._fit_view_to_plate()
+            else:
+                self._pending_refresh = True
 
     def _convert_image_dtype(self, image, target_dtype):
         """Convert image to target dtype with range scaling."""

--- a/software/control/widgets_usbspectrometer.py
+++ b/software/control/widgets_usbspectrometer.py
@@ -1,7 +1,7 @@
 # set QT_API environment variable
 import os
 
-os.environ["QT_API"] = "pyqt5"
+os.environ["QT_API"] = "pyqt6"
 import qtpy
 
 # qt libraries

--- a/software/main_hcs.bat
+++ b/software/main_hcs.bat
@@ -1,0 +1,36 @@
+@echo off
+REM Launch Squid HCS on Windows, via the virtualenv that setup_windows.ps1 builds.
+REM
+REM This exists so a startup failure stays readable: a shortcut pointed straight at
+REM python.exe closes its console the instant the process dies, so a bad config or a
+REM missing camera driver would flash past unreadable. It is the counterpart of
+REM Terminal=true in the .desktop entry setup_22.04.sh writes on Ubuntu.
+REM
+REM Usage:  main_hcs.bat [args...]      e.g.  main_hcs.bat --simulation
+
+setlocal
+
+REM control/_def.py resolves "configuration*.ini" and cache\ relative to the working
+REM directory, so run from the software root no matter where this was invoked from.
+cd /d "%~dp0"
+
+if not exist ".venv\Scripts\python.exe" (
+    echo.
+    echo ERROR: no virtualenv found at "%~dp0.venv".
+    echo Run setup_windows.ps1 first:
+    echo.
+    echo     powershell -ExecutionPolicy Bypass -File setup_windows.ps1
+    echo.
+    pause
+    exit /b 1
+)
+
+".venv\Scripts\python.exe" main_hcs.py %*
+
+if errorlevel 1 (
+    echo.
+    echo Squid exited with error code %errorlevel%.
+    pause
+)
+
+endlocal

--- a/software/main_hcs.py
+++ b/software/main_hcs.py
@@ -3,11 +3,12 @@ import argparse
 import logging
 import os
 
-os.environ["QT_API"] = "pyqt5"
+os.environ["QT_API"] = "pyqt6"
 import signal
 import sys
 
 # qt libraries
+from qtpy.QtCore import Qt
 from qtpy.QtWidgets import *
 from qtpy.QtGui import *
 
@@ -53,6 +54,14 @@ if __name__ == "__main__":
         action="store_true",
     )
     args = parser.parse_args()
+
+    # This GUI embeds several napari viewers (Live, Multichannel, Mosaic), each
+    # backed by its own vispy/OpenGL canvas, in a single process. Multiple vispy
+    # canvases must share one OpenGL context or vispy misroutes GLIR draw commands
+    # between them and rendering fails with "Cannot SIZE object N because it does
+    # not exist" (the mosaic image never appears). This attribute MUST be set
+    # before the QApplication is constructed. See napari's multiple-viewer example.
+    QApplication.setAttribute(Qt.ApplicationAttribute.AA_ShareOpenGLContexts, True)
 
     # Construct QApplication first so the single-instance check can show a
     # QMessageBox before any other startup side effects (logging, migration).

--- a/software/scripts/run_acquisition.py
+++ b/software/scripts/run_acquisition.py
@@ -113,7 +113,7 @@ def launch_gui(simulation: bool = False, verbose: bool = False) -> subprocess.Po
         cmd.append("--verbose")
 
     env = os.environ.copy()
-    env["QT_API"] = "pyqt5"
+    env["QT_API"] = "pyqt6"
 
     if verbose:
         print(f"Launching GUI: {' '.join(cmd)}")

--- a/software/setup_22.04.sh
+++ b/software/setup_22.04.sh
@@ -60,17 +60,27 @@ mkdir -p "$SQUID_SOFTWARE_ROOT/cache"
 # Ubuntu 22.04 ships an old pip; upgrade it before resolving the dependency graph.
 python3 -m pip install --upgrade pip
 
-# Qt binding: napari 0.7 requires PyQt6. Exactly ONE Qt binding may be installed —
-# PyQt5 and PyQt6 in the same environment conflict and break napari/vispy OpenGL
-# rendering. Remove any pre-existing PyQt5 (e.g. pulled in by an apt package) first.
+# Qt binding: the app targets PyQt6 (QT_API=pyqt6; napari itself supports either binding).
+# Exactly ONE Qt binding may be installed — PyQt5 and PyQt6 in the same environment
+# conflict and break napari/vispy OpenGL rendering. Remove any pre-existing PyQt5
+# (e.g. pulled in by an apt package) first.
+# Pinned to the tested combination. napari 0.7.1 blocks PyQt6-Qt6 6.11.0 and 6.11.1
+# (dock-widget and resizing bugs, napari/napari#9052); the napari[pyqt6] extra installed
+# below makes pip re-check these pins against napari's own Qt constraints, so bump them
+# together.
 sudo apt remove -y python3-pyqt5 python3-pyqt5.qtsvg 2>/dev/null || true
 pip3 uninstall -y PyQt5 PyQt5-Qt5 PyQt5-sip 2>/dev/null || true
-pip3 install PyQt6 PyQt6-Qt6 PyQt6-sip
+pip3 install "PyQt6==6.11.0" "PyQt6-Qt6==6.11.2" "PyQt6-sip==13.12.0"
 
-# install libraries. napari 0.7 requires numpy>=2, so no "numpy<2" pin here.
+# install libraries. No "numpy<2" pin: napari 0.7 only needs numpy>=1.24, but the rest of
+# the current stack (opencv-python 5.x, pyqtgraph 0.14, ...) targets NumPy 2 and the
+# pinned-back packages aicsimageio drags in (tifffile 2023.2, zarr 2.15, lxml 4.9) were
+# verified to work with it.
 pip3 install pyqtgraph qtpy pyserial pandas imageio crc==1.3.0 lxml numpy tifffile scipy pyreadline3
 pip3 install opencv-python-headless opencv-contrib-python-headless
-pip3 install "napari>=0.7,<0.8" scikit-image dask_image ome_zarr aicsimageio basicpy pytest pytest-qt pytest-xvfb gitpython matplotlib pydantic_xml pyvisa hidapi filelock lxml_html_clean psutil mcp ndv
+# napari pinned to a tested release (patch releases change its vispy/Qt constraints). The
+# [pyqt6] extra is what makes pip enforce napari's Qt blocklist against the PyQt6 above.
+pip3 install "napari[pyqt6]==0.7.1" scikit-image dask_image ome_zarr aicsimageio basicpy pytest pytest-qt pytest-xvfb gitpython matplotlib pydantic_xml pyvisa hidapi filelock lxml_html_clean psutil mcp ndv
 
 # Optional: PI V-308 / C-414 focus stage (USE_PI_FOCUS_STAGE). Safe to skip if unused;
 # squid.stage.pi imports it lazily and only needs it to connect to real hardware, so

--- a/software/setup_22.04.sh
+++ b/software/setup_22.04.sh
@@ -37,8 +37,11 @@ sudo apt update
 
 # install packages
 sudo apt install python3-pip -y
-sudo apt install python3-pyqtgraph python3-pyqt5 -y
-sudo apt install python3-pyqt5.qtsvg
+# NOTE: do NOT install apt's python3-pyqtgraph / python3-pyqt5 here. python3-pyqtgraph
+# pulls in python3-pyqt5 as a dependency, and having BOTH PyQt5 and PyQt6 present in the
+# same environment causes conflicting Qt libraries that break napari's OpenGL rendering
+# (blank/failed canvases, "Cannot SIZE object N because it does not exist"). We install
+# pyqtgraph and PyQt6 via pip below so exactly one Qt binding is present.
 
 sudo apt-get install git -y
 ## clone the repo if we don't already have it.
@@ -54,15 +57,20 @@ fi
 cd "$SQUID_SOFTWARE_ROOT"
 mkdir -p "$SQUID_SOFTWARE_ROOT/cache"
 
-# Ubuntu 22.04 ships pip 22.0.2, whose resolver can't handle the
-# napari==0.5.4 dependency graph on current PyPI (hits ResolutionTooDeep
-# after hours of backtracking). Upgrade pip before installing libraries.
+# Ubuntu 22.04 ships an old pip; upgrade it before resolving the dependency graph.
 python3 -m pip install --upgrade pip
 
-# install libraries
-pip3 install qtpy pyserial pandas imageio crc==1.3.0 lxml "numpy<2" tifffile scipy pyreadline3
+# Qt binding: napari 0.7 requires PyQt6. Exactly ONE Qt binding may be installed —
+# PyQt5 and PyQt6 in the same environment conflict and break napari/vispy OpenGL
+# rendering. Remove any pre-existing PyQt5 (e.g. pulled in by an apt package) first.
+sudo apt remove -y python3-pyqt5 python3-pyqt5.qtsvg 2>/dev/null || true
+pip3 uninstall -y PyQt5 PyQt5-Qt5 PyQt5-sip 2>/dev/null || true
+pip3 install PyQt6 PyQt6-Qt6 PyQt6-sip
+
+# install libraries. napari 0.7 requires numpy>=2, so no "numpy<2" pin here.
+pip3 install pyqtgraph qtpy pyserial pandas imageio crc==1.3.0 lxml numpy tifffile scipy pyreadline3
 pip3 install opencv-python-headless opencv-contrib-python-headless
-pip3 install napari==0.5.4 scikit-image dask_image ome_zarr aicsimageio basicpy pytest pytest-qt pytest-xvfb gitpython matplotlib pydantic_xml pyvisa hidapi filelock lxml_html_clean psutil mcp ndv
+pip3 install "napari>=0.7,<0.8" scikit-image dask_image ome_zarr aicsimageio basicpy pytest pytest-qt pytest-xvfb gitpython matplotlib pydantic_xml pyvisa hidapi filelock lxml_html_clean psutil mcp ndv
 
 # Optional: PI V-308 / C-414 focus stage (USE_PI_FOCUS_STAGE). Safe to skip if unused;
 # squid.stage.pi imports it lazily and only needs it to connect to real hardware, so

--- a/software/setup_22.04.sh
+++ b/software/setup_22.04.sh
@@ -80,7 +80,9 @@ pip3 install pyqtgraph qtpy pyserial pandas imageio crc==1.3.0 lxml numpy tifffi
 pip3 install opencv-python-headless opencv-contrib-python-headless
 # napari pinned to a tested release (patch releases change its vispy/Qt constraints). The
 # [pyqt6] extra is what makes pip enforce napari's Qt blocklist against the PyQt6 above.
-pip3 install "napari[pyqt6]==0.7.1" scikit-image dask_image ome_zarr aicsimageio basicpy pytest pytest-qt pytest-xvfb gitpython matplotlib pydantic_xml pyvisa hidapi filelock lxml_html_clean psutil mcp ndv
+# tensorstore is required by control/ndviewer_light and by tests/control/core/test_zarr_writer.py,
+# which begins with pytest.importorskip("tensorstore") -- without it ~79 zarr tests silently skip.
+pip3 install "napari[pyqt6]==0.7.1" scikit-image dask_image ome_zarr tensorstore aicsimageio basicpy pytest pytest-qt pytest-xvfb gitpython matplotlib pydantic_xml pyvisa hidapi filelock lxml_html_clean psutil mcp ndv
 
 # Optional: PI V-308 / C-414 focus stage (USE_PI_FOCUS_STAGE). Safe to skip if unused;
 # squid.stage.pi imports it lazily and only needs it to connect to real hardware, so

--- a/software/setup_22.04.sh
+++ b/software/setup_22.04.sh
@@ -72,17 +72,23 @@ sudo apt remove -y python3-pyqt5 python3-pyqt5.qtsvg 2>/dev/null || true
 pip3 uninstall -y PyQt5 PyQt5-Qt5 PyQt5-sip 2>/dev/null || true
 pip3 install "PyQt6==6.11.0" "PyQt6-Qt6==6.11.2" "PyQt6-sip==13.12.0"
 
-# install libraries. No "numpy<2" pin: napari 0.7 only needs numpy>=1.24, but the rest of
-# the current stack (opencv-python 5.x, pyqtgraph 0.14, ...) targets NumPy 2 and the
-# pinned-back packages aicsimageio drags in (tifffile 2023.2, zarr 2.15, lxml 4.9) were
-# verified to work with it.
+# install libraries. No "numpy<2" pin: napari 0.7 only needs numpy>=1.24, and the rest of
+# the current stack (opencv-python 5.x, pyqtgraph 0.14, ...) targets NumPy 2.
+#
+# aicsimageio and basicpy are deliberately NOT installed. basicpy pins scipy<1.13
+# (peng-lab/BaSiCPy#173) and scipy 1.12 ships no NumPy-2 wheel, so pip resolves the whole
+# environment back to numpy 1.26 -- which then violates napari's scipy>=1.14 and
+# opencv 5.x's numpy>=2, leaving `pip check` failing and napari unimportable. Their only
+# consumer is control/stitcher.py, which nothing in the application imports; stitching
+# lives in the separate Cephla-Lab/image-stitcher repo. If you need that module, install
+# these two into a dedicated venv rather than this one.
 pip3 install pyqtgraph qtpy pyserial pandas imageio crc==1.3.0 lxml numpy tifffile scipy pyreadline3
 pip3 install opencv-python-headless opencv-contrib-python-headless
 # napari pinned to a tested release (patch releases change its vispy/Qt constraints). The
 # [pyqt6] extra is what makes pip enforce napari's Qt blocklist against the PyQt6 above.
 # tensorstore is required by control/ndviewer_light and by tests/control/core/test_zarr_writer.py,
 # which begins with pytest.importorskip("tensorstore") -- without it ~79 zarr tests silently skip.
-pip3 install "napari[pyqt6]==0.7.1" scikit-image dask_image ome_zarr tensorstore aicsimageio basicpy pytest pytest-qt pytest-xvfb gitpython matplotlib pydantic_xml pyvisa hidapi filelock lxml_html_clean psutil mcp ndv
+pip3 install "napari[pyqt6]==0.7.1" scikit-image dask_image ome_zarr tensorstore pytest pytest-qt pytest-xvfb gitpython matplotlib pydantic_xml pyvisa hidapi filelock lxml_html_clean psutil mcp ndv
 
 # Optional: PI V-308 / C-414 focus stage (USE_PI_FOCUS_STAGE). Safe to skip if unused;
 # squid.stage.pi imports it lazily and only needs it to connect to real hardware, so

--- a/software/setup_cuda_22.04.sh
+++ b/software/setup_cuda_22.04.sh
@@ -10,6 +10,4 @@ pip install cuda-python
 pip install cupy-cuda12x
 pip3 install torch torchvision torchaudio
 
-pip3 install "numpy<2"
-
 sudo apt autoremove -y

--- a/software/setup_windows.ps1
+++ b/software/setup_windows.ps1
@@ -1,0 +1,304 @@
+<#
+.SYNOPSIS
+    Set up the Squid HCS software on Windows 10/11 (x64).
+
+.DESCRIPTION
+    The Windows counterpart to setup_22.04.sh. Installs Git and Python, clones the
+    repo, builds a virtualenv with the pinned PyQt6 + napari stack, seeds the
+    machine configuration, and creates Desktop shortcuts.
+
+    Differences from the Ubuntu script, all forced by the platform:
+
+      * A virtualenv is used instead of a system-wide pip install. Windows has no
+        distro Python to keep clean, and an isolated env is the only way to
+        guarantee exactly one Qt binding is present.
+      * apt / udev / dialout / apt-mark steps have no Windows equivalent and are
+        dropped. Serial ports need no group membership here.
+      * Camera drivers are vendor installers rather than bundled .run files.
+        ToupTek needs nothing (see below); Daheng needs the Galaxy SDK.
+
+.PARAMETER RepoPath
+    Where the repo lives (or will be cloned). Defaults to <Desktop>\Squid.
+
+.PARAMETER SkipPrereqs
+    Skip installing Git/Python via winget. Use when they are already present or
+    managed some other way.
+
+.EXAMPLE
+    powershell -ExecutionPolicy Bypass -File setup_windows.ps1
+
+.EXAMPLE
+    powershell -ExecutionPolicy Bypass -File setup_windows.ps1 -RepoPath D:\Squid
+#>
+
+[CmdletBinding()]
+param(
+    [string] $RepoPath = (Join-Path ([Environment]::GetFolderPath('Desktop')) 'Squid'),
+    [switch] $SkipPrereqs
+)
+
+# Equivalent of `set -eo pipefail`: stop on the first error rather than limping on
+# with a half-built environment.
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'  # keeps winget/pip progress bars out of logs
+
+$RepoHttp = 'https://github.com/Cephla-Lab/Squid.git'
+$PythonVersionId = 'Python.Python.3.12'  # 3.12 is the tested interpreter
+
+function Write-Step { param([string] $Message) Write-Host "`n==> $Message" -ForegroundColor Cyan }
+function Write-Note { param([string] $Message) Write-Host "    $Message" -ForegroundColor DarkGray }
+function Write-Warn { param([string] $Message) Write-Host "    WARNING: $Message" -ForegroundColor Yellow }
+
+function Update-PathFromRegistry {
+    # winget writes the new PATH to the registry, but the running process keeps the
+    # environment it started with. Without this refresh, git.exe and py.exe installed
+    # a moment ago are still not callable from this script.
+    $env:PATH = [Environment]::GetEnvironmentVariable('PATH', 'Machine') + ';' +
+                [Environment]::GetEnvironmentVariable('PATH', 'User')
+}
+
+function Invoke-Pip {
+    # pip failures must be fatal: a partially-resolved environment is worse than none,
+    # and PowerShell does not treat a nonzero native exit code as a terminating error.
+    param([string] $VenvPython, [string[]] $PipArgs, [string] $What)
+    Write-Note "pip install $What"
+    & $VenvPython -m pip install --disable-pip-version-check @PipArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "pip install failed ($What). Exit code $LASTEXITCODE."
+    }
+}
+
+# ---------------------------------------------------------------------------
+# 1. Prerequisites: Git and Python
+# ---------------------------------------------------------------------------
+if (-not $SkipPrereqs) {
+    Write-Step 'Installing prerequisites (Git, Python 3.12)'
+
+    if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+        throw 'winget not found. Install "App Installer" from the Microsoft Store, or re-run with -SkipPrereqs after installing Git and Python 3.12 manually.'
+    }
+
+    foreach ($pkg in @('Git.Git', $PythonVersionId)) {
+        Write-Note "winget install $pkg"
+        winget install --id $pkg --exact --source winget --silent `
+            --accept-source-agreements --accept-package-agreements --disable-interactivity
+        # winget exits nonzero when a package is already installed; that is not an error.
+    }
+    Update-PathFromRegistry
+}
+else {
+    Update-PathFromRegistry
+}
+
+# control/utils.py imports GitPython at module scope, and GitPython raises ImportError
+# at import time if it cannot find a git executable. So git on PATH is a hard runtime
+# requirement, not just a requirement of this installer.
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    throw 'git is not on PATH. Squid imports GitPython at startup, which fails without it. Open a new terminal (so PATH is refreshed) and re-run.'
+}
+
+$PyLauncher = Get-Command py -ErrorAction SilentlyContinue
+if (-not $PyLauncher) {
+    throw 'The py launcher was not found. Install Python 3.12 from python.org (with "Add to PATH"), then re-run with -SkipPrereqs.'
+}
+
+# ---------------------------------------------------------------------------
+# 2. The repo, including submodules
+# ---------------------------------------------------------------------------
+Write-Step "Fetching the repo into '$RepoPath'"
+
+if (-not (Test-Path -LiteralPath $RepoPath)) {
+    $parent = Split-Path -Parent $RepoPath
+    if ($parent -and -not (Test-Path -LiteralPath $parent)) {
+        New-Item -ItemType Directory -Force -Path $parent | Out-Null
+    }
+    # --recursive matters: control/ndviewer_light and fluidics_v2 are submodules, and a
+    # plain clone leaves them as empty directories.
+    git clone --recursive $RepoHttp $RepoPath
+}
+else {
+    Push-Location $RepoPath
+    Write-Note "Using existing repo at HEAD=$(git rev-parse HEAD)"
+    # Brings submodules up to the commits this checkout records, and fills them in if an
+    # earlier clone omitted --recursive. Note this discards uncommitted submodule work,
+    # checking each one out at the recorded SHA in detached HEAD.
+    git submodule update --init --recursive
+    Pop-Location
+}
+
+$SoftwareRoot = Join-Path $RepoPath 'software'
+if (-not (Test-Path -LiteralPath $SoftwareRoot)) {
+    throw "Expected '$SoftwareRoot' to exist. Is '$RepoPath' really a Squid checkout?"
+}
+
+Push-Location $SoftwareRoot
+try {
+    New-Item -ItemType Directory -Force -Path (Join-Path $SoftwareRoot 'cache') | Out-Null
+
+    # -----------------------------------------------------------------------
+    # 3. Virtualenv
+    # -----------------------------------------------------------------------
+    Write-Step 'Creating the virtualenv'
+    $VenvPython = Join-Path $SoftwareRoot '.venv\Scripts\python.exe'
+
+    if (-not (Test-Path -LiteralPath $VenvPython)) {
+        & py -3.12 -m venv (Join-Path $SoftwareRoot '.venv')
+        if ($LASTEXITCODE -ne 0) { throw "Failed to create the virtualenv. Exit code $LASTEXITCODE." }
+    }
+    else {
+        Write-Note 'Reusing the existing .venv'
+    }
+
+    Invoke-Pip $VenvPython @('--upgrade', 'pip', 'setuptools', 'wheel') 'pip, setuptools, wheel'
+
+    # -----------------------------------------------------------------------
+    # 4. Qt binding
+    # -----------------------------------------------------------------------
+    # Exactly ONE Qt binding may be present: PyQt5 and PyQt6 together break
+    # napari/vispy OpenGL rendering (blank canvases, "Cannot SIZE object N because it
+    # does not exist"). The venv gives us that guarantee for free.
+    #
+    # Pinned to the tested combination. napari 0.7.1 blocklists PyQt6-Qt6 6.11.0 and
+    # 6.11.1 (dock-widget and resizing bugs, napari/napari#9052), which is why Qt is
+    # 6.11.2; the napari[pyqt6] extra below makes pip re-check these pins, so bump
+    # them together.
+    Write-Step 'Installing the Qt binding (PyQt6)'
+    Invoke-Pip $VenvPython @('PyQt6==6.11.0', 'PyQt6-Qt6==6.11.2', 'PyQt6-sip==13.12.0') 'PyQt6 6.11.0 / Qt 6.11.2'
+
+    # -----------------------------------------------------------------------
+    # 5. Python dependencies
+    # -----------------------------------------------------------------------
+    Write-Step 'Installing Python dependencies'
+
+    Invoke-Pip $VenvPython @(
+        'pyqtgraph', 'qtpy', 'pyserial', 'pandas', 'imageio', 'crc==1.3.0',
+        'lxml', 'numpy', 'tifffile', 'scipy', 'pyreadline3'
+    ) 'base libraries'
+
+    Invoke-Pip $VenvPython @('opencv-python-headless', 'opencv-contrib-python-headless') 'OpenCV (headless)'
+
+    # napari is pinned to a tested release because patch releases move its vispy/Qt
+    # constraints. tensorstore is required by control/ndviewer_light and by
+    # tests/control/core/test_zarr_writer.py, which opens with
+    # pytest.importorskip("tensorstore").
+    #
+    # aicsimageio and basicpy are intentionally absent. basicpy pins scipy<1.13 and
+    # scipy 1.12 has no NumPy-2 wheel, so including it drags the environment back to
+    # numpy 1.26 and breaks napari's scipy>=1.14 and opencv 5.x's numpy>=2. Their only
+    # consumer is control/stitcher.py, which nothing in the application imports;
+    # stitching lives in the separate Cephla-Lab/image-stitcher repo. Install them
+    # into a separate venv if you need that module.
+    Invoke-Pip $VenvPython @(
+        'napari[pyqt6]==0.7.1', 'scikit-image', 'dask_image', 'ome_zarr', 'tensorstore',
+        'pytest', 'pytest-qt', 'gitpython', 'matplotlib', 'pydantic_xml', 'pyvisa',
+        'hidapi', 'filelock', 'lxml_html_clean', 'psutil', 'mcp', 'ndv'
+    ) 'napari 0.7.1 and the rest of the stack'
+
+    # Optional: PI V-308 / C-414 focus stage (USE_PI_FOCUS_STAGE). squid.stage.pi
+    # imports it lazily and only needs it to talk to real hardware, so a failure here
+    # must not abort the install.
+    Write-Note 'pip install pipython (optional)'
+    & $VenvPython -m pip install --disable-pip-version-check pipython
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warn 'pipython install failed; continuing (only needed for USE_PI_FOCUS_STAGE).'
+    }
+
+    Write-Step 'Verifying the environment'
+    & $VenvPython -m pip check
+    if ($LASTEXITCODE -ne 0) { Write-Warn 'pip check reported broken requirements (see above).' }
+
+    # Kept to a single line: a multi-line script handed to `python -c` gets re-parsed by
+    # PowerShell's native-argument handling and arrives at the interpreter mangled.
+    & $VenvPython -c "import qtpy, napari, numpy, cv2; from qtpy import QtCore; print('  qtpy binding :', qtpy.API_NAME); print('  Qt           :', QtCore.__version__); print('  napari       :', napari.__version__); print('  numpy        :', numpy.__version__); print('  opencv       :', cv2.__version__)"
+    if ($LASTEXITCODE -ne 0) { throw 'The installed stack failed to import. See the traceback above.' }
+
+    # -----------------------------------------------------------------------
+    # 6. Machine configuration
+    # -----------------------------------------------------------------------
+    Write-Step 'Seeding machine configuration'
+
+    $IlluminationExample = Join-Path $SoftwareRoot 'machine_configs\illumination_channel_config.yaml.example'
+    $IlluminationConfig = Join-Path $SoftwareRoot 'machine_configs\illumination_channel_config.yaml'
+    if ((Test-Path -LiteralPath $IlluminationExample) -and -not (Test-Path -LiteralPath $IlluminationConfig)) {
+        Copy-Item -LiteralPath $IlluminationExample -Destination $IlluminationConfig
+        Write-Note 'Created machine_configs\illumination_channel_config.yaml from the example.'
+        Write-Warn 'EDIT IT: the example assumes 405/488/561/638/730 laser lines and a stock LED matrix. The GUI degrades and channels are missing if it does not match your engine.'
+    }
+    else {
+        Write-Note 'illumination_channel_config.yaml already present; leaving it alone.'
+    }
+
+    # _def.py globs "configuration*.ini" in the software root and silently takes the
+    # first match, so more than one is a real hazard. Which one is right depends on the
+    # instrument, so this is left to the operator rather than guessed.
+    $ConfigsInRoot = @(Get-ChildItem -LiteralPath $SoftwareRoot -Filter 'configuration*.ini' -File -ErrorAction SilentlyContinue)
+    if ($ConfigsInRoot.Count -eq 0) {
+        Write-Warn 'No configuration*.ini in the software root. Squid needs exactly one. Copy the file matching your instrument:'
+        Get-ChildItem -LiteralPath (Join-Path $SoftwareRoot 'configurations') -Filter '*.ini' -File |
+            ForEach-Object { Write-Host "      configurations\$($_.Name)" -ForegroundColor DarkGray }
+    }
+    elseif ($ConfigsInRoot.Count -gt 1) {
+        Write-Warn "Found $($ConfigsInRoot.Count) configuration*.ini files in the software root. Squid takes whichever the glob returns first - delete all but the one you want:"
+        $ConfigsInRoot | ForEach-Object { Write-Host "      $($_.Name)" -ForegroundColor DarkGray }
+    }
+    else {
+        Write-Note "Using configuration: $($ConfigsInRoot[0].Name)"
+    }
+
+    # -----------------------------------------------------------------------
+    # 7. Desktop shortcuts
+    # -----------------------------------------------------------------------
+    Write-Step 'Creating Desktop shortcuts'
+
+    $Launcher = Join-Path $SoftwareRoot 'main_hcs.bat'
+    $IconPath = Join-Path $SoftwareRoot 'icon\cephla_logo.ico'
+    $Desktop = [Environment]::GetFolderPath('Desktop')
+    $WScript = New-Object -ComObject WScript.Shell
+
+    foreach ($sc in @(
+            @{ Name = 'Squid'; Args = ''; Desc = 'Squid HCS - real hardware' },
+            @{ Name = 'Squid (simulation)'; Args = '--simulation'; Desc = 'Squid HCS - simulated hardware' }
+        )) {
+        $lnk = $WScript.CreateShortcut((Join-Path $Desktop "$($sc.Name).lnk"))
+        $lnk.TargetPath = $Launcher
+        $lnk.Arguments = $sc.Args
+        $lnk.WorkingDirectory = $SoftwareRoot
+        $lnk.Description = $sc.Desc
+        if (Test-Path -LiteralPath $IconPath) { $lnk.IconLocation = $IconPath }
+        $lnk.Save()
+        Write-Note "$Desktop\$($sc.Name).lnk"
+    }
+}
+finally {
+    Pop-Location
+}
+
+# ---------------------------------------------------------------------------
+# 8. What is left for the operator
+# ---------------------------------------------------------------------------
+Write-Step 'Setup complete. Remaining manual steps:'
+
+Write-Host @"
+
+  Camera drivers
+    ToupTek   nothing to install - the x64 toupcam.dll ships in the repo under
+              'drivers and libraries\toupcam\windows\x64' and control/toupcam.py
+              loads it from there directly.
+    Daheng    install the Galaxy SDK for Windows (provides GxIAPI.dll, which
+              control/gxipy loads by name), then REBOOT. Required for the laser
+              autofocus camera. The installer is linked from the repo README.
+    Others    Hamamatsu (DCAM-API), Photometrics (PVCAM + pyvcam), Tucsen
+              (TUCam.dll under software\lib\x64), FLIR (Spinnaker + PySpin),
+              iDS (ids_peak), Andor (pyAndorSDK3) each need their vendor SDK.
+
+  Configuration
+    Confirm exactly one configuration*.ini sits in '$SoftwareRoot'
+    and that machine_configs\illumination_channel_config.yaml matches your
+    laser engine.
+
+  Launching
+    Use the Desktop shortcuts, or from '$SoftwareRoot':
+      main_hcs.bat              # real hardware
+      main_hcs.bat --simulation # no hardware required
+
+"@ -ForegroundColor Gray

--- a/software/squid/camera/utils.py
+++ b/software/squid/camera/utils.py
@@ -462,4 +462,4 @@ class SimulatedCamera(AbstractCamera):
 
     @debug_log
     def close(self):
-        pass
+        self.stop_streaming()

--- a/software/tests/control/core/test_zarr_writer.py
+++ b/software/tests/control/core/test_zarr_writer.py
@@ -30,6 +30,17 @@ from control.models import AcquisitionChannel, CameraSettings, IlluminationSetti
 pytest.importorskip("tensorstore")
 
 
+def as_posix_path(path: str) -> str:
+    """Normalize a built path to forward slashes so it can be compared to a literal.
+
+    The path builders use os.path.join, so they emit "\\" on Windows while the expected
+    paths in these tests are written in the POSIX form the code produces on Linux. The
+    assertions are about path *structure*, not about which separator the OS uses, so
+    normalize before comparing rather than duplicating every expectation per platform.
+    """
+    return path.replace(os.sep, "/")
+
+
 def make_test_capture_info(
     region_id: str = "A1",
     fov: int = 0,
@@ -475,18 +486,18 @@ class TestZarrWriterInfo:
 
         # Test single-letter row
         path = info.get_output_path("A1", 0)
-        assert path == "/tmp/experiment/plate.ome.zarr/A/1/0/0"
+        assert as_posix_path(path) == "/tmp/experiment/plate.ome.zarr/A/1/0/0"
 
         path = info.get_output_path("A1", 2)
-        assert path == "/tmp/experiment/plate.ome.zarr/A/1/2/0"
+        assert as_posix_path(path) == "/tmp/experiment/plate.ome.zarr/A/1/2/0"
 
         # Test multi-digit column
         path = info.get_output_path("B12", 2)
-        assert path == "/tmp/experiment/plate.ome.zarr/B/12/2/0"
+        assert as_posix_path(path) == "/tmp/experiment/plate.ome.zarr/B/12/2/0"
 
         # Test double-letter row (e.g., AA, AB)
         path = info.get_output_path("AA3", 0)
-        assert path == "/tmp/experiment/plate.ome.zarr/AA/3/0/0"
+        assert as_posix_path(path) == "/tmp/experiment/plate.ome.zarr/AA/3/0/0"
 
     def test_zarr_writer_info_non_hcs_per_fov_output_path(self):
         """Test non-HCS default: per-FOV zarr files (OME-NGFF compliant)."""
@@ -501,12 +512,12 @@ class TestZarrWriterInfo:
         )
 
         # Each FOV gets its own zarr file - get_output_path returns ARRAY path (group + /0)
-        assert info.get_output_path("region_1", 0) == "/tmp/experiment/zarr/region_1/fov_0.ome.zarr/0"
-        assert info.get_output_path("region_1", 1) == "/tmp/experiment/zarr/region_1/fov_1.ome.zarr/0"
-        assert info.get_output_path("region_1", 2) == "/tmp/experiment/zarr/region_1/fov_2.ome.zarr/0"
+        assert as_posix_path(info.get_output_path("region_1", 0)) == "/tmp/experiment/zarr/region_1/fov_0.ome.zarr/0"
+        assert as_posix_path(info.get_output_path("region_1", 1)) == "/tmp/experiment/zarr/region_1/fov_1.ome.zarr/0"
+        assert as_posix_path(info.get_output_path("region_1", 2)) == "/tmp/experiment/zarr/region_1/fov_2.ome.zarr/0"
 
         # Different region
-        assert info.get_output_path("region_2", 0) == "/tmp/experiment/zarr/region_2/fov_0.ome.zarr/0"
+        assert as_posix_path(info.get_output_path("region_2", 0)) == "/tmp/experiment/zarr/region_2/fov_0.ome.zarr/0"
 
     def test_zarr_writer_info_non_hcs_6d_output_path(self):
         """Test non-HCS with 6D mode: single zarr per region (non-standard)."""
@@ -524,12 +535,12 @@ class TestZarrWriterInfo:
         path_fov0 = info.get_output_path("region_1", 0)
         path_fov1 = info.get_output_path("region_1", 1)
 
-        assert path_fov0 == "/tmp/experiment/zarr/region_1/acquisition.zarr"
-        assert path_fov1 == "/tmp/experiment/zarr/region_1/acquisition.zarr"
+        assert as_posix_path(path_fov0) == "/tmp/experiment/zarr/region_1/acquisition.zarr"
+        assert as_posix_path(path_fov1) == "/tmp/experiment/zarr/region_1/acquisition.zarr"
 
         # Different region
         path_region2 = info.get_output_path("region_2", 0)
-        assert path_region2 == "/tmp/experiment/zarr/region_2/acquisition.zarr"
+        assert as_posix_path(path_region2) == "/tmp/experiment/zarr/region_2/acquisition.zarr"
 
     def test_zarr_writer_info_get_fov_count(self):
         """Test get_fov_count returns correct counts for regions."""
@@ -1925,7 +1936,7 @@ class TestZarrPathConsistency:
         for well_id, fov, expected_group_path, expected_array_path in test_cases:
             # Utility returns GROUP path (for NDViewer/readers)
             group_path = build_hcs_zarr_fov_path(base_path, well_id, fov)
-            assert group_path == expected_group_path, (
+            assert as_posix_path(group_path) == expected_group_path, (
                 f"Group path mismatch for well={well_id}, fov={fov}: "
                 f"got={group_path}, expected={expected_group_path}"
             )
@@ -1939,7 +1950,7 @@ class TestZarrPathConsistency:
                 is_hcs=True,
             )
             writer_path = zarr_info.get_output_path(well_id, fov)
-            assert writer_path == expected_array_path, (
+            assert as_posix_path(writer_path) == expected_array_path, (
                 f"Writer path mismatch for well={well_id}, fov={fov}: "
                 f"writer={writer_path}, expected={expected_array_path}"
             )
@@ -1985,7 +1996,7 @@ class TestZarrPathConsistency:
         for region_id, fov, expected_group_path, expected_array_path in test_cases:
             # Utility returns GROUP path (for NDViewer/readers)
             group_path = build_per_fov_zarr_path(base_path, region_id, fov)
-            assert group_path == expected_group_path, (
+            assert as_posix_path(group_path) == expected_group_path, (
                 f"Group path mismatch for region={region_id}, fov={fov}: "
                 f"got={group_path}, expected={expected_group_path}"
             )
@@ -2000,7 +2011,7 @@ class TestZarrPathConsistency:
                 use_6d_fov=False,
             )
             writer_path = zarr_info.get_output_path(region_id, fov)
-            assert writer_path == expected_array_path, (
+            assert as_posix_path(writer_path) == expected_array_path, (
                 f"Writer path mismatch for region={region_id}, fov={fov}: "
                 f"writer={writer_path}, expected={expected_array_path}"
             )
@@ -2019,7 +2030,7 @@ class TestZarrPathConsistency:
         for region_id, expected_path in test_cases:
             # Test utility function directly
             util_path = build_6d_zarr_path(base_path, region_id)
-            assert util_path == expected_path, (
+            assert as_posix_path(util_path) == expected_path, (
                 f"Utility path mismatch for region={region_id}: " f"got={util_path}, expected={expected_path}"
             )
 

--- a/software/tests/control/test_napari_connections.py
+++ b/software/tests/control/test_napari_connections.py
@@ -1,0 +1,89 @@
+"""Unit tests for HighContentScreeningGui.updateNapariConnections.
+
+Runs the method against a minimal stand-in object instead of the full GUI so the
+tests can assert exact connection counts: toggling performance mode back and
+forth must never stack duplicate connections on the widgets that stay connected
+(plain ``signal.connect`` silently adds a second connection; it does not raise).
+"""
+
+from qtpy.QtCore import QObject, Qt, Signal
+
+from control.gui_hcs import HighContentScreeningGui
+
+
+class _Emitter(QObject):
+    sig = Signal(int)
+    queued_sig = Signal(int)
+
+
+class _Receiver(QObject):
+    def __init__(self):
+        super().__init__()
+        self.calls = 0
+        self.queued_calls = 0
+
+    def slot(self, _value):
+        self.calls += 1
+
+    def queued_slot(self, _value):
+        self.queued_calls += 1
+
+
+class _GuiStub:
+    """Only the attributes updateNapariConnections reads."""
+
+    def __init__(self, emitter, mosaic, multichannel):
+        self.performance_mode = False
+        self.napariLiveWidget = None
+        self.unifiedMosaicWidget = mosaic
+        self.napariMultiChannelWidget = multichannel
+        self.napari_connections = {
+            "napariLiveWidget": [],
+            "napariMultiChannelWidget": [(emitter.sig, multichannel.slot)],
+            "unifiedMosaicWidget": [
+                (emitter.sig, mosaic.slot),
+                (emitter.queued_sig, mosaic.queued_slot, Qt.QueuedConnection),
+            ],
+        }
+
+    def update(self, performance_mode):
+        self.performance_mode = performance_mode
+        HighContentScreeningGui.updateNapariConnections(self)
+
+
+def _make():
+    emitter, mosaic, multichannel = _Emitter(), _Receiver(), _Receiver()
+    return emitter, mosaic, multichannel, _GuiStub(emitter, mosaic, multichannel)
+
+
+def test_toggling_performance_mode_keeps_exactly_one_mosaic_connection(qtbot):
+    emitter, mosaic, _multichannel, gui = _make()
+
+    gui.update(performance_mode=False)  # initial wiring (makeNapariConnections)
+    for mode in (True, False, True):  # user toggles performance mode a few times
+        gui.update(performance_mode=mode)
+
+    emitter.sig.emit(1)
+    emitter.queued_sig.emit(1)
+    qtbot.waitUntil(lambda: mosaic.queued_calls >= 1, timeout=1000)
+    qtbot.wait(20)  # let any stacked queued deliveries land before counting
+
+    assert mosaic.calls == 1, "direct-connection slot must fire once per emit"
+    assert mosaic.queued_calls == 1, "queued-connection slot must fire once per emit"
+    # In performance mode only the mosaic stays on `sig` (multichannel is disconnected).
+    assert emitter.receivers(emitter.sig) == 1
+
+
+def test_multichannel_disconnects_in_performance_mode_and_reconnects_once(qtbot):
+    emitter, _mosaic, multichannel, gui = _make()
+
+    gui.update(performance_mode=False)
+    gui.update(performance_mode=True)
+    emitter.sig.emit(1)
+    assert multichannel.calls == 0, "multichannel must be disconnected in performance mode"
+
+    gui.update(performance_mode=False)
+    gui.update(performance_mode=False)  # a redundant refresh must not double-connect
+    emitter.sig.emit(1)
+    assert multichannel.calls == 1
+    assert emitter.receivers(emitter.sig) == 2  # mosaic + multichannel, once each

--- a/software/tests/control/test_performance_mode.py
+++ b/software/tests/control/test_performance_mode.py
@@ -26,8 +26,11 @@ def test_performance_mode_defers_mosaic_and_renders_at_completion(qtbot, confirm
     Lives in its own module because it forces the mosaic napari.Viewer on; grouping
     it with the other full-GUI tests accumulates enough napari/vispy viewers to hit
     the known STATUS_HEAP_CORRUPTION on OpenGL teardown at process exit (documented;
-    run napari-heavy GUI test files separately). See gui_hcs.updateNapariConnections
-    and gui_hcs.toggleAcquisitionStart.
+    run napari-heavy GUI test files separately). CI also runs this file in its own
+    pytest process (main.yml): destroying the full GUI segfaults, and the deferred
+    delete pytest-qt posts for the window at teardown would otherwise be flushed
+    inside a later test's event loop. See gui_hcs.updateNapariConnections and
+    gui_hcs.toggleAcquisitionStart.
     """
     # gui_hcs star-imports _def; force the mosaic view on before construction so the
     # widget exists regardless of this machine's cached [VIEWS] config.

--- a/software/tests/control/test_performance_mode.py
+++ b/software/tests/control/test_performance_mode.py
@@ -1,0 +1,74 @@
+import pytest
+
+import control.gui_hcs
+import control.microscope
+from qtpy.QtWidgets import QMessageBox
+
+
+@pytest.fixture
+def confirm_exit_yes(monkeypatch):
+    """Auto-accept the 'Confirm Exit' dialog GUI shutdown shows, or teardown hangs forever."""
+
+    def confirm_exit(parent, title, text, *args, **kwargs):
+        if title == "Confirm Exit":
+            return QMessageBox.Yes
+        raise RuntimeError(f"Unexpected QMessageBox: {title} - {text}")
+
+    monkeypatch.setattr(QMessageBox, "question", confirm_exit)
+
+
+def test_performance_mode_defers_mosaic_and_renders_at_completion(qtbot, confirm_exit_yes, monkeypatch):
+    """Performance mode keeps the mosaic's data feed connected (so its canvas still
+    builds during acquisition) but holds its tab hidden/disabled so rendering is
+    deferred; on completion the mosaic tab is re-enabled and shown so the single
+    deferred refresh flushes.
+
+    Lives in its own module because it forces the mosaic napari.Viewer on; grouping
+    it with the other full-GUI tests accumulates enough napari/vispy viewers to hit
+    the known STATUS_HEAP_CORRUPTION on OpenGL teardown at process exit (documented;
+    run napari-heavy GUI test files separately). See gui_hcs.updateNapariConnections
+    and gui_hcs.toggleAcquisitionStart.
+    """
+    # gui_hcs star-imports _def; force the mosaic view on before construction so the
+    # widget exists regardless of this machine's cached [VIEWS] config.
+    monkeypatch.setattr(control.gui_hcs, "USE_NAPARI_FOR_MOSAIC_DISPLAY", True)
+
+    scope = control.microscope.Microscope.build_from_global_config(True)
+    win = control.gui_hcs.HighContentScreeningGui(microscope=scope, is_simulation=True)
+    qtbot.add_widget(win)
+
+    mosaic = win.unifiedMosaicWidget
+    assert mosaic is not None, "mosaic widget should be created when USE_NAPARI_FOR_MOSAIC_DISPLAY is on"
+    mosaic_idx = win.imageDisplayTabs.indexOf(mosaic)
+
+    def mosaic_feed_connected():
+        """True if the controller's mosaic_tile_update is still wired to updateTile.
+        Probes by disconnect (raises TypeError if not connected) then restores."""
+        try:
+            win.multipointController.mosaic_tile_update.disconnect(mosaic.updateTile)
+        except TypeError:
+            return False
+        win.multipointController.mosaic_tile_update.connect(mosaic.updateTile)
+        return True
+
+    assert mosaic_feed_connected(), "mosaic feed should be connected in normal mode"
+
+    # Enter performance mode via the toggle-button path.
+    win.performanceModeToggle.setChecked(True)
+    win.togglePerformanceMode()
+    assert win.performance_mode is True
+
+    # Key change: the mosaic's data feed stays CONNECTED in performance mode (so its
+    # canvas still builds during acquisition; rendering is what gets deferred).
+    assert mosaic_feed_connected(), "mosaic feed must remain connected in performance mode"
+
+    # Start of run: the mosaic tab is hidden/disabled so rendering defers (no per-tile GL).
+    win.toggleAcquisitionStart(True)
+    assert win.imageDisplayTabs.isTabEnabled(mosaic_idx) is False
+
+    # Completion: the mosaic tab is re-enabled and made current so its showEvent
+    # flushes the single deferred render.
+    win.toggleAcquisitionStart(False)
+    qtbot.wait(20)
+    assert win.imageDisplayTabs.isTabEnabled(mosaic_idx) is True
+    assert win.imageDisplayTabs.currentWidget() is mosaic

--- a/software/tests/control/test_single_instance.py
+++ b/software/tests/control/test_single_instance.py
@@ -71,7 +71,7 @@ def test_stale_lock_from_dead_process_is_reclaimed(tmp_path):
 
     # Pin QT_API so qtpy in the child selects the same binding as the parent
     # regardless of what other Qt bindings are installed in the environment.
-    child_env = {**os.environ, "QT_API": "pyqt5"}
+    child_env = {**os.environ, "QT_API": "pyqt6"}
     result = subprocess.run(
         [sys.executable, "-c", child_script],
         capture_output=True,

--- a/software/tests/squid/test_camera.py
+++ b/software/tests/squid/test_camera.py
@@ -169,3 +169,18 @@ def test_send_trigger_dropped_while_settings_change_in_flight():
     sim_cam.send_trigger()
     assert sim_cam.read_frame() is not None
     assert sim_cam.get_frame_id() == frame_id_before + 1
+
+
+def test_simulated_camera_close_stops_streaming_thread():
+    """close() must stop a running streaming thread. Owners (Microscope.close, the GUI
+    shutdown path) rely on close() as the final stop; a stream thread that survives it keeps
+    pushing frames into callbacks whose Qt receivers are gone, which segfaulted later Qt
+    tests in the same pytest process."""
+    sim_cam = squid.camera.utils.get_camera(squid.config.get_camera_config(), simulated=True)
+    sim_cam.start_streaming()
+    assert sim_cam.get_is_streaming()
+
+    sim_cam.close()
+
+    assert not sim_cam.get_is_streaming()
+    assert not any("stream_fn" in t.name for t in threading.enumerate())

--- a/software/tests/squid/test_stage.py
+++ b/software/tests/squid/test_stage.py
@@ -1,5 +1,6 @@
 import builtins
 import logging
+import os
 import pytest
 import tempfile
 
@@ -27,7 +28,11 @@ def test_simulated_cephla_stage_ops():
 
 
 def test_position_caching():
-    (unused_temp_fd, temp_cache_path) = tempfile.mkstemp(".cache", "squid_testing_")
+    (temp_fd, temp_cache_path) = tempfile.mkstemp(".cache", "squid_testing_")
+    # mkstemp hands back an *open* descriptor. cache_position() writes a temp file and
+    # os.replace()s it over this path, which Windows refuses with PermissionError while
+    # another handle to the destination is open, so close it before the call.
+    os.close(temp_fd)
 
     # Use 6 figures after the decimal so we test that we can capture nanometers
     p = squid.abc.Pos(x_mm=11.111111, y_mm=22.222222, z_mm=1.333333, theta_rad=None)

--- a/software/tools/view_laser_af_reference_image.py
+++ b/software/tools/view_laser_af_reference_image.py
@@ -1,11 +1,15 @@
+import os
+
+os.environ["QT_API"] = "pyqt6"
+
 import sys
 import json
 import base64
 import numpy as np
-from PyQt5.QtWidgets import QApplication, QMainWindow, QLabel, QVBoxLayout, QWidget, QPushButton, QFileDialog
-from PyQt5.QtCore import Qt
+from qtpy.QtWidgets import QApplication, QMainWindow, QLabel, QVBoxLayout, QWidget, QPushButton, QFileDialog
+from qtpy.QtCore import Qt
 import matplotlib.pyplot as plt
-from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg
 
 try:
     import yaml


### PR DESCRIPTION
Supersedes #606 (`feat/pyqt6-napari07-migration`). That PR's head branch lives on the `jsschwrz/Squid` fork, and pushes to it are rejected for the author and maintainers alike (no push permission; "allow edits from maintainers" is unavailable because the PR author doesn't own the fork), so the review items could not land there. This branch is #606's two commits unchanged, a merge of current `master`, and the fixes on top.

### Review items addressed

- **fix(gui): `updateNapariConnections` is now idempotent** (Copilot) — plain `connect()` silently stacks a second connection, so every performance-mode toggle re-wired the mosaic widget and `updateTile` ran N times per emit. Disconnect-before-connect; `Qt.UniqueConnection` can't be OR'd with `QueuedConnection` under PyQt6 (`Qt.ConnectionType` is a plain `Enum`). New `tests/control/test_napari_connections.py` asserts exact receiver counts across toggles.
- **build: pinned Qt stack, `napari[pyqt6]==0.7.1`** (Copilot + dependency review item 3) — `PyQt6==6.11.0`, `PyQt6-Qt6==6.11.2`, `PyQt6-sip==13.12.0`. The `[pyqt6]` extra makes pip enforce napari's Qt blocklist: napari 0.7.1 blocks Qt 6.11.0/6.11.1 (napari/napari#9052, dock-widget + resizing bugs) and the unpinned install had put 6.11.1 on CI. Setup-script comments corrected — napari 0.7 requires neither PyQt6 nor `numpy>=2` (`numpy>=1.24.2`; it still ships a `[pyqt5]` extra).
- **ci: GUI-test step pinned to `pyqt6`** (dependency review item 2) — master's step still said `QT_API/PYTEST_QT_API=pyqt5`; with PyQt5 uninstalled by the setup script, pytest-qt aborts at startup (`ModuleNotFoundError: No module named 'PyQt5'`). This only shows up once #606 is updated with master, which is why it's fixed here.
- **`widgets.py`: `backend_qtagg`** instead of `backend_qt5agg` (matches the `tools/` change; the old import worked via matplotlib's shim but was misleading).
- **docs: Python 3.14 checklist corrected** — PyQt5 does install on 3.14 (`cp38-abi3` wheels + cp314 PyQt5-sip), pydantic v1 isn't in play (napari 0.5.x already ran on pydantic 2), napari still ships a pyqt5 extra. Points at the actual unknowns (aicsimageio/basicpy pins, vendor SDKs) instead.

### Why CI was red, and the fix

Every CI run of #606 and the first run of this PR segfaulted at 67% in `test_squid_laser_engine.py::test_status_updated_signal` — same on PyQt5/3.10, PyQt6/3.10 and PyQt6/3.12 locally, so not a Qt- or Python-version issue, and *not* the #604 leak (that fixture is already in this branch via master). Root cause: #606's new `test_performance_mode.py` builds the full HCS GUI in the main pytest process. Destroying the full GUI segfaults (pre-existing destructor-order crash — `QSplitter → QTabWidget → QFrame → QVBoxLayout → QGridLayout → ~QHBoxLayout` under gdb; reproducible by flushing `DeferredDelete` right after the test), and pytest-qt `deleteLater()`s the window at teardown, so the first later test whose event-loop activity flushes deferred deletes dies. With the file excluded, the whole suite runs to completion under PyQt6.

- **ci: `test_performance_mode.py` runs in its own pytest process** — same treatment `test_HighContentScreeningGui.py` already gets (own step, `SQUID_PYTEST_HARD_EXIT`). Documented in the workflow and the test's docstring.
- **fix: two threads the GUI genuinely leaked past shutdown** (found while probing): `SimulatedCamera.close()` was a no-op, so the laser-AF focus camera's stream thread survived `Microscope.close()`; and the GUI never closed its `SlackNotifier` worker. Both fixed, with a regression test for the camera half.

### Deliberately not addressed

basicpy (falls back to an un-importable 1.1.0 in the new env) and the PyQt5-importing `ndviewer_light` submodule — both are slated for removal, so left as-is per discussion on #606.

### Verification

- `tests/control/test_napari_connections.py` (new, 2 tests) fails on the old code, passes on the fix.
- `tests/control/test_performance_mode.py` passes locally, alone (as CI now runs it) and under PyQt6 leaves no threads behind.
- Full suite under **Python 3.12 / PyQt6 6.11.0 / Qt 6.11.2** in a venv built with the setup script's exact pip sequence, CI-equivalent main step: **1552 passed, 10 skipped, 1 xfailed, no segfault**. The 4 remaining failures are `TestNDViewerTab*` hitting `ndviewer_light`'s PyQt5 import — local-only (CI has no submodule checkout, so that dir imports as an empty namespace package). `test_HighContentScreeningGui.py` alone: 5 passed.
- `uv pip compile` of the pinned setup-script set (py3.10) resolves: PyQt6 6.11.0 / PyQt6-Qt6 6.11.2 / napari 0.7.1 / numpy 2.2.6 / vispy 0.16.2, no PySide6.
- `black --check` clean.
- Real PyQt6 validation is this PR's CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
