### PR TITLE
feat(gui): host-computed phase-contrast annulus with per-configuration rings

### DIFF
--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -204,6 +204,8 @@ class CMD_SET:
     SET_PIN_LEVEL = 41
     HEARTBEAT = 42  # No-op keepalive for watchdog
     MOVETO_W2 = 43  # Absolute move on the W2 filter wheel
+    SET_ILLUMINATION_LED_MATRIX_PIXEL = 45  # Set one LED in the user framebuffer [index,g,r,b]
+    CLEAR_ILLUMINATION_LED_MATRIX = 46  # Zero the user framebuffer (no show)
     INITFILTERWHEEL_W2 = 252
     INITFILTERWHEEL = 253
     INITIALIZE = 254
@@ -278,6 +280,7 @@ class ILLUMINATION_CODE:
     ILLUMINATION_SOURCE_LED_ARRAY_RIGHT_DOT = 6
     ILLUMINATION_SOURCE_LED_ARRAY_TOP_HALF = 7
     ILLUMINATION_SOURCE_LED_ARRAY_BOTTOM_HALF = 8
+    ILLUMINATION_SOURCE_LED_ARRAY_PROGRAMMABLE = 10  # host-painted per-pixel framebuffer
     ILLUMINATION_SOURCE_LED_EXTERNAL_FET = 20
 
     # Illumination Control TTL Ports - port-based names (preferred)

--- a/software/control/core/live_controller.py
+++ b/software/control/core/live_controller.py
@@ -37,6 +37,10 @@ class LiveController(QObject):
         self.microscope = microscope
         self.camera: AbstractCamera = camera
         self.currentConfiguration: Optional[AcquisitionChannel] = None
+        # Settings source for the "Phase contrast annulus" channel (set by the GUI); the
+        # annulus ring geometry/color is read from it when that channel is on (intensity
+        # comes from the channel's own intensity slider).
+        self.led_matrix_ring_widget = None
         self.trigger_mode: Optional[TriggerMode] = TriggerMode.SOFTWARE  # @@@ change to None
         self.is_live = False
         # True only for the duration of a single snap(); see should_display_frames().
@@ -93,8 +97,8 @@ class LiveController(QObject):
         return self.currentConfiguration.get_illumination_wavelength(ill_config)
 
     def _is_led_matrix(self) -> bool:
-        """Check if current configuration is LED matrix (source code 0-9)."""
-        return 0 <= self._get_illumination_source() < 10
+        """Check if current configuration is LED matrix (source code 0-10)."""
+        return 0 <= self._get_illumination_source() < 11
 
     def get_intensity_cap_percent(self, channel_config: Optional["AcquisitionChannel"]) -> float:
         """Maximum allowed illumination intensity (percent) for a channel.
@@ -304,7 +308,18 @@ class LiveController(QObject):
             else:
                 micro: Microcontroller = self.microscope.low_level_drivers.microcontroller
                 name = self.currentConfiguration.name
-                if "BF LED matrix full_R" in name:
+                if illumination_source == ILLUMINATION_CODE.ILLUMINATION_SOURCE_LED_ARRAY_PROGRAMMABLE and self.led_matrix_ring_widget is not None:
+                    # Programmable channel: the pattern (which LEDs, what color) is computed
+                    # on the host by the LED Matrix panel and painted per-pixel into the
+                    # controller's framebuffer; intensity comes from this channel's own
+                    # intensity slider. No firmware pattern logic -- new patterns need no reflash.
+                    frame = self.led_matrix_ring_widget.get_frame(intensity / 100.0, self.currentConfiguration.name)
+                    lit = sum(1 for px in frame if px[0] or px[1] or px[2])
+                    self._log.info(f"applying programmable LED matrix frame: {lit} LEDs lit @ {intensity}%")
+                    micro.set_illumination_led_matrix_frame(frame)
+                    # Select the PROGRAMMABLE source (displays the painted framebuffer).
+                    micro.set_illumination_led_matrix(illumination_source, r=0, g=0, b=0)
+                elif "BF LED matrix full_R" in name:
                     micro.set_illumination_led_matrix(illumination_source, r=(intensity / 100), g=0, b=0)
                 elif "BF LED matrix full_G" in name:
                     micro.set_illumination_led_matrix(illumination_source, r=0, g=(intensity / 100), b=0)

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -956,6 +956,8 @@ class HighContentScreeningGui(QMainWindow):
         )
         self.stageUtils = widgets.StageUtils(self.stage, self.liveController, is_wellplate=True)
         self.dacControlWidget = widgets.DACControWidget(self.microcontroller)
+        self.ledMatrixRingWidget = widgets.LedMatrixRingWidget(self.microcontroller, self.liveController)
+        self.liveController.led_matrix_ring_widget = self.ledMatrixRingWidget
         self.autofocusWidget = widgets.AutoFocusWidget(self.autofocusController)
         if self.piezo:
             self.piezoWidget = widgets.PiezoWidget(self.piezo)
@@ -1353,6 +1355,7 @@ class HighContentScreeningGui(QMainWindow):
         if SUPPORT_LASER_AUTOFOCUS:
             self.cameraTabWidget.addTab(self.laserAutofocusControlWidget, "Laser AF")
         self.cameraTabWidget.addTab(self.focusMapWidget, "Focus Map")
+        self.cameraTabWidget.addTab(self.ledMatrixRingWidget, "Phase Contrast")
         if self.laserEngineWidget:
             self.cameraTabWidget.addTab(self.laserEngineWidget, "Laser Engine")
         self.cameraTabWidget.currentChanged.connect(lambda: self.resizeCurrentTab(self.cameraTabWidget))
@@ -1511,6 +1514,9 @@ class HighContentScreeningGui(QMainWindow):
 
         self.liveControlWidget.signal_newExposureTime.connect(self.cameraSettingWidget.set_exposure_time)
         self.liveControlWidget.signal_newAnalogGain.connect(self.cameraSettingWidget.set_analog_gain)
+        # Auto-follow: the Phase Contrast tab shows the ring for whichever annulus
+        # configuration is selected in live view.
+        self.liveControlWidget.signal_live_configuration.connect(self.ledMatrixRingWidget.on_live_configuration_changed)
         if not self.live_only_mode:
             self.liveControlWidget.signal_start_live.connect(self.onStartLive)
             self.liveControlWidget.signal_show_live_view.connect(self.onShowLiveView)

--- a/software/control/microcontroller.py
+++ b/software/control/microcontroller.py
@@ -786,6 +786,35 @@ class Microcontroller:
         cmd[5] = min(int(b * 255), 255)
         self.send_command(cmd)
 
+    def set_illumination_led_matrix_pixel(self, index, r, g, b):
+        """Set one LED (index 0..127) in the controller's user framebuffer. r,g,b are
+        0..1. Does NOT display -- paint all pixels, then select the PROGRAMMABLE source
+        (set_illumination_led_matrix) to show them. Same R/G channel order + scaling as
+        set_illumination_led_matrix, so a pixel matches the built-in patterns' color."""
+        cmd = bytearray(self.tx_buffer_length)
+        cmd[1] = CMD_SET.SET_ILLUMINATION_LED_MATRIX_PIXEL
+        cmd[2] = int(index) & 0xFF
+        cmd[3] = min(max(int(g * 255), 0), 255)
+        cmd[4] = min(max(int(r * 255), 0), 255)
+        cmd[5] = min(max(int(b * 255), 0), 255)
+        self.send_command(cmd)
+
+    def clear_illumination_led_matrix(self):
+        """Zero the controller's user framebuffer (no display)."""
+        cmd = bytearray(self.tx_buffer_length)
+        cmd[1] = CMD_SET.CLEAR_ILLUMINATION_LED_MATRIX
+        self.send_command(cmd)
+
+    def set_illumination_led_matrix_frame(self, frame):
+        """Paint the whole 128-LED user framebuffer. `frame` is an iterable of (r,g,b)
+        tuples in 0..1 (index = LED number). Clears first, then sends only the non-black
+        LEDs to keep the number of serial commands small. Does NOT display -- the caller
+        selects the PROGRAMMABLE source afterwards to show it."""
+        self.clear_illumination_led_matrix()
+        for index, (r, g, b) in enumerate(frame):
+            if r > 0 or g > 0 or b > 0:
+                self.set_illumination_led_matrix_pixel(index, r, g, b)
+
     # Multi-port illumination commands (firmware v1.0+)
     # These allow multiple ports to be ON simultaneously with independent intensities
     # Maximum number of ports supported by firmware

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -5477,6 +5477,277 @@ class DACControWidget(QFrame):
         self.microcontroller.analog_write_onboard_DAC(1, round(value * 65535 / 100))
 
 
+class LedMatrixRingWidget(QFrame):
+    """SETTINGS for the LED-matrix annulus ring (radius, ring type, color).
+
+    This panel does NOT turn LEDs on/off itself -- the ring is switched on/off by
+    selecting the "Phase contrast annulus" imaging channel in live view / acquisition.
+    The pattern is computed HERE in Python (get_frame) as a per-LED framebuffer and sent
+    to the controller pixel-by-pixel, so changing/adding patterns never needs a firmware
+    reflash. Intensity is NOT set here -- it comes from that channel's own intensity slider
+    in live view. The lit LEDs are those whose ring DIAMETER (in pixels, i.e. LED pitches)
+    is in [inner, outer], as a full ring or a 180-deg half-ring.
+    """
+
+    _COLORS = {"Green": (0.0, 1.0, 0.0), "Red": (1.0, 0.0, 0.0), "Blue": (0.0, 0.0, 1.0), "White": (1.0, 1.0, 1.0)}  # (r,g,b)
+
+    # Physical (x,y) grid position of each of the 128 LEDs (12-column serpentine circular
+    # array), mirroring led_x/led_y in the firmware. Used to compute which LEDs fall in a
+    # ring. Kept here (host) so the geometry is fully programmable without reflashing.
+    _LED_X = (
+        -11, -11, -11, -11, -11, -11, -11, -11, -9, -9, -9, -9, -9, -9, -9, -9,
+        -7, -7, -7, -7, -7, -7, -7, -7, -7, -7, -7, -7, -5, -5, -5, -5,
+        -5, -5, -5, -5, -5, -5, -5, -5, -3, -3, -3, -3, -3, -3, -3, -3,
+        -3, -3, -3, -3, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 3,
+        3, 3, 3, 3, 3, 3, 3, 3, 5, 5, 5, 5, 5, 5, 5, 5,
+        5, 5, 5, 5, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+        9, 9, 9, 9, 9, 9, 9, 9, 11, 11, 11, 11, 11, 11, 11, 11,
+    )
+    _LED_Y = (
+        7, 5, 3, 1, -1, -3, -5, -7, -7, -5, -3, -1, 1, 3, 5, 7,
+        11, 9, 7, 5, 3, 1, -1, -3, -5, -7, -9, -11, -11, -9, -7, -5,
+        -3, -1, 1, 3, 5, 7, 9, 11, 11, 9, 7, 5, 3, 1, -1, -3,
+        -5, -7, -9, -11, -11, -9, -7, -5, -3, -1, 1, 3, 5, 7, 9, 11,
+        11, 9, 7, 5, 3, 1, -1, -3, -5, -7, -9, -11, -11, -9, -7, -5,
+        -3, -1, 1, 3, 5, 7, 9, 11, 11, 9, 7, 5, 3, 1, -1, -3,
+        -5, -7, -9, -11, -11, -9, -7, -5, -3, -1, 1, 3, 5, 7, 9, 11,
+        7, 5, 3, 1, -1, -3, -5, -7, -7, -5, -3, -1, 1, 3, 5, 7,
+    )
+    _NUM_LEDS = 128
+    # Spacing between adjacent LEDs in the coordinate grid above (one "pixel"). Adjacent
+    # columns differ by 2 (e.g. x = -11, -9), so pitch = 2 coordinate units per pixel.
+    # An LED's ring diameter in pixels = 2 * (coord_distance / pitch) = coord_distance.
+    _LED_PITCH_COORD = 2.0
+    # Default ring for a configuration that has no saved settings yet.
+    _DEFAULTS = {"inner": 6.0, "outer": 8.0, "type": "Full ring", "dir": 0, "color": "Green"}
+    # Sidecar file holding per-configuration ring settings (keyed by channel name).
+    _SETTINGS_PATH = "cache/phase_contrast_annulus_settings.json"
+
+    def __init__(self, microcontroller, live_controller=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.microcontroller = microcontroller
+        self.live_controller = live_controller
+        self.setFrameStyle(QFrame.Panel | QFrame.Raised)
+
+        # Per-configuration ring settings, keyed by channel name. Each annulus-based imaging
+        # configuration keeps its own ring; persisted to a sidecar file across restarts.
+        self._settings = {}
+        self._current_name = None   # channel currently loaded into the editor controls
+        self._loading = False       # guard: suppress saves while we populate controls
+        self._load_settings_file()
+
+        grid = QGridLayout()
+
+        # Row 0: pick which imaging configuration's ring you're editing.
+        grid.addWidget(QLabel("Configuration"), 0, 0)
+        self.combo_config = QComboBox()
+        self.combo_config.setToolTip("Imaging configuration whose annulus ring is being edited.")
+        grid.addWidget(self.combo_config, 0, 1, 1, 3)
+
+        grid.addWidget(QLabel("Inner diameter"), 1, 0)
+        self.spin_inner = QDoubleSpinBox()
+        self.spin_inner.setRange(0.0, 20.0); self.spin_inner.setSingleStep(1.0); self.spin_inner.setValue(self._DEFAULTS["inner"])
+        grid.addWidget(self.spin_inner, 1, 1)
+
+        grid.addWidget(QLabel("Outer diameter"), 1, 2)
+        self.spin_outer = QDoubleSpinBox()
+        self.spin_outer.setRange(0.0, 22.0); self.spin_outer.setSingleStep(1.0); self.spin_outer.setValue(self._DEFAULTS["outer"])
+        grid.addWidget(self.spin_outer, 1, 3)
+
+        grid.addWidget(QLabel("Ring type"), 2, 0)
+        self.combo_type = QComboBox(); self.combo_type.addItems(["Full ring", "Half ring"])
+        grid.addWidget(self.combo_type, 2, 1)
+        grid.addWidget(QLabel("Direction (0–7)"), 2, 2)
+        self.spin_dir = QSpinBox(); self.spin_dir.setRange(0, 7); self.spin_dir.setValue(0)
+        self.spin_dir.setEnabled(False)
+        grid.addWidget(self.spin_dir, 2, 3)
+
+        grid.addWidget(QLabel("Color"), 3, 0)
+        self.combo_color = QComboBox(); self.combo_color.addItems(list(self._COLORS.keys()))
+        grid.addWidget(self.combo_color, 3, 1)
+
+        self.setLayout(grid)
+
+        self.combo_type.currentIndexChanged.connect(lambda _: self.spin_dir.setEnabled(self.combo_type.currentText() == "Half ring"))
+        # Keep inner <= outer: cap inner at the outer value and floor outer at the inner value.
+        self.spin_inner.valueChanged.connect(self._apply_diameter_coupling)
+        self.spin_outer.valueChanged.connect(self._apply_diameter_coupling)
+        for w in (self.spin_inner, self.spin_outer, self.spin_dir):
+            w.valueChanged.connect(self._on_settings_changed)
+        self.combo_type.currentIndexChanged.connect(self._on_settings_changed)
+        self.combo_color.currentIndexChanged.connect(self._on_settings_changed)
+        self.combo_config.currentIndexChanged.connect(self._on_config_selected)
+
+        self._apply_diameter_coupling()
+        self.refresh_configurations()
+
+    def set_live_controller(self, live_controller):
+        self.live_controller = live_controller
+        self.refresh_configurations()
+
+    def _settings_for(self, channel_name) -> dict:
+        """Stored ring settings for a channel, falling back to defaults for unknown ones."""
+        s = dict(self._DEFAULTS)
+        if channel_name and channel_name in self._settings:
+            s.update(self._settings[channel_name])
+        return s
+
+    def get_frame(self, intensity_frac: float = 1.0, channel_name=None) -> list:
+        """Compute the per-LED framebuffer for a configuration's ring settings.
+
+        Returns a list of 128 (r, g, b) tuples in 0..1 (index = LED number), scaled by
+        intensity_frac. Reads the stored settings for `channel_name` (or the one currently
+        selected in the editor) -- NOT the live control widgets -- so acquisition on a
+        background thread gets the right ring for whichever configuration is imaging, even
+        if the editor is showing a different one. An LED lights if the DIAMETER of its ring
+        (in pixels) is within [inner, outer], and (for a half ring) it faces the direction.
+        """
+        import math
+
+        s = self._settings_for(channel_name if channel_name is not None else self._current_name)
+        r_w, g_w, b_w = self._COLORS.get(s["color"], (0.0, 1.0, 0.0))
+        r = r_w * intensity_frac * LED_MATRIX_R_FACTOR
+        g = g_w * intensity_frac * LED_MATRIX_G_FACTOR
+        b = b_w * intensity_frac * LED_MATRIX_B_FACTOR
+        inner_d = float(s["inner"])   # inner ring diameter, in pixels
+        outer_d = float(s["outer"])   # outer ring diameter, in pixels
+        full = s["type"] == "Full ring"
+        th = 0.0 if full else int(s["dir"]) * (math.pi / 4.0)
+        c, s_ = math.cos(th), math.sin(th)
+
+        frame = [(0.0, 0.0, 0.0)] * self._NUM_LEDS
+        for i in range(self._NUM_LEDS):
+            x, y = self._LED_X[i], self._LED_Y[i]
+            # Diameter (in pixels) of the circle this LED sits on. With pitch = 2 coordinate
+            # units per pixel, diameter_px = 2 * (coord_distance / pitch) = coord_distance.
+            diam_px = 2.0 * math.hypot(x, y) / self._LED_PITCH_COORD
+            if inner_d <= diam_px <= outer_d and (full or (x * c - y * s_) >= 0.0):
+                frame[i] = (r, g, b)
+        return frame
+
+    # ── configuration selection / persistence ──────────────────────────────────
+    def _annulus_channel_names(self) -> list:
+        """Names of the imaging configurations that use the programmable annulus source."""
+        lc = self.live_controller
+        if lc is None:
+            return []
+        try:
+            ill = lc._get_illumination_config()
+            objective = lc.microscope.objective_store.current_objective
+            programmable = ILLUMINATION_CODE.ILLUMINATION_SOURCE_LED_ARRAY_PROGRAMMABLE
+            return [ch.name for ch in lc.get_channels(objective) if ch.get_illumination_source_code(ill) == programmable]
+        except Exception:
+            return []
+
+    def refresh_configurations(self, select=None):
+        """Repopulate the configuration selector from the current annulus-based channels."""
+        if not hasattr(self, "combo_config"):
+            return
+        names = self._annulus_channel_names()
+        if select is None:
+            select = self._current_name if self._current_name in names else (names[0] if names else None)
+        self._loading = True
+        try:
+            self.combo_config.clear()
+            self.combo_config.addItems(names)
+            if select in names:
+                self.combo_config.setCurrentText(select)
+        finally:
+            self._loading = False
+        self._current_name = self.combo_config.currentText() if names else None
+        has = self._current_name is not None
+        for w in (self.spin_inner, self.spin_outer, self.combo_type, self.spin_dir, self.combo_color):
+            w.setEnabled(has)
+        if has:
+            self._write_controls(self._settings_for(self._current_name))
+
+    def _apply_diameter_coupling(self, *args):
+        # Constrain inner <= outer without fighting the user: cap the inner spinbox at the
+        # current outer value, and floor the outer spinbox at the current inner value.
+        self.spin_inner.setMaximum(self.spin_outer.value())
+        self.spin_outer.setMinimum(self.spin_inner.value())
+
+    def _read_controls(self) -> dict:
+        return {
+            "inner": self.spin_inner.value(),
+            "outer": self.spin_outer.value(),
+            "type": self.combo_type.currentText(),
+            "dir": self.spin_dir.value(),
+            "color": self.combo_color.currentText(),
+        }
+
+    def _write_controls(self, s: dict):
+        self._loading = True
+        try:
+            # Relax the coupling bounds so stored values load without being clamped, then
+            # re-apply the inner <= outer coupling once both are set.
+            self.spin_inner.setMaximum(20.0)
+            self.spin_outer.setMinimum(0.0)
+            self.spin_inner.setValue(float(s["inner"]))
+            self.spin_outer.setValue(float(s["outer"]))
+            self.combo_type.setCurrentText(s["type"])
+            self.spin_dir.setValue(int(s["dir"]))
+            self.spin_dir.setEnabled(s["type"] == "Half ring")
+            self.combo_color.setCurrentText(s["color"])
+            self._apply_diameter_coupling()
+        finally:
+            self._loading = False
+
+    def _on_config_selected(self, *args):
+        if self._loading:
+            return
+        self._current_name = self.combo_config.currentText() or None
+        if self._current_name:
+            self._write_controls(self._settings_for(self._current_name))
+
+    def _on_settings_changed(self, *args):
+        if self._loading or not self._current_name:
+            return
+        self._settings[self._current_name] = self._read_controls()
+        self._save_settings_file()
+        # Push to hardware immediately only if the configuration being edited is the one
+        # currently live -- otherwise just keep the settings for when it's next selected.
+        lc = self.live_controller
+        cfg = getattr(lc, "currentConfiguration", None) if lc is not None else None
+        if cfg is not None and getattr(cfg, "name", None) == self._current_name:
+            try:
+                lc.update_illumination()
+            except Exception:
+                pass
+
+    def on_live_configuration_changed(self, config):
+        """Auto-follow: when live view switches to an annulus configuration, show it here."""
+        name = getattr(config, "name", None)
+        if name and name in self._annulus_channel_names():
+            self.refresh_configurations(select=name)
+
+    def showEvent(self, event):
+        self.refresh_configurations()
+        super().showEvent(event)
+
+    def _load_settings_file(self):
+        try:
+            with open(self._SETTINGS_PATH, "r") as f:
+                data = json.load(f)
+            if isinstance(data, dict):
+                self._settings = {
+                    k: {**self._DEFAULTS, **v} for k, v in data.items() if isinstance(v, dict)
+                }
+        except Exception:
+            self._settings = {}
+
+    def _save_settings_file(self):
+        try:
+            directory = os.path.dirname(self._SETTINGS_PATH)
+            if directory:
+                os.makedirs(directory, exist_ok=True)
+            with open(self._SETTINGS_PATH, "w") as f:
+                json.dump(self._settings, f, indent=2)
+        except Exception:
+            pass
+
+
 class AutoFocusWidget(QFrame):
     signal_autoLevelSetting = Signal(bool)
 


### PR DESCRIPTION
## What

Host side of the host-programmable LED matrix: a **Phase Contrast** tab that computes an annular illumination pattern in Python and drives it through the programmable LED-matrix source. Because the pattern is computed on the host, the ring can be tuned — and new patterns added — with no firmware reflash.

> **Requires #623** (firmware) to be flashed — this PR targets illumination source 10, added there. Files are disjoint (host-only), so they can merge in either order, but both must land for the feature to run.

## Changes

**Protocol (`_def.py`, `microcontroller.py`)**
- Mirror the firmware commands: `SET_ILLUMINATION_LED_MATRIX_PIXEL` (45), `CLEAR_ILLUMINATION_LED_MATRIX` (46), `ILLUMINATION_SOURCE_LED_ARRAY_PROGRAMMABLE` (10).
- `set_illumination_led_matrix_pixel` / `clear_illumination_led_matrix`, and `set_illumination_led_matrix_frame(frame)` to push a full 128-LED frame (clear + non-black pixels), using the same R/G order and scaling as `set_illumination_led_matrix`.

**GUI (`widgets.py`, `gui_hcs.py`, `live_controller.py`)**
- New **Phase Contrast** tab (`LedMatrixRingWidget`) computes a 128-LED annulus frame and hands it to the live controller, which sends it per-pixel and selects the programmable source.
- Ring is specified by inner/outer **diameter in pixels** (LED pitches), with inner constrained ≤ outer. Ring type (full / 180° half), direction, and color are selectable; **intensity comes from the channel's own live-view slider**.
- **Per-configuration settings**: a selector lists the imaging configurations that use the programmable source; each keeps its own ring, persisted to `cache/phase_contrast_annulus_settings.json`. `get_frame(intensity, channel_name)` reads stored settings by name (plain data, not Qt widgets), so **live view and wellplate multipoint acquisition both use the correct ring** for whichever configuration is imaging — thread-safe from the acquisition worker.
- `live_controller` routes the programmable source through the widget frame and includes source 10 in `_is_led_matrix`; `gui_hcs` adds the tab and auto-follows the active live configuration.

## Required machine config (not in this PR)

The annulus imaging channel and its port mapping live in `machine_configs/` + `user_profiles/`, which are **gitignored** (per-machine). To enable the feature on a device, add:

**`machine_configs/illumination_channel_config.yaml`** — map a free controller port to source 10, and add the channel:
```yaml
controller_port_mapping:
  USB6: 10          # any UNUSED port; must match ^(D[1-8]|USB[1-8])$ (USB9 is rejected)
channels:
  - name: Phase contrast annulus
    type: transillumination
    controller_port: USB6
    wavelength_nm: null
    intensity_calibration_file: null
```

**`user_profiles/<profile>/channel_configs/general.yaml`** — add the imaging channel (merges into every objective):
```yaml
- name: Phase contrast annulus
  enabled: true
  display_color: '#FFFFFF'
  z_offset_um: 0.0
  camera_settings: {exposure_time_ms: 20.0, gain_mode: 10.0}
  illumination_settings:
    illumination_channel: Phase contrast annulus   # MUST equal the name above
    intensity: 20.0
```

Any imaging configuration whose `illumination_channel` resolves to source 10 appears in the tab's selector and gets its own ring.

## Testing

- Host compiles; launched against a Teensy flashed with #623. Verified the "Phase contrast annulus" configuration paints the ring in live view and applies the correct per-configuration ring during acquisition. Ring geometry checked numerically (default 6→8 px lights the expected 20-LED ring; half-ring lights exactly half).
