### PR TITLE
fix(firmware): bound the Power Good wait so a stuck PG line cannot block boot

### DIFF
--- a/firmware/controller/src/init.cpp
+++ b/firmware/controller/src/init.cpp
@@ -52,9 +52,11 @@ void init_power()
   // power good pin
   pinMode(pin_PG, INPUT_PULLUP);
 
-  // wait for PG to turn high
+  // wait up to 2s for PG to turn high, then continue regardless so a stuck or
+  // unwired PG line can never block boot
   delay(100);
-  while (!digitalRead(pin_PG))
+  elapsedMillis pg_wait;
+  while (!digitalRead(pin_PG) && pg_wait < 2000)
   {
     delay(50);
   }


### PR DESCRIPTION
init_power() spun in an unbounded `while (!digitalRead(pin_PG))` inside setup(),
so a Power Good line that never asserts hangs the controller before loop() is
ever reached. The board still enumerates over USB, because Teensy 4.1 brings USB
up in startup code before setup() runs — so the failure presents exactly like a
bad flash: the port opens, and then zero bytes forever.

On the CustomerBuild20260802 demo unit PG does not assert even with the controller rail
powered and reseated, which makes the stock firmware unbootable on that hardware.

Wait up to 2s for PG, then continue regardless. The wait is bounded rather than
removed outright: where PG does work, this still lets the rail settle before
init_stages() configures the TMC4361A/TMC2660 drivers over SPI. Note that a board
booted with the rail down will now configure those drivers against a dead rail,
so bring rail power up before power-cycling the Teensy.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
