### PR TITLE
feat(live-view): toggleable center crosshair

### DIFF
--- a/software/control/core/core.py
+++ b/software/control/core/core.py
@@ -854,11 +854,13 @@ class ImageDisplayWindow(QMainWindow):
         window_title="",
         show_LUT=False,
         autoLevels=False,
+        enable_crosshair=False,
     ):
         super().__init__()
         self._log = squid.logging.get_logger(self.__class__.__name__)
         self.liveController = liveController
         self.contrastManager = contrastManager
+        self.enable_crosshair = enable_crosshair
         self.setWindowTitle(window_title)
         self.setWindowFlags(self.windowFlags() | Qt.CustomizeWindowHint)
         self.setWindowFlags(self.windowFlags() & ~Qt.WindowCloseButtonHint)
@@ -883,6 +885,12 @@ class ImageDisplayWindow(QMainWindow):
         self.normal_cursor = QCursor(Qt.ArrowCursor)  # Normal cursor
         self.preview_line = None
         self.start_point_marker = None
+
+        # Crosshair state. The InfiniteLines are created lazily on first toggle
+        # (_ensure_crosshair_items) so a window that never shows the crosshair pays nothing.
+        self.crosshair_v = None  # vertical line, positioned at image center x
+        self.crosshair_h = None  # horizontal line, positioned at image center y
+        self._crosshair_shape = None  # (h, w) the lines are currently centered on
 
         # Create main layout
         layout = QVBoxLayout()
@@ -916,6 +924,18 @@ class ImageDisplayWindow(QMainWindow):
         self.btn_well_selector = QPushButton("Show Well Selector")
         self.btn_well_selector.setCheckable(False)
 
+        # Add crosshair toggle button. Only built for windows that opted in, so the
+        # laser-AF focus view doesn't grow a button it can't use. Disabled until the
+        # first image arrives — there is no frame to center on before that.
+        self.btn_crosshair = None
+        if self.enable_crosshair:
+            self.btn_crosshair = QPushButton("Crosshair")
+            self.btn_crosshair.setCheckable(True)
+            self.btn_crosshair.setChecked(False)
+            self.btn_crosshair.setEnabled(False)
+            self.btn_crosshair.setToolTip("Show a fixed crosshair at the center of the live image.")
+            self.btn_crosshair.clicked.connect(self.toggle_crosshair)
+
         # Add labels to status layout with spacing
         status_layout.addWidget(self.cursor_position_label)
         status_layout.addWidget(QLabel(" | "))  # Add separator
@@ -925,6 +945,9 @@ class ImageDisplayWindow(QMainWindow):
         status_layout.addWidget(QLabel(" | "))  # Add separator
         status_layout.addWidget(self.piezo_position_label)
         status_layout.addStretch()  # Push labels to the left
+        if self.btn_crosshair is not None:
+            status_layout.addWidget(self.btn_crosshair)  # Add crosshair button
+            status_layout.addWidget(QLabel(" | "))  # Add separator
         status_layout.addWidget(self.btn_well_selector)  # Add well selector button
         status_layout.addWidget(QLabel(" | "))  # Add separator
         status_layout.addWidget(self.btn_line_profiler)  # Add line profiler button
@@ -1122,6 +1145,53 @@ class ImageDisplayWindow(QMainWindow):
 
     def _active_view(self):
         return self.graphics_widget.view.getView() if self.show_LUT else self.graphics_widget.view
+
+    def _ensure_crosshair_items(self):
+        """Create the two crosshair InfiniteLines on first use. Idempotent."""
+        if self.crosshair_v is not None:
+            return
+        pen = pg.mkPen(color=(255, 255, 0, 180), width=1)
+        # movable=False so the lines never intercept mouse events — the line profiler's
+        # click-to-draw and click-to-move both rely on clicks reaching the view.
+        self.crosshair_v = pg.InfiniteLine(angle=90, movable=False, pen=pen)
+        self.crosshair_h = pg.InfiniteLine(angle=0, movable=False, pen=pen)
+        view = self._active_view()
+        for item in (self.crosshair_v, self.crosshair_h):
+            item.setZValue(20)  # above the image and the ROI (which uses 10)
+            item.hide()
+            # ignoreBounds keeps infinite lines out of auto-range, so toggling the
+            # crosshair never changes the current zoom.
+            view.addItem(item, ignoreBounds=True)
+
+    def _update_crosshair_position(self, image):
+        """Center the crosshair on the frame. No-op unless the frame size changed.
+
+        display_image runs at frame rate, so the shape guard keeps the common path to a
+        single tuple comparison with no Qt calls.
+        """
+        shape = image.shape[:2]
+        if shape == self._crosshair_shape:
+            return
+        self._crosshair_shape = shape
+        height, width = shape
+        # imageAxisOrder is "row-major" (set above), so image[row, col] -> x=col, y=row.
+        self.crosshair_v.setPos(width / 2.0)
+        self.crosshair_h.setPos(height / 2.0)
+
+    def toggle_crosshair(self):
+        """Show/hide the fixed center crosshair."""
+        if not self.enable_crosshair:
+            return
+        self._ensure_crosshair_items()
+        show = self.btn_crosshair.isChecked()
+        if show:
+            # The lines are created before any frame has been seen when the user toggles
+            # between acquisitions; center them on the frame currently on screen.
+            current = getattr(self.graphics_widget.img, "image", None)
+            if current is not None:
+                self._update_crosshair_position(current)
+        self.crosshair_v.setVisible(show)
+        self.crosshair_h.setVisible(show)
 
     def _remove_line_preview_items(self):
         view = self._active_view()
@@ -1399,6 +1469,8 @@ class ImageDisplayWindow(QMainWindow):
         if self.first_image:
             self.first_image = False
             self.btn_line_profiler.setEnabled(True)
+            if self.btn_crosshair is not None:
+                self.btn_crosshair.setEnabled(True)
 
         if ENABLE_TRACKING:
             image = np.copy(image)
@@ -1428,6 +1500,9 @@ class ImageDisplayWindow(QMainWindow):
                 self.graphics_widget.img.setLevels((min_val, max_val))
 
         self.graphics_widget.img.updateImage()
+
+        if self.crosshair_v is not None:
+            self._update_crosshair_position(image)
 
         # Update pixel value based on last valid position
         if self.has_valid_position:

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -1020,11 +1020,13 @@ class HighContentScreeningGui(QMainWindow):
         self.imageDisplayTabs = QTabWidget(parent=self)
         if self.live_only_mode:
             if ENABLE_TRACKING:
-                self.imageDisplayWindow = core.ImageDisplayWindow(self.liveController, self.contrastManager)
+                self.imageDisplayWindow = core.ImageDisplayWindow(
+                    self.liveController, self.contrastManager, enable_crosshair=True
+                )
                 self.imageDisplayWindow.show_ROI_selector()
             else:
                 self.imageDisplayWindow = core.ImageDisplayWindow(
-                    self.liveController, self.contrastManager, show_LUT=True, autoLevels=True
+                    self.liveController, self.contrastManager, show_LUT=True, autoLevels=True, enable_crosshair=True
                 )
             self.imageDisplayTabs = self.imageDisplayWindow.widget
             self.unifiedMosaicWidget = None
@@ -1175,11 +1177,13 @@ class HighContentScreeningGui(QMainWindow):
             self.imageDisplayTabs.addTab(self.napariLiveWidget, "Live View")
         else:
             if ENABLE_TRACKING:
-                self.imageDisplayWindow = core.ImageDisplayWindow(self.liveController, self.contrastManager)
+                self.imageDisplayWindow = core.ImageDisplayWindow(
+                    self.liveController, self.contrastManager, enable_crosshair=True
+                )
                 self.imageDisplayWindow.show_ROI_selector()
             else:
                 self.imageDisplayWindow = core.ImageDisplayWindow(
-                    self.liveController, self.contrastManager, show_LUT=True, autoLevels=True
+                    self.liveController, self.contrastManager, show_LUT=True, autoLevels=True, enable_crosshair=True
                 )
             self.imageDisplayTabs.addTab(self.imageDisplayWindow.widget, "Live View")
 

--- a/software/tests/control/test_image_display_window.py
+++ b/software/tests/control/test_image_display_window.py
@@ -1,5 +1,7 @@
-"""Tests for ImageDisplayWindow's Ctrl+Scroll Z-navigation event filter."""
+"""Tests for ImageDisplayWindow's Ctrl+Scroll Z-navigation event filter and center crosshair."""
 
+import numpy as np
+import pyqtgraph as pg
 import pytest
 from qtpy.QtCore import Qt, QPointF, QPoint
 from qtpy.QtGui import QWheelEvent
@@ -101,3 +103,101 @@ def test_wheel_step_size_picks_up_live_def_changes(image_display_window, monkeyp
     image_display_window.eventFilter(image_display_window, _wheel_event(120, Qt.ControlModifier | Qt.ShiftModifier))
 
     assert received == [pytest.approx(7.5), pytest.approx(99.0)]
+
+
+# --- Center crosshair -------------------------------------------------------
+
+
+# Deliberately non-square (h=100, w=200) so an x/y swap fails loudly; a square
+# frame would let a transposed center pass.
+FRAME = np.zeros((100, 200), dtype=np.uint16)
+CENTER_X = 100.0  # width / 2
+CENTER_Y = 50.0  # height / 2
+
+
+@pytest.fixture
+def crosshair_window(qtbot):
+    win = ImageDisplayWindow(enable_crosshair=True)
+    qtbot.addWidget(win)
+    return win
+
+
+def test_crosshair_button_absent_when_not_enabled(image_display_window):
+    """The laser-AF focus view opts out and must not grow a crosshair button."""
+    assert image_display_window.btn_crosshair is None
+    assert image_display_window.enable_crosshair is False
+
+
+def test_crosshair_button_disabled_until_first_image(crosshair_window):
+    assert crosshair_window.btn_crosshair is not None
+    assert crosshair_window.btn_crosshair.isEnabled() is False
+    crosshair_window.display_image(FRAME)
+    assert crosshair_window.btn_crosshair.isEnabled() is True
+
+
+def test_toggle_creates_and_shows_lines_then_hides(crosshair_window):
+    crosshair_window.display_image(FRAME)
+    assert crosshair_window.crosshair_v is None  # created lazily, not before first toggle
+
+    crosshair_window.btn_crosshair.setChecked(True)
+    crosshair_window.toggle_crosshair()
+    assert isinstance(crosshair_window.crosshair_v, pg.InfiniteLine)
+    assert isinstance(crosshair_window.crosshair_h, pg.InfiniteLine)
+    assert crosshair_window.crosshair_v.isVisible() is True
+    assert crosshair_window.crosshair_h.isVisible() is True
+
+    crosshair_window.btn_crosshair.setChecked(False)
+    crosshair_window.toggle_crosshair()
+    assert crosshair_window.crosshair_v.isVisible() is False
+    assert crosshair_window.crosshair_h.isVisible() is False
+
+
+def test_crosshair_is_centered_on_the_frame(crosshair_window):
+    crosshair_window.display_image(FRAME)
+    crosshair_window.btn_crosshair.setChecked(True)
+    crosshair_window.toggle_crosshair()
+
+    assert crosshair_window.crosshair_v.value() == pytest.approx(CENTER_X)
+    assert crosshair_window.crosshair_h.value() == pytest.approx(CENTER_Y)
+
+
+def test_crosshair_recenters_when_frame_size_changes(crosshair_window):
+    crosshair_window.display_image(FRAME)
+    crosshair_window.btn_crosshair.setChecked(True)
+    crosshair_window.toggle_crosshair()
+
+    crosshair_window.display_image(np.zeros((40, 60), dtype=np.uint16))
+    assert crosshair_window.crosshair_v.value() == pytest.approx(30.0)
+    assert crosshair_window.crosshair_h.value() == pytest.approx(20.0)
+
+
+def test_same_shape_frame_does_not_reposition(crosshair_window, monkeypatch):
+    """display_image runs at frame rate; the shape guard must skip the Qt calls."""
+    crosshair_window.display_image(FRAME)
+    crosshair_window.btn_crosshair.setChecked(True)
+    crosshair_window.toggle_crosshair()
+
+    calls = []
+    monkeypatch.setattr(crosshair_window.crosshair_v, "setPos", lambda *a: calls.append(a))
+    monkeypatch.setattr(crosshair_window.crosshair_h, "setPos", lambda *a: calls.append(a))
+
+    crosshair_window.display_image(FRAME)
+    assert calls == []
+
+
+def test_crosshair_works_with_lut(qtbot):
+    """show_LUT=True is the real live-view configuration: the lines must be added to the
+    inner ViewBox via _active_view(), not to the outer pg.ImageView."""
+    win = ImageDisplayWindow(show_LUT=True, enable_crosshair=True)
+    qtbot.addWidget(win)
+    win.display_image(FRAME)
+    win.btn_crosshair.setChecked(True)
+    win.toggle_crosshair()
+
+    # getViewBox(), not ViewBox.addedItems — pyqtgraph does not track items added with
+    # ignoreBounds=True in addedItems, but they are still parented to the ViewBox.
+    view = win._active_view()
+    assert win.crosshair_v.getViewBox() is view
+    assert win.crosshair_h.getViewBox() is view
+    assert win.crosshair_v.value() == pytest.approx(CENTER_X)
+    assert win.crosshair_h.value() == pytest.approx(CENTER_Y)


### PR DESCRIPTION
Adds a fixed crosshair at the center of the Live View image, switched on and
off by a new button in the image status bar alongside Show Well Selector and
Line Profiler. Intended for centering a feature in the FOV, which previously
had to be judged by eye against the frame edges.

The feature is opt-in per ImageDisplayWindow via enable_crosshair (default
False), so only the Live View instances get it and the laser-AF focus camera
view is unchanged.

Implementation notes:
- The two InfiniteLines are created lazily on first toggle and added through
  the existing _active_view() helper, which already resolves the show_LUT vs
  non-LUT ViewBox difference used by the line profiler.
- movable=False so the lines never intercept clicks meant for the line
  profiler's click-to-draw or for click-to-move.
- ignoreBounds=True keeps them out of auto-range, so toggling the crosshair
  never changes the current zoom.
- display_image runs at frame rate, so repositioning is guarded by a cached
  frame shape and is a no-op unless the frame size changes.

Tests cover the opt-out case, enable gating, lazy creation and toggling,
centering on a non-square frame, recentering, the frame-rate guard, and the
show_LUT=True configuration the Live View actually uses.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
