### PR TITLE
feat(firmware): host-programmable per-pixel LED matrix framebuffer

### DIFF
--- a/firmware/controller/src/commands/commands.cpp
+++ b/firmware/controller/src/commands/commands.cpp
@@ -27,6 +27,8 @@ void init_callbacks()
     cmd_map[TURN_OFF_ILLUMINATION] = &callback_turn_off_illumination;
     cmd_map[SET_ILLUMINATION] = &callback_set_illumination;
     cmd_map[SET_ILLUMINATION_LED_MATRIX] = &callback_set_illumination_led_matrix;
+    cmd_map[SET_ILLUMINATION_LED_MATRIX_PIXEL] = &callback_set_illumination_led_matrix_pixel;
+    cmd_map[CLEAR_ILLUMINATION_LED_MATRIX] = &callback_clear_illumination_led_matrix;
     // Multi-port illumination commands (firmware v1.0+)
     cmd_map[SET_PORT_INTENSITY] = &callback_set_port_intensity;
     cmd_map[TURN_ON_PORT] = &callback_turn_on_port;

--- a/firmware/controller/src/commands/light_commands.cpp
+++ b/firmware/controller/src/commands/light_commands.cpp
@@ -23,6 +23,17 @@ void callback_set_illumination_led_matrix()
     set_illumination_led_matrix(buffer_rx[2], buffer_rx[3], buffer_rx[4], buffer_rx[5]);
 }
 
+void callback_set_illumination_led_matrix_pixel()
+{
+    // [2]=LED index (0..127), [3]=g*255, [4]=r*255, [5]=b*255 (same channel order as SET_ILLUMINATION_LED_MATRIX)
+    set_illumination_led_matrix_pixel(buffer_rx[2], buffer_rx[3], buffer_rx[4], buffer_rx[5]);
+}
+
+void callback_clear_illumination_led_matrix()
+{
+    clear_illumination_led_matrix_buffer();
+}
+
 void callback_set_illumination_intensity_factor()
 {
     uint8_t factor   = uint8_t(buffer_rx[2]);

--- a/firmware/controller/src/commands/light_commands.h
+++ b/firmware/controller/src/commands/light_commands.h
@@ -7,6 +7,8 @@ void callback_turn_on_illumination();
 void callback_turn_off_illumination();
 void callback_set_illumination();
 void callback_set_illumination_led_matrix();
+void callback_set_illumination_led_matrix_pixel();
+void callback_clear_illumination_led_matrix();
 void callback_set_illumination_intensity_factor();
 
 // Multi-port illumination commands (firmware v1.0+)

--- a/firmware/controller/src/constants_protocol.h
+++ b/firmware/controller/src/constants_protocol.h
@@ -75,6 +75,8 @@ static const int SET_WATCHDOG_TIMEOUT = 40;   // Set serial watchdog timeout and
 static const int SET_PIN_LEVEL = 41;
 static const int HEARTBEAT = 42;              // No-op keepalive for watchdog
 static const int MOVETO_W2 = 43;              // Absolute move on the W2 filter wheel
+static const int SET_ILLUMINATION_LED_MATRIX_PIXEL = 45;  // Set one LED in the user framebuffer [index,g,r,b]
+static const int CLEAR_ILLUMINATION_LED_MATRIX = 46;  // Zero the user framebuffer (no show)
 static const int INITFILTERWHEEL_W2 = 252;
 static const int INITFILTERWHEEL = 253;
 static const int INITIALIZE = 254;
@@ -135,6 +137,7 @@ static const int ILLUMINATION_SOURCE_LED_ARRAY_LEFT_DOT = 5;
 static const int ILLUMINATION_SOURCE_LED_ARRAY_RIGHT_DOT = 6;
 static const int ILLUMINATION_SOURCE_LED_ARRAY_TOP_HALF = 7;
 static const int ILLUMINATION_SOURCE_LED_ARRAY_BOTTOM_HALF = 8;
+static const int ILLUMINATION_SOURCE_LED_ARRAY_PROGRAMMABLE = 10;  // display host-painted per-pixel framebuffer
 static const int ILLUMINATION_SOURCE_LED_EXTERNAL_FET = 20;
 
 // Illumination Control TTL Ports - port-based names (preferred)

--- a/firmware/controller/src/functions.cpp
+++ b/firmware/controller/src/functions.cpp
@@ -134,6 +134,42 @@ void set_right_dot(CRGB * matrix, uint8_t r, uint8_t g, uint8_t b)
   matrix[124].setRGB(r, g, b);
 }
 
+// Host-painted framebuffer for the PROGRAMMABLE source. The host sets each LED
+// individually (SET_ILLUMINATION_LED_MATRIX_PIXEL); when the programmable source is
+// turned on we copy this into `matrix` and show it. Kept separate from `matrix` so it
+// survives the clear_matrix() that strobe-off does between acquisition frames.
+CRGB led_matrix_user[NUM_LEDS] = {0};
+
+// Set a single LED in the host-painted framebuffer (no show). The payload bytes mirror
+// SET_ILLUMINATION_LED_MATRIX exactly (host sends g*255, r*255, b*255), so a pixel painted
+// here renders identically to the same color drawn by the built-in full/half patterns.
+// The built-in path calls setRGB(host_red, host_green, host_blue) after scaling (the R/G
+// swap already happened on the host), so we do the same here.
+void set_illumination_led_matrix_pixel(uint8_t index, uint8_t byte_g, uint8_t byte_r, uint8_t byte_b)
+{
+  if (index >= NUM_LEDS)
+    return;
+  uint8_t g = (float(byte_g) / 255) * LED_MATRIX_MAX_INTENSITY;
+  uint8_t r = (float(byte_r) / 255) * LED_MATRIX_MAX_INTENSITY;
+  uint8_t b = (float(byte_b) / 255) * LED_MATRIX_MAX_INTENSITY;
+  led_matrix_user[index].setRGB(r * RED_ADJUSTMENT_FACTOR, g * GREEN_ADJUSTMENT_FACTOR, b * BLUE_ADJUSTMENT_FACTOR);
+}
+
+// Zero the host-painted framebuffer (no show). Call before painting a fresh pattern.
+void clear_illumination_led_matrix_buffer()
+{
+  for (int i = 0; i < NUM_LEDS; i++)
+    led_matrix_user[i].setRGB(0, 0, 0);
+}
+
+// Copy the host-painted framebuffer into the live matrix and display it.
+void turn_on_LED_matrix_user(CRGB * matrix)
+{
+  for (int i = 0; i < NUM_LEDS; i++)
+    matrix[i] = led_matrix_user[i];
+  FastLED.show();
+}
+
 void clear_matrix(CRGB * matrix)
 {
   for (int i = 0; i < NUM_LEDS; i++)
@@ -252,6 +288,9 @@ static void turn_on_illumination_source(int source)
     case ILLUMINATION_SOURCE_LED_ARRAY_BOTTOM_HALF:
       turn_on_LED_matrix_pattern(matrix,ILLUMINATION_SOURCE_LED_ARRAY_BOTTOM_HALF,led_matrix_r,led_matrix_g,led_matrix_b);
       break;
+    case ILLUMINATION_SOURCE_LED_ARRAY_PROGRAMMABLE:
+      turn_on_LED_matrix_user(matrix);
+      break;
     case ILLUMINATION_SOURCE_LED_EXTERNAL_FET:
       break;
     case ILLUMINATION_D1:
@@ -320,6 +359,9 @@ static void turn_off_illumination_source(int source)
       clear_matrix(matrix);
       break;
     case ILLUMINATION_SOURCE_LED_ARRAY_BOTTOM_HALF:
+      clear_matrix(matrix);
+      break;
+    case ILLUMINATION_SOURCE_LED_ARRAY_PROGRAMMABLE:
       clear_matrix(matrix);
       break;
     case ILLUMINATION_SOURCE_LED_EXTERNAL_FET:

--- a/firmware/controller/src/functions.h
+++ b/firmware/controller/src/functions.h
@@ -53,6 +53,9 @@ void turn_on_illumination();
 void turn_off_illumination();
 void set_illumination(int source, uint16_t intensity);
 void set_illumination_led_matrix(int source, uint8_t r, uint8_t g, uint8_t b);
+void set_illumination_led_matrix_pixel(uint8_t index, uint8_t byte_g, uint8_t byte_r, uint8_t byte_b);
+void clear_illumination_led_matrix_buffer();
+void turn_on_LED_matrix_user(CRGB * matrix);
 void ISR_strobeTimer();
 
 // Multi-port illumination control


### PR DESCRIPTION
## What

Make the LED matrix **host-programmable per-pixel**, so patterns (rings, DPC, custom apertures) are computed on the host instead of hard-coded in firmware. New patterns no longer require a firmware reflash.

## Changes

- **`ILLUMINATION_SOURCE_LED_ARRAY_PROGRAMMABLE` (10)** — displays a host-painted 128-LED framebuffer (`led_matrix_user`). It's kept separate from the live `matrix` so it survives the `clear_matrix()` that strobe-off does between acquisition frames; turning the source on copies the framebuffer into the live matrix and shows it.
- **`SET_ILLUMINATION_LED_MATRIX_PIXEL` (45)** — write one LED into the framebuffer (no show).
- **`CLEAR_ILLUMINATION_LED_MATRIX` (46)** — zero the framebuffer.
- Pixel `/255*MAX_INTENSITY` scaling and R/G channel order match the built-in full/half patterns, so a host-painted color renders identically to the same built-in color.

## Testing

- `pio run -e teensy41` builds clean; flashed to a Teensy 4.1 and exercised via the host (see companion host PR): painting a 128-LED annulus frame and displaying it in live view and acquisition.

## Companion PR

Host support (protocol + Phase Contrast configurator) is in a separate host-only PR that depends on this firmware being flashed.
