### PR TITLE
fix(autofocus): honor the configured contrast AF channel, and expose the FOV interval

### DIFF
--- a/software/control/core/multi_point_worker.py
+++ b/software/control/core/multi_point_worker.py
@@ -1172,10 +1172,24 @@ class MultiPointWorker:
                 and (self.do_autofocus)
                 and (self.af_fov_count % Acquisition.NUMBER_OF_FOVS_PER_AF == 0)
             ):
-                configuration_name_AF = MULTIPOINT_AUTOFOCUS_CHANNEL
-                config_AF = self.liveController.get_channel_by_name(
-                    self.objectiveStore.current_objective, configuration_name_AF
-                )
+                # Read through the module, NOT the star-imported name.  `from control._def
+                # import *` above bound a snapshot of MULTIPOINT_AUTOFOCUS_CHANNEL into this
+                # module at import time, and Preferences only rebinds control._def's copy
+                # (widgets.py:_apply_live_settings), so the star-imported name would pin the
+                # AF channel to whatever it was at startup.
+                configuration_name_AF = control._def.MULTIPOINT_AUTOFOCUS_CHANNEL
+                objective = self.objectiveStore.current_objective
+                config_AF = self.liveController.get_channel_by_name(objective, configuration_name_AF)
+                if config_AF is None:
+                    # set_microscope_mode() only logs and returns on a None config, so without
+                    # this guard AF would silently run on whichever channel happened to be
+                    # active -- a wrong-but-plausible focus rather than a visible failure.
+                    available = [c.name for c in self.liveController.get_channels(objective)]
+                    self._log.error(
+                        f"Contrast autofocus channel '{configuration_name_AF}' does not exist for objective "
+                        f"'{objective}'; skipping autofocus for this FOV.  Available channels: {available}"
+                    )
+                    return False
                 self._select_config(config_AF)
                 if (
                     self.af_fov_count % Acquisition.NUMBER_OF_FOVS_PER_AF == 0

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -1972,11 +1972,19 @@ class HighContentScreeningGui(QMainWindow):
         if CACHED_CONFIG_FILE_PATH and os.path.exists(CACHED_CONFIG_FILE_PATH):
             config = ConfigParser()
             config.read(CACHED_CONFIG_FILE_PATH)
+            try:
+                channel_names = [
+                    c.name for c in self.liveController.get_channels(self.objectiveStore.current_objective)
+                ]
+            except Exception:
+                self.log.exception("Could not list channels for the preferences dialog")
+                channel_names = None
             dialog = widgets.PreferencesDialog(
                 config,
                 CACHED_CONFIG_FILE_PATH,
                 parent=self,
                 on_restart=self.restart_application,
+                channel_names=channel_names,
             )
             dialog.signal_config_changed.connect(self._update_ram_monitor_visibility)
             dialog.signal_config_changed.connect(

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -1181,12 +1181,15 @@ class PreferencesDialog(QDialog):
 
     signal_config_changed = Signal()
 
-    def __init__(self, config, config_filepath, parent=None, on_restart=None):
+    def __init__(self, config, config_filepath, parent=None, on_restart=None, channel_names=None):
         super().__init__(parent)
         self._log = squid.logging.get_logger(self.__class__.__name__)
         self.config = config
         self.config_filepath = config_filepath
         self._on_restart = on_restart  # Optional callback for application restart
+        # Channel names for the current objective, used to populate the autofocus channel
+        # picker.  None/empty falls back to a free-text field.
+        self._channel_names = list(channel_names) if channel_names else []
         self.setWindowTitle("Preferences")
         self.setMinimumWidth(500)
         self.setMinimumHeight(600)
@@ -1291,10 +1294,24 @@ class PreferencesDialog(QDialog):
         layout = QFormLayout(tab)
         layout.setSpacing(10)
 
-        # Autofocus Channel
-        self.autofocus_channel_edit = QLineEdit()
-        self.autofocus_channel_edit.setText(
-            self._get_config_value("GENERAL", "multipoint_autofocus_channel", "BF LED matrix full")
+        # Autofocus Channel (contrast-based AF during multipoint acquisition)
+        current_af_channel = self._get_config_value("GENERAL", "multipoint_autofocus_channel", "BF LED matrix full")
+        if self._channel_names:
+            # The name has to match a channel exactly or contrast AF is skipped, so offer the
+            # real names -- but keep it editable so a channel that only exists under another
+            # objective or profile can still be entered.
+            self.autofocus_channel_edit = QComboBox()
+            self.autofocus_channel_edit.setEditable(True)
+            self.autofocus_channel_edit.addItems(self._channel_names)
+            if current_af_channel not in self._channel_names:
+                self.autofocus_channel_edit.addItem(current_af_channel)
+            self.autofocus_channel_edit.setCurrentText(current_af_channel)
+        else:
+            self.autofocus_channel_edit = QLineEdit()
+            self.autofocus_channel_edit.setText(current_af_channel)
+        self.autofocus_channel_edit.setToolTip(
+            "Channel used for contrast-based autofocus during multipoint acquisition.\n"
+            "Must match a channel name exactly; unknown names cause autofocus to be skipped."
         )
         layout.addRow("Autofocus Channel:", self.autofocus_channel_edit)
 
@@ -1925,6 +1942,12 @@ class PreferencesDialog(QDialog):
         self.zarr_compression_label.setVisible(is_zarr)
         self.zarr_compression_combo.setVisible(is_zarr)
 
+    def _autofocus_channel_text(self):
+        """Selected autofocus channel name, from either the combo box or the free-text field."""
+        if isinstance(self.autofocus_channel_edit, QComboBox):
+            return self.autofocus_channel_edit.currentText().strip()
+        return self.autofocus_channel_edit.text().strip()
+
     def _ensure_section(self, section):
         """Ensure a config section exists, creating it if necessary."""
         if not self.config.has_section(section):
@@ -1956,7 +1979,7 @@ class PreferencesDialog(QDialog):
         self.config.set("GENERAL", "live_view_z_step_fast_um", str(self.click_to_move_z_coarse_spinbox.value()))
 
         # Acquisition settings
-        self.config.set("GENERAL", "multipoint_autofocus_channel", self.autofocus_channel_edit.text())
+        self.config.set("GENERAL", "multipoint_autofocus_channel", self._autofocus_channel_text())
         self.config.set(
             "GENERAL",
             "enable_flexible_multipoint",
@@ -2135,8 +2158,9 @@ class PreferencesDialog(QDialog):
         # Default saving path
         control._def.DEFAULT_SAVING_PATH = self.saving_path_edit.text()
 
-        # Autofocus channel
-        control._def.MULTIPOINT_AUTOFOCUS_CHANNEL = self.autofocus_channel_edit.text()
+        # Autofocus channel.  Consumers must read control._def.MULTIPOINT_AUTOFOCUS_CHANNEL
+        # (not a star-imported copy) for this to take effect without a restart.
+        control._def.MULTIPOINT_AUTOFOCUS_CHANNEL = self._autofocus_channel_text()
 
         # Flexible multipoint
         control._def.ENABLE_FLEXIBLE_MULTIPOINT = self.flexible_multipoint_checkbox.isChecked()
@@ -2237,7 +2261,7 @@ class PreferencesDialog(QDialog):
 
         # Acquisition settings (live update)
         old_val = self._get_config_value("GENERAL", "multipoint_autofocus_channel", "BF LED matrix full")
-        new_val = self.autofocus_channel_edit.text()
+        new_val = self._autofocus_channel_text()
         if old_val != new_val:
             changes.append(("Autofocus Channel", old_val, new_val, False))
 
@@ -5511,6 +5535,18 @@ class AutoFocusWidget(QFrame):
         self.entry_N.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         self.autofocusController.set_N(10)
 
+        self.entry_fovs_per_af = QSpinBox()
+        self.entry_fovs_per_af.setMinimum(1)
+        self.entry_fovs_per_af.setMaximum(1000)
+        self.entry_fovs_per_af.setSingleStep(1)
+        self.entry_fovs_per_af.setValue(Acquisition.NUMBER_OF_FOVS_PER_AF)
+        self.entry_fovs_per_af.setKeyboardTracking(False)
+        self.entry_fovs_per_af.setFixedWidth(self.entry_fovs_per_af.sizeHint().width())
+        self.entry_fovs_per_af.setToolTip(
+            "During multipoint acquisition, run contrast autofocus once every N FOVs.\n"
+            "1 = every FOV.  Does not affect the Autofocus button, which always runs on demand."
+        )
+
         self.btn_autofocus = QPushButton("Autofocus")
         self.btn_autofocus.setDefault(False)
         self.btn_autofocus.setCheckable(True)
@@ -5532,16 +5568,34 @@ class AutoFocusWidget(QFrame):
         grid_line0.addSpacing(20)
         grid_line0.addWidget(self.btn_autolevel)
 
+        grid_line1 = QHBoxLayout()
+        grid_line1.addWidget(QLabel("Acquisition AF every"))
+        grid_line1.addWidget(self.entry_fovs_per_af)
+        grid_line1.addWidget(QLabel("FOV(s)"))
+        grid_line1.addStretch()
+
         self.grid.addLayout(grid_line0)
+        self.grid.addLayout(grid_line1)
         self.grid.addWidget(self.btn_autofocus)
         self.setLayout(self.grid)
 
         # connections
+        self.entry_fovs_per_af.valueChanged.connect(self.set_fovs_per_af)
         self.btn_autofocus.toggled.connect(lambda: self.autofocusController.autofocus(False))
         self.btn_autolevel.toggled.connect(self.signal_autoLevelSetting.emit)
         self.entry_delta.valueChanged.connect(self.set_deltaZ)
         self.entry_N.valueChanged.connect(self.autofocusController.set_N)
         self.autofocusController.autofocusFinished.connect(self.autofocus_is_finished)
+
+    def set_fovs_per_af(self, value):
+        """Set how often multipoint acquisition runs contrast AF (1 = every FOV).
+
+        NUMBER_OF_FOVS_PER_AF is a class attribute, so every module that did
+        `from control._def import *` shares this one Acquisition object and sees the new
+        value -- unlike a module-level name, which each star import would have copied.
+        """
+        control._def.Acquisition.NUMBER_OF_FOVS_PER_AF = int(value)
+        self.log.info(f"contrast autofocus interval set to every {int(value)} FOV(s)")
 
     def set_deltaZ(self, value):
         mm_per_ustep = 1.0 / self.stage.get_config().Z_AXIS.convert_real_units_to_ustep(1.0)

--- a/software/tests/control/test_widgets.py
+++ b/software/tests/control/test_widgets.py
@@ -179,6 +179,46 @@ def surface_plot_widget(qtbot):
     return widget
 
 
+@pytest.fixture
+def autofocus_widget(qtbot):
+    """Create an AutoFocusWidget backed by a mock controller."""
+    controller = MagicMock()
+    widget = control.widgets.AutoFocusWidget(controller)
+    qtbot.addWidget(widget)
+    return widget
+
+
+class TestAutoFocusWidget:
+    """Tests for the contrast AF panel's FOVs-per-autofocus control."""
+
+    def test_fovs_per_af_initializes_from_config(self, autofocus_widget):
+        assert autofocus_widget.entry_fovs_per_af.value() == control._def.Acquisition.NUMBER_OF_FOVS_PER_AF
+
+    def test_fovs_per_af_spinbox_updates_acquisition_setting(self, autofocus_widget):
+        """The acquisition worker reads Acquisition.NUMBER_OF_FOVS_PER_AF, so the spinbox
+        has to write through to the class attribute -- not just hold a local value."""
+        original = control._def.Acquisition.NUMBER_OF_FOVS_PER_AF
+        try:
+            autofocus_widget.entry_fovs_per_af.setValue(1)
+            assert control._def.Acquisition.NUMBER_OF_FOVS_PER_AF == 1
+
+            autofocus_widget.entry_fovs_per_af.setValue(5)
+            assert control._def.Acquisition.NUMBER_OF_FOVS_PER_AF == 5
+        finally:
+            control._def.Acquisition.NUMBER_OF_FOVS_PER_AF = original
+
+    def test_fovs_per_af_minimum_is_every_fov(self, autofocus_widget):
+        """1 (autofocus at every FOV) must be reachable; 0 would disable AF entirely and
+        would make the worker's `af_fov_count % N` gate raise."""
+        original = control._def.Acquisition.NUMBER_OF_FOVS_PER_AF
+        try:
+            autofocus_widget.entry_fovs_per_af.setValue(0)
+            assert autofocus_widget.entry_fovs_per_af.value() == 1
+            assert control._def.Acquisition.NUMBER_OF_FOVS_PER_AF == 1
+        finally:
+            control._def.Acquisition.NUMBER_OF_FOVS_PER_AF = original
+
+
 class TestSurfacePlotWidget:
     """Tests for SurfacePlotWidget Z-stack handling and edge cases."""
 


### PR DESCRIPTION
The Preferences "Autofocus Channel" setting was silently ignored until a restart.
multi_point_worker does `from control._def import *`, which binds a snapshot of
MULTIPOINT_AUTOFOCUS_CHANNEL at import time, while PreferencesDialog applies the
setting by rebinding control._def's copy -- so acquisition kept using whatever
the channel was at startup, with no warning and the dialog listing the change as
requiring no restart. perform_autofocus() now reads control._def at use time.

An unknown channel name was equally quiet: get_channel_by_name() returns None and
set_microscope_mode() only logs and returns, so contrast AF ran on whichever
channel happened to be active. It now logs the bad name plus the available
channels and skips AF for that FOV instead of focusing on the wrong channel.

The Preferences field is now a combo box populated with the current objective's
channel names (still editable, for channels defined only under another objective
or profile), falling back to free text if the channel list can't be read.

Also adds an "Acquisition AF every N FOV(s)" spinbox to the Contrast AF panel,
which drives Acquisition.NUMBER_OF_FOVS_PER_AF (previously fixed at 3, with no
way to autofocus at every FOV). That one is a class attribute, so the star
imports share it and the running acquisition picks the value up per FOV.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
