### PR TITLE
feat(startup): show a device-by-device progress window during initialization

### DIFF
--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -865,6 +865,13 @@ ACQUISITION_MAX_PENDING_JOBS = 10  # Max jobs in flight before throttling
 ACQUISITION_MAX_PENDING_MB = 2000.0  # Max pending MB before throttling
 ACQUISITION_THROTTLE_TIMEOUT_S = 30.0  # Max wait time when throttled
 
+# Startup Settings
+# How long to keep retrying a device that answers "still warming up" during
+# initialization before giving up. A laser engine powered on moments before
+# launch can need a minute or more; the old fixed 5-attempt retry gave up after
+# about 5 seconds and killed startup outright.
+STARTUP_DEVICE_TIMEOUT_S = 90.0
+
 CAMERA_SN = {"ch 1": "SN1", "ch 2": "SN2"}  # for multiple cameras, to be overwritten in the configuration file
 
 ENABLE_STROBE_OUTPUT = False

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -43,6 +43,7 @@ from control._def import *
 
 # app specific libraries
 from control.laser_engine_widget import LaserEngineWidget
+from control.startup_progress import NULL_REPORTER, StartupReporter
 from control.NL5Widget import NL5Widget
 from control.core.contrast_manager import ContrastManager
 from control.core.live_controller import LiveController
@@ -608,8 +609,11 @@ class HighContentScreeningGui(QMainWindow):
         live_only_mode=False,
         skip_init=False,
         *args,
+        reporter: StartupReporter = NULL_REPORTER,
         **kwargs,
     ):
+        # reporter is declared after *args so it stays keyword-only and is never
+        # forwarded into QMainWindow.__init__.
         super().__init__(*args, **kwargs)
 
         self.log = squid.logging.get_logger(self.__class__.__name__)
@@ -689,9 +693,13 @@ class HighContentScreeningGui(QMainWindow):
         # Load Slack settings from cache
         load_slack_settings_from_cache()
 
-        self.load_objects(is_simulation=is_simulation)
-        self.setup_hardware()
+        with reporter.step("gui_objects", core=True):
+            self.load_objects(is_simulation=is_simulation)
+        with reporter.step("gui_hardware", core=True):
+            self.setup_hardware()
 
+        # Builds movement_updater (make_connections needs it) but leaves its
+        # 100 ms timer stopped until the window is shown - see showEvent.
         self.setup_movement_updater()
 
         # Pre-declare and give types to all our widgets so type hinting tools work.  You should
@@ -735,9 +743,17 @@ class HighContentScreeningGui(QMainWindow):
 
         self.recordTabWidget: QTabWidget = QTabWidget()
         self.cameraTabWidget: QTabWidget = QTabWidget()
-        self.load_widgets()
-        self.setup_layout()
-        self.make_connections()
+        # These three are not pumped from the inside: load_widgets builds the
+        # napari/vispy viewers and make_connections wires ~90 signals one at a
+        # time, and delivering a queued signal into that half-wired graph is far
+        # worse than a few seconds of an unresponsive window. There is no
+        # hardware wait here to abort anyway.
+        with reporter.step("gui_widgets", core=True, interruptible=False):
+            self.load_widgets()
+        with reporter.step("gui_layout", core=True, interruptible=False):
+            self.setup_layout()
+        with reporter.step("gui_connections", core=True, interruptible=False):
+            self.make_connections()
 
         # Emit initial performance mode state to sync widgets
         self.signal_performance_mode_changed.emit(self.performance_mode)
@@ -750,41 +766,46 @@ class HighContentScreeningGui(QMainWindow):
 
         # Skip cached position restoration on restart (hardware position hasn't changed),
         # except Z when using Xeryon (Z was retracted during cleanup).
-        if self._skip_init:
-            if USE_XERYON and self.objective_changer:
-                if cached_pos := squid.stage.utils.get_cached_position():
-                    safety_z_mm = int(Z_HOME_SAFETY_POINT) / 1000.0
-                    target_z_mm = max(cached_pos.z_mm, safety_z_mm)
-                    self.log.info(f"Restoring cached Z position after Xeryon restart: {target_z_mm} mm")
-                    self.stage.move_z_to(target_z_mm)
-            else:
-                self.log.info("Skipping cached position restoration (--skip-init flag set)")
-        elif HOMING_ENABLED_X and HOMING_ENABLED_Y and HOMING_ENABLED_Z:
-            # TODO(imo): Why is moving to the cached position after boot hidden behind homing?
-            if cached_pos := squid.stage.utils.get_cached_position():
-                self.log.info(
-                    f"Cache position exists.  Moving to: ({cached_pos.x_mm},{cached_pos.y_mm},{cached_pos.z_mm}) [mm]"
-                )
-                self.stage.move_x_to(cached_pos.x_mm)
-                self.stage.move_y_to(cached_pos.y_mm)
-
-                if USE_PI_FOCUS_STAGE:
-                    # V-308: no Z_HOME_SAFETY_POINT floor; restore the cached absolute Z directly.
-                    # The PI driver clamps every move to the configured Z limits, so a stale
-                    # cached Z cannot command an out-of-range move.
-                    self.stage.move_z_to(cached_pos.z_mm)
-                elif (int(Z_HOME_SAFETY_POINT) / 1000.0) < cached_pos.z_mm:
-                    self.stage.move_z_to(cached_pos.z_mm)
+        # Physical stage moves: they block in the microcontroller wait with no
+        # callback, so Abort only lands once they finish.
+        with reporter.step("gui_position", interruptible=False):
+            if self._skip_init:
+                if USE_XERYON and self.objective_changer:
+                    if cached_pos := squid.stage.utils.get_cached_position():
+                        safety_z_mm = int(Z_HOME_SAFETY_POINT) / 1000.0
+                        target_z_mm = max(cached_pos.z_mm, safety_z_mm)
+                        self.log.info(f"Restoring cached Z position after Xeryon restart: {target_z_mm} mm")
+                        self.stage.move_z_to(target_z_mm)
                 else:
-                    self.log.info(f"Cache z position is smaller than Z_HOME_SAFETY_POINT, move to Z_HOME_SAFETY_POINT")
-                    self.stage.move_z_to(int(Z_HOME_SAFETY_POINT) / 1000.0)
-            else:
-                self.log.info(f"Cache position is not exists.  Moving Z axis to safety position")
-                squid.stage.utils.move_z_axis_to_safety_position(self.stage)
+                    self.log.info("Skipping cached position restoration (--skip-init flag set)")
+            elif HOMING_ENABLED_X and HOMING_ENABLED_Y and HOMING_ENABLED_Z:
+                # TODO(imo): Why is moving to the cached position after boot hidden behind homing?
+                if cached_pos := squid.stage.utils.get_cached_position():
+                    self.log.info(
+                        f"Cache position exists.  Moving to: ({cached_pos.x_mm},{cached_pos.y_mm},{cached_pos.z_mm}) [mm]"
+                    )
+                    self.stage.move_x_to(cached_pos.x_mm)
+                    self.stage.move_y_to(cached_pos.y_mm)
 
-            if ENABLE_WELLPLATE_MULTIPOINT:
-                self.wellplateMultiPointWidget.init_z()
-            self.flexibleMultiPointWidget.init_z()
+                    if USE_PI_FOCUS_STAGE:
+                        # V-308: no Z_HOME_SAFETY_POINT floor; restore the cached absolute Z directly.
+                        # The PI driver clamps every move to the configured Z limits, so a stale
+                        # cached Z cannot command an out-of-range move.
+                        self.stage.move_z_to(cached_pos.z_mm)
+                    elif (int(Z_HOME_SAFETY_POINT) / 1000.0) < cached_pos.z_mm:
+                        self.stage.move_z_to(cached_pos.z_mm)
+                    else:
+                        self.log.info(
+                            f"Cache z position is smaller than Z_HOME_SAFETY_POINT, move to Z_HOME_SAFETY_POINT"
+                        )
+                        self.stage.move_z_to(int(Z_HOME_SAFETY_POINT) / 1000.0)
+                else:
+                    self.log.info(f"Cache position is not exists.  Moving Z axis to safety position")
+                    squid.stage.utils.move_z_axis_to_safety_position(self.stage)
+
+                if ENABLE_WELLPLATE_MULTIPOINT:
+                    self.wellplateMultiPointWidget.init_z()
+                self.flexibleMultiPointWidget.init_z()
 
         # Create the menu bar
         menubar = self.menuBar()
@@ -1695,7 +1716,15 @@ class HighContentScreeningGui(QMainWindow):
         self.movement_update_timer = QTimer()
         self.movement_update_timer.setInterval(100)
         self.movement_update_timer.timeout.connect(self.movement_updater.do_update)
-        self.movement_update_timer.start()
+        # Deliberately not started here: do_update polls stage.get_pos(), and the
+        # startup window pumps the event loop during initialization, so a tick
+        # now would hit a half-built GUI and a stage that may still be homing.
+        # showEvent calls start_movement_updates() once the window is up.
+
+    def start_movement_updates(self):
+        """Begin polling the stage for movement updates."""
+        if not self.movement_update_timer.isActive():
+            self.movement_update_timer.start()
 
     def makeNapariConnections(self):
         """Initialize all Napari connections in one place"""
@@ -2697,6 +2726,12 @@ class HighContentScreeningGui(QMainWindow):
         self._show_event_initialized = True
         self._update_ram_monitor_visibility()
         self._connect_warning_handler()
+        # Started here rather than in __init__ so their 100 ms stage polling
+        # cannot fire into a half-built GUI while the startup window is pumping
+        # the event loop.
+        self.start_movement_updates()
+        if self.navigationWidget is not None:
+            self.navigationWidget.start_polling()
 
     def _on_plate_view_fov_clicked(self, well_id: str, fov_index: int) -> None:
         """Handle double-click on plate view: navigate NDViewer to FOV and switch tab."""

--- a/software/control/microscope.py
+++ b/software/control/microscope.py
@@ -16,6 +16,7 @@ from control.lighting import LightSourceType, IntensityControlMode, ShutterContr
 from control.microcontroller import Microcontroller
 from control.piezo import PiezoStage
 from control.serial_peripherals import SciMicroscopyLEDArray
+from control.startup_progress import NULL_REPORTER, StartupReporter, is_squid_filter_wheel
 from squid.abc import CameraAcquisitionMode, AbstractCamera, AbstractStage, AbstractFilterWheelController
 from squid.stage.cephla import CephlaStage
 from squid.stage.prior import PriorStage
@@ -93,10 +94,29 @@ def _should_simulate(global_simulated: bool, component_override: bool) -> bool:
     return bool(component_override)
 
 
+def _close_serial_connection(device) -> None:
+    """Release a device that owns a SerialDevice but has no close() of its own.
+
+    XLight and SciMicroscopyLEDArray both fall into this category, which is why
+    the teardown registry takes an explicit callable instead of duck-typing a
+    .close() method.
+    """
+    if device is None:
+        return
+    connection = getattr(device, "serial_connection", None)
+    if connection is not None:
+        connection.close()
+
+
 class MicroscopeAddons:
     @staticmethod
     def build_from_global_config(
-        stage: AbstractStage, micro: Optional[Microcontroller], simulated: bool = False, skip_init: bool = False
+        stage: AbstractStage,
+        micro: Optional[Microcontroller],
+        simulated: bool = False,
+        skip_init: bool = False,
+        *,
+        reporter: StartupReporter = NULL_REPORTER,
     ) -> "MicroscopeAddons":
         # Per-component simulation settings
         spinning_disk_simulated = _should_simulate(simulated, control._def.SIMULATE_SPINNING_DISK)
@@ -105,53 +125,74 @@ class MicroscopeAddons:
         laser_af_camera_simulated = _should_simulate(simulated, control._def.SIMULATE_LASER_AF_CAMERA)
         fluidics_simulated = _should_simulate(simulated, control._def.SIMULATE_FLUIDICS)
 
+        # Every device below is wrapped in reporter.step(). None of these are
+        # marked core, so a failure is recorded and the sweep carries on - the
+        # operator gets one dialog listing everything that is off, instead of
+        # power-cycling one box at a time. Each device is also registered with
+        # the reporter as soon as it exists, because these locals are the only
+        # reference to them until this function returns; without that an abort
+        # would strand every open port.
         xlight = None
         if control._def.ENABLE_SPINNING_DISK_CONFOCAL and not control._def.USE_DRAGONFLY:
             # TODO: For user compatibility, when ENABLE_SPINNING_DISK_CONFOCAL is True, we use XLight/Cicero on default.
             # This needs to be changed when we figure out better machine configuration structure.
-            xlight = (
-                serial_peripherals.XLight(
-                    control._def.XLIGHT_SERIAL_NUMBER,
-                    control._def.XLIGHT_SLEEP_TIME_FOR_WHEEL,
+            with reporter.step("spinning_disk"):
+                xlight = (
+                    serial_peripherals.XLight(
+                        control._def.XLIGHT_SERIAL_NUMBER,
+                        control._def.XLIGHT_SLEEP_TIME_FOR_WHEEL,
+                    )
+                    if not spinning_disk_simulated
+                    else serial_peripherals.XLight_Simulation()
                 )
-                if not spinning_disk_simulated
-                else serial_peripherals.XLight_Simulation()
-            )
+                # XLight has no close() of its own.
+                reporter.register_opened("spinning disk", lambda: _close_serial_connection(xlight))
 
         dragonfly = None
         if control._def.ENABLE_SPINNING_DISK_CONFOCAL and control._def.USE_DRAGONFLY:
-            dragonfly = (
-                serial_peripherals.Dragonfly(SN=control._def.DRAGONFLY_SERIAL_NUMBER)
-                if not spinning_disk_simulated
-                else serial_peripherals.Dragonfly_Simulation()
-            )
+            with reporter.step("spinning_disk"):
+                dragonfly = (
+                    serial_peripherals.Dragonfly(SN=control._def.DRAGONFLY_SERIAL_NUMBER)
+                    if not spinning_disk_simulated
+                    else serial_peripherals.Dragonfly_Simulation()
+                )
+                reporter.register_opened("spinning disk", dragonfly.close)
 
         nl5 = None
         if control._def.ENABLE_NL5:
-            nl5 = NL5.NL5() if not simulated else NL5.NL5_Simulation()
+            with reporter.step("nl5"):
+                nl5 = NL5.NL5() if not simulated else NL5.NL5_Simulation()
 
         cellx = None
         if control._def.ENABLE_CELLX:
-            cellx = (
-                serial_peripherals.CellX(control._def.CELLX_SN)
-                if not simulated
-                else serial_peripherals.CellX_Simulation()
-            )
+            with reporter.step("cellx"):
+                cellx = (
+                    serial_peripherals.CellX(control._def.CELLX_SN)
+                    if not simulated
+                    else serial_peripherals.CellX_Simulation()
+                )
+                reporter.register_opened("CellX", cellx.close)
 
         emission_filter_wheel = None
         fw_config = squid.config.get_filter_wheel_config()
         if fw_config:
-            emission_filter_wheel = squid.filter_wheel_controller.utils.get_filter_wheel_controller(
-                fw_config, microcontroller=micro, simulated=filter_wheel_simulated, skip_init=skip_init
-            )
+            # The Squid variant rides on the microcontroller and raises hard
+            # without it; Zaber/Optospin own their own port and are survivable.
+            fw_core = is_squid_filter_wheel(fw_config)
+            with reporter.step("filter_wheel", core=fw_core):
+                emission_filter_wheel = squid.filter_wheel_controller.utils.get_filter_wheel_controller(
+                    fw_config, microcontroller=micro, simulated=filter_wheel_simulated, skip_init=skip_init
+                )
+                reporter.register_opened("emission filter wheel", emission_filter_wheel.close)
 
         objective_changer = None
         if control._def.USE_XERYON:
-            objective_changer = (
-                ObjectiveChanger2PosController(sn=control._def.XERYON_SERIAL_NUMBER, stage=stage)
-                if not objective_changer_simulated
-                else ObjectiveChanger2PosController_Simulation(sn=control._def.XERYON_SERIAL_NUMBER, stage=stage)
-            )
+            with reporter.step("objective_changer"):
+                objective_changer = (
+                    ObjectiveChanger2PosController(sn=control._def.XERYON_SERIAL_NUMBER, stage=stage)
+                    if not objective_changer_simulated
+                    else ObjectiveChanger2PosController_Simulation(sn=control._def.XERYON_SERIAL_NUMBER, stage=stage)
+                )
         elif control._def.USE_OBJECTIVE_TURRET:
             turret_kwargs = dict(
                 serial_number=control._def.OBJECTIVE_TURRET_SERIAL_NUMBER,
@@ -161,57 +202,69 @@ class MicroscopeAddons:
                 offset_pulses=control._def.OBJECTIVE_TURRET_OFFSET_PULSES,
                 stage=stage,
             )
-            objective_changer = (
-                ObjectiveTurret4PosController(**turret_kwargs)
-                if not objective_changer_simulated
-                else ObjectiveTurret4PosControllerSimulation(**turret_kwargs)
-            )
+            with reporter.step("objective_changer"):
+                objective_changer = (
+                    ObjectiveTurret4PosController(**turret_kwargs)
+                    if not objective_changer_simulated
+                    else ObjectiveTurret4PosControllerSimulation(**turret_kwargs)
+                )
+                reporter.register_opened("objective turret", objective_changer.close)
 
         camera_focus = None
         if control._def.SUPPORT_LASER_AUTOFOCUS:
-            camera_focus = squid.camera.utils.get_camera(
-                squid.config.get_autofocus_camera_config(), simulated=laser_af_camera_simulated
-            )
+            with reporter.step("camera_focus"):
+                camera_focus = squid.camera.utils.get_camera(
+                    squid.config.get_autofocus_camera_config(), simulated=laser_af_camera_simulated
+                )
+                reporter.register_opened("laser autofocus camera", camera_focus.close)
 
         fluidics = None
         if control._def.RUN_FLUIDICS:
-            # Uninitialized on purpose: the Fluidics tab's Initialize button loads the config and brings the
-            # system up (blocking, off the GUI thread). See control/fluidics_system.py.
-            fluidics = FluidicsService(
-                default_config_path=control._def.FLUIDICS_CONFIG_PATH, simulated=fluidics_simulated
-            )
+            with reporter.step("fluidics"):
+                # Uninitialized on purpose: the Fluidics tab's Initialize button loads the config and brings the
+                # system up (blocking, off the GUI thread). See control/fluidics_system.py.
+                fluidics = FluidicsService(
+                    default_config_path=control._def.FLUIDICS_CONFIG_PATH, simulated=fluidics_simulated
+                )
 
         piezo_stage = None
         if control._def.HAS_OBJECTIVE_PIEZO:
-            if not micro:
-                raise ValueError("Cannot create PiezoStage without a Microcontroller.")
-            piezo_stage = PiezoStage(
-                microcontroller=micro,
-                config={
-                    "OBJECTIVE_PIEZO_HOME_UM": control._def.OBJECTIVE_PIEZO_HOME_UM,
-                    "OBJECTIVE_PIEZO_RANGE_UM": control._def.OBJECTIVE_PIEZO_RANGE_UM,
-                    "OBJECTIVE_PIEZO_CONTROL_VOLTAGE_RANGE": control._def.OBJECTIVE_PIEZO_CONTROL_VOLTAGE_RANGE,
-                    "OBJECTIVE_PIEZO_FLIP_DIR": control._def.OBJECTIVE_PIEZO_FLIP_DIR,
-                },
-            )
+            with reporter.step("piezo", core=True):
+                if not micro:
+                    raise ValueError("Cannot create PiezoStage without a Microcontroller.")
+                piezo_stage = PiezoStage(
+                    microcontroller=micro,
+                    config={
+                        "OBJECTIVE_PIEZO_HOME_UM": control._def.OBJECTIVE_PIEZO_HOME_UM,
+                        "OBJECTIVE_PIEZO_RANGE_UM": control._def.OBJECTIVE_PIEZO_RANGE_UM,
+                        "OBJECTIVE_PIEZO_CONTROL_VOLTAGE_RANGE": control._def.OBJECTIVE_PIEZO_CONTROL_VOLTAGE_RANGE,
+                        "OBJECTIVE_PIEZO_FLIP_DIR": control._def.OBJECTIVE_PIEZO_FLIP_DIR,
+                    },
+                )
 
         sci_microscopy_led_array = None
         if control._def.SUPPORT_SCIMICROSCOPY_LED_ARRAY:
-            # to do: add error handling
-            sci_microscopy_led_array = serial_peripherals.SciMicroscopyLEDArray(
-                control._def.SCIMICROSCOPY_LED_ARRAY_SN,
-                control._def.SCIMICROSCOPY_LED_ARRAY_DISTANCE,
-                control._def.SCIMICROSCOPY_LED_ARRAY_TURN_ON_DELAY,
-            )
-            sci_microscopy_led_array.set_NA(control._def.SCIMICROSCOPY_LED_ARRAY_DEFAULT_NA)
+            with reporter.step("led_array"):
+                sci_microscopy_led_array = serial_peripherals.SciMicroscopyLEDArray(
+                    control._def.SCIMICROSCOPY_LED_ARRAY_SN,
+                    control._def.SCIMICROSCOPY_LED_ARRAY_DISTANCE,
+                    control._def.SCIMICROSCOPY_LED_ARRAY_TURN_ON_DELAY,
+                )
+                # SciMicroscopyLEDArray has no close() of its own.
+                reporter.register_opened(
+                    "SciMicroscopy LED array", lambda: _close_serial_connection(sci_microscopy_led_array)
+                )
+                sci_microscopy_led_array.set_NA(control._def.SCIMICROSCOPY_LED_ARRAY_DEFAULT_NA)
 
         laser_engine = None
         if control._def.USE_SQUID_LASER_ENGINE:
-            laser_engine = (
-                squid_laser_engine.SquidLaserEngine(sn=control._def.SQUID_LASER_ENGINE_SN)
-                if not simulated
-                else squid_laser_engine.SquidLaserEngine_Simulation()
-            )
+            with reporter.step("laser_engine"):
+                laser_engine = (
+                    squid_laser_engine.SquidLaserEngine(sn=control._def.SQUID_LASER_ENGINE_SN)
+                    if not simulated
+                    else squid_laser_engine.SquidLaserEngine_Simulation()
+                )
+                reporter.register_opened("laser engine", laser_engine.close)
 
         return MicroscopeAddons(
             xlight,
@@ -253,66 +306,82 @@ class MicroscopeAddons:
         self.sci_microscopy_led_array = sci_microscopy_led_array
         self.squid_laser_engine = squid_laser_engine
 
-    def prepare_for_use(self, skip_init: bool = False):
+    def prepare_for_use(self, skip_init: bool = False, *, reporter: StartupReporter = NULL_REPORTER):
         """
         Prepare all the addon hardware for immediate use.
 
         Args:
             skip_init: If True, skip homing operations (e.g., during restart).
+            reporter: Startup progress sink; defaults to a no-op.
         """
         if self.emission_filter_wheel:
-            fw_config = squid.config.get_filter_wheel_config()
-            self.emission_filter_wheel.initialize(fw_config.indices)
-            if not skip_init:
-                try:
-                    self.emission_filter_wheel.home()
-                except Exception:
-                    # A filter-wheel homing failure must not brick the whole
-                    # microscope: the wheel controller leaves its tracked
-                    # position unchanged (and possibly stale) on failure, so
-                    # treat the position as unknown, come up anyway, and let the
-                    # operator re-home from the GUI rather than aborting startup
-                    # before the window even opens.
-                    _log.error(
-                        "Filter wheel homing failed during startup; continuing with the "
-                        "filter wheel position unknown. Re-home from the GUI before relying "
-                        "on filter selection.",
-                        exc_info=True,
-                    )
+            with reporter.step("prep_filter_wheel") as progress:
+                fw_config = squid.config.get_filter_wheel_config()
+                self.emission_filter_wheel.initialize(fw_config.indices)
+                if not skip_init:
+                    try:
+                        self.emission_filter_wheel.home()
+                    except Exception:
+                        # A filter-wheel homing failure must not brick the whole
+                        # microscope: the wheel controller leaves its tracked
+                        # position unchanged (and possibly stale) on failure, so
+                        # treat the position as unknown, come up anyway, and let the
+                        # operator re-home from the GUI rather than aborting startup
+                        # before the window even opens.
+                        _log.error(
+                            "Filter wheel homing failed during startup; continuing with the "
+                            "filter wheel position unknown. Re-home from the GUI before relying "
+                            "on filter selection.",
+                            exc_info=True,
+                        )
+                        # A warning row, deliberately not a failure: machines
+                        # that boot fine today must keep booting.
+                        progress.warning("homing failed - position unknown, re-home from the GUI")
         if self.piezo_stage and not skip_init:
-            self.piezo_stage.home()
+            with reporter.step("prep_piezo"):
+                self.piezo_stage.home()
         if self.squid_laser_engine:
-            # start() may raise if the USB device is missing — intentional hard fail
-            # when USE_SQUID_LASER_ENGINE=True so we don't silently disable it.
-            self.squid_laser_engine.start()
-            self.squid_laser_engine.wake_up_all()  # fire-and-forget
+            with reporter.step("prep_laser_engine") as progress:
+                # start() may raise if the USB device is missing — intentional hard fail
+                # when USE_SQUID_LASER_ENGINE=True so we don't silently disable it.
+                self.squid_laser_engine.start()
+                self.squid_laser_engine.wake_up_all()  # fire-and-forget
+                # Reaching ACTIVE takes minutes; that wait belongs to the
+                # acquisition-time gate (wait_until_ready), not to startup.
+                progress.detail("started; warms up in the background")
 
 
 class LowLevelDrivers:
     @staticmethod
-    def build_from_global_config(simulated: bool = False, skip_init: bool = False) -> "LowLevelDrivers":
+    def build_from_global_config(
+        simulated: bool = False, skip_init: bool = False, *, reporter: StartupReporter = NULL_REPORTER
+    ) -> "LowLevelDrivers":
         # Per-component simulation for microcontroller
         mcu_simulated = _should_simulate(simulated, control._def.SIMULATE_MICROCONTROLLER)
 
-        micro_serial_device = (
-            control.microcontroller.get_microcontroller_serial_device(
-                version=control._def.CONTROLLER_VERSION, sn=control._def.CONTROLLER_SN
+        # Core: without the microcontroller there is no stage, no illumination
+        # and no triggering, so there is nothing useful left to probe.
+        with reporter.step("microcontroller", core=True):
+            micro_serial_device = (
+                control.microcontroller.get_microcontroller_serial_device(
+                    version=control._def.CONTROLLER_VERSION, sn=control._def.CONTROLLER_SN
+                )
+                if not mcu_simulated
+                else control.microcontroller.get_microcontroller_serial_device(simulated=True)
             )
-            if not mcu_simulated
-            else control.microcontroller.get_microcontroller_serial_device(simulated=True)
-        )
-        # Skip MCU reset/initialize when restarting (hardware already configured)
-        micro = control.microcontroller.Microcontroller(
-            serial_device=micro_serial_device,
-            reset_and_initialize=not skip_init,
-        )
+            # Skip MCU reset/initialize when restarting (hardware already configured)
+            micro = control.microcontroller.Microcontroller(
+                serial_device=micro_serial_device,
+                reset_and_initialize=not skip_init,
+            )
+            reporter.register_opened("microcontroller", micro.close)
 
         return LowLevelDrivers(microcontroller=micro)
 
     def __init__(self, microcontroller: Optional[Microcontroller] = None):
         self.microcontroller: Optional[Microcontroller] = microcontroller
 
-    def prepare_for_use(self, skip_init: bool = False):
+    def prepare_for_use(self, skip_init: bool = False, *, reporter: StartupReporter = NULL_REPORTER):
         # Note: Currently no homing operations here, but accepting skip_init for API consistency
         if self.microcontroller and control._def.HAS_OBJECTIVE_PIEZO:
             # Configure DAC gains for objective piezo
@@ -324,44 +393,52 @@ class LowLevelDrivers:
 
 class Microscope:
     @staticmethod
-    def build_from_global_config(simulated: bool = False, skip_init: bool = False) -> "Microscope":
-        low_level_devices = LowLevelDrivers.build_from_global_config(simulated, skip_init=skip_init)
+    def build_from_global_config(
+        simulated: bool = False, skip_init: bool = False, *, reporter: StartupReporter = NULL_REPORTER
+    ) -> "Microscope":
+        low_level_devices = LowLevelDrivers.build_from_global_config(simulated, skip_init=skip_init, reporter=reporter)
 
         # Per-component simulation for camera
         camera_simulated = _should_simulate(simulated, control._def.SIMULATE_CAMERA)
 
         stage_config = squid.config.get_stage_config()
-        if control._def.USE_PRIOR_STAGE:
-            stage = PriorStage(sn=control._def.PRIOR_STAGE_SN, stage_config=stage_config)
-        else:
-            if low_level_devices.microcontroller is None:
-                raise ValueError("For a cephla stage microscope, you must provide a microcontroller.")
-            stage = CephlaStage(low_level_devices.microcontroller, stage_config)
+        with reporter.step("stage_xy", core=True):
+            if control._def.USE_PRIOR_STAGE:
+                stage = PriorStage(sn=control._def.PRIOR_STAGE_SN, stage_config=stage_config)
+            else:
+                if low_level_devices.microcontroller is None:
+                    raise ValueError("For a cephla stage microscope, you must provide a microcontroller.")
+                stage = CephlaStage(low_level_devices.microcontroller, stage_config)
+            reporter.register_opened("XY stage", stage.close)
 
         if control._def.USE_PI_FOCUS_STAGE:
             pi_simulated = _should_simulate(simulated, control._def.SIMULATE_PI_FOCUS_STAGE)
-            # Normalise SN to a string (the config reader may coerce an all-digit serial to int);
-            # treat only "" / None as "unset" so a numeric serial of 0 is not lost.
-            pi_sn = control._def.PI_FOCUS_STAGE_SN
-            pi_sn = str(pi_sn) if pi_sn not in (None, "") else None
-            z_stage = squid.stage.pi.connect_pi_focus_stage(
-                simulated=pi_simulated,
-                serialnum=pi_sn,
-                serial_port=control._def.PI_FOCUS_SERIAL_PORT or None,
-                baudrate=control._def.PI_FOCUS_BAUDRATE,
-                axis=control._def.PI_FOCUS_AXIS,
-                reference=control._def.PI_FOCUS_REFERENCE_ON_STARTUP and not skip_init,
-                velocity_mm_s=control._def.PI_FOCUS_VELOCITY_MM_S or None,
-                home_mm=control._def.OBJECTIVE_RETRACTED_POS_MM,
-                invert_z=control._def.PI_FOCUS_INVERT_Z,
-                home_to_positive_limit=control._def.PI_FOCUS_HOME_TO_POSITIVE_LIMIT,
-                z_travel_mm=control._def.PI_FOCUS_Z_TRAVEL_MM,
-                stage_config=stage_config,
-            )
-            stage = squid.stage.pi.CombinedStage(xy_stage=stage, z_stage=z_stage, stage_config=stage_config)
+            # Referencing physically sweeps the axis and blocks inside pipython
+            # with no callback, so Abort cannot interrupt it.
+            with reporter.step("stage_z", core=True, interruptible=False):
+                # Normalise SN to a string (the config reader may coerce an all-digit serial to int);
+                # treat only "" / None as "unset" so a numeric serial of 0 is not lost.
+                pi_sn = control._def.PI_FOCUS_STAGE_SN
+                pi_sn = str(pi_sn) if pi_sn not in (None, "") else None
+                z_stage = squid.stage.pi.connect_pi_focus_stage(
+                    simulated=pi_simulated,
+                    serialnum=pi_sn,
+                    serial_port=control._def.PI_FOCUS_SERIAL_PORT or None,
+                    baudrate=control._def.PI_FOCUS_BAUDRATE,
+                    axis=control._def.PI_FOCUS_AXIS,
+                    reference=control._def.PI_FOCUS_REFERENCE_ON_STARTUP and not skip_init,
+                    velocity_mm_s=control._def.PI_FOCUS_VELOCITY_MM_S or None,
+                    home_mm=control._def.OBJECTIVE_RETRACTED_POS_MM,
+                    invert_z=control._def.PI_FOCUS_INVERT_Z,
+                    home_to_positive_limit=control._def.PI_FOCUS_HOME_TO_POSITIVE_LIMIT,
+                    z_travel_mm=control._def.PI_FOCUS_Z_TRAVEL_MM,
+                    stage_config=stage_config,
+                )
+                reporter.register_opened("Z focus stage", z_stage.close)
+                stage = squid.stage.pi.CombinedStage(xy_stage=stage, z_stage=z_stage, stage_config=stage_config)
 
         addons = MicroscopeAddons.build_from_global_config(
-            stage, low_level_devices.microcontroller, simulated=simulated, skip_init=skip_init
+            stage, low_level_devices.microcontroller, simulated=simulated, skip_init=skip_init, reporter=reporter
         )
 
         cam_trigger_log = squid.logging.get_logger("camera hw functions")
@@ -389,41 +466,76 @@ class Microscope:
 
             return True
 
-        camera = squid.camera.utils.get_camera(
-            config=squid.config.get_camera_config(),
-            simulated=camera_simulated,
-            hw_trigger_fn=acquisition_camera_hw_trigger_fn,
-            hw_set_strobe_delay_ms_fn=acquisition_camera_hw_strobe_delay_fn,
-        )
+        with reporter.step("camera", core=True):
+            camera = squid.camera.utils.get_camera(
+                config=squid.config.get_camera_config(),
+                simulated=camera_simulated,
+                hw_trigger_fn=acquisition_camera_hw_trigger_fn,
+                hw_set_strobe_delay_ms_fn=acquisition_camera_hw_strobe_delay_fn,
+            )
+            reporter.register_opened("main camera", camera.close)
 
+        # The external light source is built as its own (independent) step so a
+        # warm-up or power failure there is reported without stopping the sweep,
+        # then consumed by the illumination controller below. light_source stays
+        # None if that step failed, which the controller step turns into a clear
+        # message instead of an UnboundLocalError.
+        light_source = None
+        light_source_type = None
         if control._def.USE_LDI_SERIAL_CONTROL and not simulated:
-            ldi = serial_peripherals.LDI()
-
-            illumination_controller = IlluminationController(
-                low_level_devices.microcontroller, ldi.intensity_mode, ldi.shutter_mode, LightSourceType.LDI, ldi
-            )
+            light_source_type = LightSourceType.LDI
+            # initialize() is normally called from IlluminationController, but
+            # doing it here first lets the warm-up handshake report progress and
+            # honour Abort. By the time IlluminationController repeats it, the
+            # engine is in RUN state and it is one fast round trip.
+            with reporter.step("light_source") as progress:
+                ldi = serial_peripherals.LDI()
+                # Register the raw port close, NOT IlluminationController.close():
+                # that one politely walks every channel and takes ~55s against a
+                # wedged LDI, which is an eternity on the abort path.
+                reporter.register_opened("LDI", ldi.serial_connection.close)
+                ldi.initialize(
+                    timeout_s=reporter.device_timeout_s,
+                    cancel_fn=reporter.cancel_fn(),
+                    on_retry=progress.on_warmup_retry,
+                    sleep_fn=reporter.sleep_fn,
+                )
+                light_source = ldi
         elif control._def.USE_CELESTA_ETHERNET_CONTROL and not simulated:
-            celesta = control.celesta.CELESTA()
-            illumination_controller = IlluminationController(
-                low_level_devices.microcontroller,
-                IntensityControlMode.Software,
-                ShutterControlMode.TTL,
-                LightSourceType.CELESTA,
-                celesta,
-            )
+            light_source_type = LightSourceType.CELESTA
+            with reporter.step("light_source"):
+                light_source = control.celesta.CELESTA()
         elif control._def.USE_ANDOR_LASER_CONTROL and not simulated:
-            andor_laser = control.illumination_andor.AndorLaser(
-                control._def.ANDOR_LASER_VID, control._def.ANDOR_LASER_PID
-            )
-            illumination_controller = IlluminationController(
-                low_level_devices.microcontroller,
-                IntensityControlMode.Software,
-                ShutterControlMode.TTL,
-                LightSourceType.AndorLaser,
-                andor_laser,
-            )
-        else:
-            illumination_controller = IlluminationController(low_level_devices.microcontroller)
+            light_source_type = LightSourceType.AndorLaser
+            with reporter.step("light_source"):
+                light_source = control.illumination_andor.AndorLaser(
+                    control._def.ANDOR_LASER_VID, control._def.ANDOR_LASER_PID
+                )
+
+        with reporter.step("illumination_controller", core=True):
+            if light_source_type is not None and light_source is None:
+                raise RuntimeError(
+                    "The configured light source did not initialize, so illumination cannot be "
+                    "set up. See the light source entry above for the underlying failure."
+                )
+            if light_source_type == LightSourceType.LDI:
+                illumination_controller = IlluminationController(
+                    low_level_devices.microcontroller,
+                    light_source.intensity_mode,
+                    light_source.shutter_mode,
+                    LightSourceType.LDI,
+                    light_source,
+                )
+            elif light_source_type is not None:
+                illumination_controller = IlluminationController(
+                    low_level_devices.microcontroller,
+                    IntensityControlMode.Software,
+                    ShutterControlMode.TTL,
+                    light_source_type,
+                    light_source,
+                )
+            else:
+                illumination_controller = IlluminationController(low_level_devices.microcontroller)
 
         return Microscope(
             stage=stage,
@@ -433,6 +545,7 @@ class Microscope:
             low_level_drivers=low_level_devices,
             simulated=simulated,
             skip_init=skip_init,
+            reporter=reporter,
         )
 
     def __init__(
@@ -446,7 +559,11 @@ class Microscope:
         simulated: bool = False,
         skip_prepare_for_use: bool = False,
         skip_init: bool = False,
+        *,
+        reporter: StartupReporter = NULL_REPORTER,
     ):
+        # reporter is deliberately not stored on self: it owns a QWidget, and a
+        # Microscope outlives the startup window.
         self._log = squid.logging.get_logger(self.__class__.__name__)
         self._closed = False
 
@@ -470,15 +587,16 @@ class Microscope:
         # by run_auto_migration() in main_hcs.py before Microscope is created
 
         # Load default profile (ensures configs exist)
-        profiles = self.config_repo.get_available_profiles()
-        if profiles:
-            self.config_repo.load_profile(profiles[0])
-        else:
-            # Create a default profile if none exist - load_profile() will call
-            # ensure_default_configs() to generate configs from illumination_channel_config.yaml
-            self._log.info("No profiles found, creating 'default' profile")
-            self.config_repo.create_profile("default")
-            self.config_repo.load_profile("default")
+        with reporter.step("config_profiles", core=True):
+            profiles = self.config_repo.get_available_profiles()
+            if profiles:
+                self.config_repo.load_profile(profiles[0])
+            else:
+                # Create a default profile if none exist - load_profile() will call
+                # ensure_default_configs() to generate configs from illumination_channel_config.yaml
+                self._log.info("No profiles found, creating 'default' profile")
+                self.config_repo.create_profile("default")
+                self.config_repo.load_profile("default")
 
         self.contrast_manager: ContrastManager = ContrastManager()
         self.stream_handler: StreamHandler = StreamHandler(handler_functions=stream_handler_callbacks)
@@ -498,10 +616,14 @@ class Microscope:
 
         # Sync confocal mode from hardware (must be after LiveController creation)
         if control._def.ENABLE_SPINNING_DISK_CONFOCAL:
-            self._sync_confocal_mode_from_hardware()
+            with reporter.step("confocal_sync") as progress:
+                if not self._sync_confocal_mode_from_hardware():
+                    # This path already swallows its own errors and boots anyway;
+                    # surface it as a warning rather than changing that.
+                    progress.warning("could not read disk state from hardware")
 
         if not skip_prepare_for_use:
-            self._prepare_for_use(skip_init=skip_init)
+            self._prepare_for_use(skip_init=skip_init, reporter=reporter)
 
     @property
     def config_repo(self) -> ConfigRepository:
@@ -515,93 +637,106 @@ class Microscope:
         self._config_repo = repo
         self.illumination_controller.config_repo = repo
 
-    def _prepare_for_use(self, skip_init: bool = False):
-        self.low_level_drivers.prepare_for_use(skip_init=skip_init)
-        self.addons.prepare_for_use(skip_init=skip_init)
+    def _prepare_for_use(self, skip_init: bool = False, *, reporter: StartupReporter = NULL_REPORTER):
+        self.low_level_drivers.prepare_for_use(skip_init=skip_init, reporter=reporter)
+        self.addons.prepare_for_use(skip_init=skip_init, reporter=reporter)
 
         # Configure serial watchdog for illumination safety (requires firmware v1.1+)
         if self.low_level_drivers.microcontroller:
-            mcu = self.low_level_drivers.microcontroller
-            if mcu.firmware_version >= (1, 1):
-                timeout_s = control._def.WATCHDOG_TIMEOUT_S
-                mcu.set_watchdog_timeout(timeout_s)
-                mcu.wait_till_operation_is_completed()
-                mcu.start_heartbeat(interval_s=timeout_s / 2)
-                self._log.info(f"Illumination watchdog enabled: timeout={timeout_s}s, heartbeat={timeout_s / 2}s")
+            with reporter.step("prep_watchdog") as progress:
+                mcu = self.low_level_drivers.microcontroller
+                if mcu.firmware_version >= (1, 1):
+                    timeout_s = control._def.WATCHDOG_TIMEOUT_S
+                    mcu.set_watchdog_timeout(timeout_s)
+                    mcu.wait_till_operation_is_completed()
+                    mcu.start_heartbeat(interval_s=timeout_s / 2)
+                    self._log.info(f"Illumination watchdog enabled: timeout={timeout_s}s, heartbeat={timeout_s / 2}s")
+                else:
+                    self._log.warning(
+                        f"Illumination watchdog not available: firmware v{mcu.firmware_version[0]}.{mcu.firmware_version[1]} "
+                        "requires v1.1+"
+                    )
+                    progress.warning(
+                        f"not available: firmware v{mcu.firmware_version[0]}.{mcu.firmware_version[1]} requires v1.1+"
+                    )
+
+        with reporter.step("prep_camera", core=True):
+            self.camera.set_pixel_format(
+                squid.config.CameraPixelFormat.from_string(control._def.CAMERA_CONFIG.PIXEL_FORMAT_DEFAULT)
+            )
+            if control._def.DEFAULT_TRIGGER_MODE == control._def.TriggerMode.HARDWARE:
+                if not self.low_level_drivers.microcontroller:
+                    raise RuntimeError("Hardware trigger mode requires a microcontroller, but none is configured.")
+                self._log.info("Setting acquisition mode to HARDWARE_TRIGGER")
+                self.camera.set_acquisition_mode(CameraAcquisitionMode.HARDWARE_TRIGGER)
+                self.low_level_drivers.microcontroller.set_trigger_mode(control._def.HARDWARE_TRIGGER_MODE)
+                self.live_controller.trigger_mode = control._def.TriggerMode.HARDWARE
             else:
-                self._log.warning(
-                    f"Illumination watchdog not available: firmware v{mcu.firmware_version[0]}.{mcu.firmware_version[1]} "
-                    "requires v1.1+"
-                )
+                self.camera.set_acquisition_mode(CameraAcquisitionMode.SOFTWARE_TRIGGER)
+                self.live_controller.trigger_mode = control._def.TriggerMode.SOFTWARE
 
-        self.camera.set_pixel_format(
-            squid.config.CameraPixelFormat.from_string(control._def.CAMERA_CONFIG.PIXEL_FORMAT_DEFAULT)
-        )
-        if control._def.DEFAULT_TRIGGER_MODE == control._def.TriggerMode.HARDWARE:
-            if not self.low_level_drivers.microcontroller:
-                raise RuntimeError("Hardware trigger mode requires a microcontroller, but none is configured.")
-            self._log.info("Setting acquisition mode to HARDWARE_TRIGGER")
-            self.camera.set_acquisition_mode(CameraAcquisitionMode.HARDWARE_TRIGGER)
-            self.low_level_drivers.microcontroller.set_trigger_mode(control._def.HARDWARE_TRIGGER_MODE)
-            self.live_controller.trigger_mode = control._def.TriggerMode.HARDWARE
-        else:
-            self.camera.set_acquisition_mode(CameraAcquisitionMode.SOFTWARE_TRIGGER)
-            self.live_controller.trigger_mode = control._def.TriggerMode.SOFTWARE
-
-        if self.addons.camera_focus:
-            self.addons.camera_focus.set_pixel_format(squid.config.CameraPixelFormat.from_string("MONO8"))
-            self.addons.camera_focus.set_acquisition_mode(CameraAcquisitionMode.SOFTWARE_TRIGGER)
+            if self.addons.camera_focus:
+                self.addons.camera_focus.set_pixel_format(squid.config.CameraPixelFormat.from_string("MONO8"))
+                self.addons.camera_focus.set_acquisition_mode(CameraAcquisitionMode.SOFTWARE_TRIGGER)
 
         if not skip_init:
-            try:
-                stage_config = self.stage.get_config()
-                x_config = stage_config.X_AXIS
-                y_config = stage_config.Y_AXIS
-                z_config = stage_config.Z_AXIS
-                self._log.info(
-                    f"Setting stage limits: x=[{x_config.MIN_POSITION},{x_config.MAX_POSITION}], "
-                    f"y=[{y_config.MIN_POSITION},{y_config.MAX_POSITION}], "
-                    f"z=[{z_config.MIN_POSITION},{z_config.MAX_POSITION}]"
-                )
-                self.stage.set_limits(
-                    x_pos_mm=x_config.MAX_POSITION,
-                    x_neg_mm=x_config.MIN_POSITION,
-                    y_pos_mm=y_config.MAX_POSITION,
-                    y_neg_mm=y_config.MIN_POSITION,
-                    z_pos_mm=z_config.MAX_POSITION,
-                    z_neg_mm=z_config.MIN_POSITION,
-                )
-                self.home_xyz()
-            except TimeoutError:
-                self._log.error("Hardware setup timed out, resetting microcontroller")
-                if self.low_level_drivers.microcontroller:
-                    self.low_level_drivers.microcontroller.reset()
-                raise
+            # Homing blocks in a microcontroller condition-variable wait with no
+            # callback hook, so Abort only takes effect once it returns.
+            with reporter.step("prep_home_xyz", core=True, interruptible=False):
+                try:
+                    stage_config = self.stage.get_config()
+                    x_config = stage_config.X_AXIS
+                    y_config = stage_config.Y_AXIS
+                    z_config = stage_config.Z_AXIS
+                    self._log.info(
+                        f"Setting stage limits: x=[{x_config.MIN_POSITION},{x_config.MAX_POSITION}], "
+                        f"y=[{y_config.MIN_POSITION},{y_config.MAX_POSITION}], "
+                        f"z=[{z_config.MIN_POSITION},{z_config.MAX_POSITION}]"
+                    )
+                    self.stage.set_limits(
+                        x_pos_mm=x_config.MAX_POSITION,
+                        x_neg_mm=x_config.MIN_POSITION,
+                        y_pos_mm=y_config.MAX_POSITION,
+                        y_neg_mm=y_config.MIN_POSITION,
+                        z_pos_mm=z_config.MAX_POSITION,
+                        z_neg_mm=z_config.MIN_POSITION,
+                    )
+                    self.home_xyz()
+                except TimeoutError:
+                    self._log.error("Hardware setup timed out, resetting microcontroller")
+                    if self.low_level_drivers.microcontroller:
+                        self.low_level_drivers.microcontroller.reset()
+                    raise
 
         if self.addons.objective_changer:
-            # Xeryon always re-homes (findIndex is fast and required). The turret skips
-            # homing on a software restart: the controller retains its position counter
-            # across close()/re-init (the motor is de-energized but the drive stays
-            # powered), so a re-home would just be wasted motion.
-            if control._def.USE_XERYON or not skip_init:
-                self.addons.objective_changer.home()
+            with reporter.step("prep_objective", interruptible=False):
+                self._position_objective_changer(skip_init=skip_init)
+
+    def _position_objective_changer(self, skip_init: bool = False):
+        """Home the objective changer and move to the default objective."""
+        # Xeryon always re-homes (findIndex is fast and required). The turret skips
+        # homing on a software restart: the controller retains its position counter
+        # across close()/re-init (the motor is de-energized but the drive stays
+        # powered), so a re-home would just be wasted motion.
+        if control._def.USE_XERYON or not skip_init:
+            self.addons.objective_changer.home()
+        if control._def.USE_XERYON:
+            self.addons.objective_changer.setSpeed(control._def.XERYON_SPEED)
+        try:
             if control._def.USE_XERYON:
-                self.addons.objective_changer.setSpeed(control._def.XERYON_SPEED)
-            try:
-                if control._def.USE_XERYON:
-                    self.addons.objective_changer.move_to_objective(control._def.DEFAULT_OBJECTIVE)
-                else:
-                    # Turret: when Z was just homed it sits at the home reference (0.0, below the
-                    # working soft floor), so don't restore Z to it after rotating — the cached-Z
-                    # restore at GUI startup positions Z. Later objective changes (Z not freshly
-                    # homed) restore the live focus position as before.
-                    restore_z = skip_init or not control._def.HOMING_ENABLED_Z
-                    self.addons.objective_changer.move_to_objective(control._def.DEFAULT_OBJECTIVE, restore_z=restore_z)
-            except KeyError as e:
-                raise RuntimeError(
-                    f"DEFAULT_OBJECTIVE={control._def.DEFAULT_OBJECTIVE!r} "
-                    f"is not configured for the active objective changer"
-                ) from e
+                self.addons.objective_changer.move_to_objective(control._def.DEFAULT_OBJECTIVE)
+            else:
+                # Turret: when Z was just homed it sits at the home reference (0.0, below the
+                # working soft floor), so don't restore Z to it after rotating — the cached-Z
+                # restore at GUI startup positions Z. Later objective changes (Z not freshly
+                # homed) restore the live focus position as before.
+                restore_z = skip_init or not control._def.HOMING_ENABLED_Z
+                self.addons.objective_changer.move_to_objective(control._def.DEFAULT_OBJECTIVE, restore_z=restore_z)
+        except KeyError as e:
+            raise RuntimeError(
+                f"DEFAULT_OBJECTIVE={control._def.DEFAULT_OBJECTIVE!r} "
+                f"is not configured for the active objective changer"
+            ) from e
 
     def _sync_confocal_mode_from_hardware(self) -> bool:
         """Sync confocal mode state from spinning disk hardware.

--- a/software/control/serial_peripherals.py
+++ b/software/control/serial_peripherals.py
@@ -5,11 +5,68 @@ from serial.tools import list_ports
 import time
 from control.lighting import LightSourceType, IntensityControlMode, ShutterControlMode
 from control._def import *
+
+# The star import above snapshots values at import time, so anything the user
+# can change at runtime (Preferences) must be read as control._def.NAME.
+import control._def
 from squid.abc import LightSource
 
 import squid.logging
 
 log = squid.logging.get_logger(__name__)
+
+
+def _is_warmup_response(response):
+    """True for a device saying 'not yet, still warming up'.
+
+    The LDI answers 'ERR=System in Warmup State'; the wording is matched loosely
+    so a firmware revision that rephrases it slightly still gets waited out
+    rather than killing startup.
+    """
+    lowered = response.lower()
+    return "warmup" in lowered or "warm up" in lowered or "warming" in lowered
+
+
+class SerialDeviceError(RuntimeError):
+    pass
+
+
+class SerialPortNotFoundError(SerialDeviceError):
+    """The device never showed up as a serial port - almost always powered off.
+
+    Raised at construction so the failure names the device, instead of
+    surfacing much later as `AttributeError: 'NoneType' object has no attribute
+    'write'` from inside whichever driver method happened to talk first.
+    """
+
+    def __init__(self, device_label, SN=None, VID=None, PID=None):
+        self.device_label = device_label
+        self.SN = SN
+        if SN is not None:
+            which = f"SN={SN!r}"
+        elif VID is not None or PID is not None:
+            which = f"VID={VID!r} PID={PID!r}"
+        else:
+            which = "the configured port"
+        super().__init__(
+            f"{device_label}: no serial port found for {which}. " "The device is probably powered off or unplugged."
+        )
+
+
+class SerialDeviceTimeout(SerialDeviceError):
+    """A device kept answering, but never with what we were waiting for."""
+
+    def __init__(self, device_label, command, expected_response, last_response, timeout_s):
+        self.device_label = device_label
+        self.last_response = last_response
+        super().__init__(
+            f"{device_label}: {command!r} still returning {last_response!r} "
+            f"instead of {expected_response!r} after {timeout_s:.1f}s"
+        )
+
+
+class SerialDeviceAborted(SerialDeviceError):
+    """The user aborted while we were waiting on this device."""
 
 
 class SerialDevice:
@@ -19,7 +76,19 @@ class SerialDevice:
     or serial number.
     """
 
-    def __init__(self, port=None, VID=None, PID=None, SN=None, baudrate=9600, read_timeout=0.1, **kwargs):
+    def __init__(
+        self,
+        port=None,
+        VID=None,
+        PID=None,
+        SN=None,
+        baudrate=9600,
+        read_timeout=0.1,
+        *,
+        device_label="serial device",
+        require_port=True,
+        **kwargs,
+    ):
         # Initialize the serial connection
         self.port = port
         self.VID = VID
@@ -29,9 +98,24 @@ class SerialDevice:
         self.baudrate = baudrate
         self.read_timeout = read_timeout
         self.serial_kwargs = kwargs
+        self.device_label = device_label
+        self.require_port = require_port
 
         self.serial = None
 
+        self._find_port(SN, VID, PID)
+
+        if self.port is None:
+            if require_port:
+                raise SerialPortNotFoundError(device_label, SN=SN, VID=VID, PID=PID)
+            return
+
+        self.serial = serial.Serial(self.port, baudrate=baudrate, timeout=read_timeout, **kwargs)
+
+    def _find_port(self, SN, VID, PID):
+        """Resolve self.port by USB enumeration. SN wins over VID/PID."""
+        if self.port is not None:
+            return
         if VID is not None and PID is not None:
             for d in list_ports.comports():
                 if d.vid == VID and d.pid == PID:
@@ -43,10 +127,12 @@ class SerialDevice:
                     self.port = d.device
                     break
 
-        if self.port is not None:
-            self.serial = serial.Serial(self.port, baudrate=baudrate, timeout=read_timeout, **kwargs)
+    def _require_serial(self):
+        """Fail with the device's name rather than an AttributeError on None."""
+        if self.serial is None:
+            raise SerialPortNotFoundError(self.device_label, SN=self.SN, VID=self.VID, PID=self.PID)
 
-    def open_ser(self, SN=None, VID=None, PID=None, baudrate=None, read_timeout=None, **kwargs):
+    def open_ser(self, SN=None, VID=None, PID=None, baudrate=None, read_timeout=None, require_port=None, **kwargs):
         if self.serial is not None and not self.serial.is_open:
             self.serial.open()
 
@@ -65,23 +151,19 @@ class SerialDevice:
         if read_timeout is None:
             read_timeout = self.read_timeout
 
+        if require_port is None:
+            require_port = self.require_port
+
         for k in self.serial_kwargs.keys():
             if k not in kwargs:
                 kwargs[k] = self.serial_kwargs[k]
 
         if self.serial is None:
-            if VID is not None and PID is not None:
-                for d in list_ports.comports():
-                    if d.vid == VID and d.pid == PID:
-                        self.port = d.device
-                        break
-            if SN is not None:
-                for d in list_ports.comports():
-                    if d.serial_number == SN:
-                        self.port = d.device
-                        break
+            self._find_port(SN, VID, PID)
             if self.port is not None:
                 self.serial = serial.Serial(self.port, **kwargs)
+            elif require_port:
+                raise SerialPortNotFoundError(self.device_label, SN=SN, VID=VID, PID=PID)
 
     def write_and_check(
         self,
@@ -92,11 +174,42 @@ class SerialDevice:
         attempt_delay=1,
         check_prefix=True,
         print_response=False,
+        *,
+        timeout_s=None,
+        retry_if=None,
+        cancel_fn=None,
+        on_retry=None,
+        sleep_fn=None,
     ):
-        # Write a command and check the response
-        for attempt in range(max_attempts):
+        """Write a command and check the response.
+
+        With none of the keyword-only arguments set this behaves exactly as it
+        always has: `max_attempts` tries, `attempt_delay` between them, then
+        `SerialDeviceError`.
+
+        `timeout_s` turns on a deadline for *transient* replies - those matching
+        `retry_if`, e.g. a laser engine answering 'ERR=System in Warmup State'.
+        Those keep retrying until the deadline instead of burning one of the
+        few attempts, which is what used to kill startup about five seconds
+        after the light source was powered on. Any other wrong reply still
+        fails fast against `max_attempts`, so a genuinely misbehaving device
+        does not cost the full timeout.
+
+        `sleep_fn` lets the caller keep a UI painted while this blocks.
+        """
+        self._require_serial()
+        sleep = sleep_fn if sleep_fn is not None else time.sleep
+        started = time.monotonic()
+        deadline = None if timeout_s is None else started + timeout_s
+        attempts_used = 0
+        last_response = ""
+
+        while True:
+            if cancel_fn is not None and cancel_fn():
+                raise SerialDeviceAborted(f"{self.device_label}: aborted while waiting for {expected_response!r}")
+
             self.serial.write(command.encode())
-            time.sleep(read_delay)  # Wait for the command to be sent/executed
+            sleep(read_delay)  # Wait for the command to be sent/executed
 
             response = self.serial.readline().decode().strip()
             if print_response:
@@ -120,13 +233,25 @@ class SerialDevice:
 
             # Log mismatch for debugging (response didn't match exactly or by prefix)
             if response:
+                last_response = response
                 log.warning(f"Serial response mismatch: got '{response}', expected '{expected_response}'")
 
-            time.sleep(attempt_delay)  # Wait before retrying
+            transient = bool(deadline is not None and retry_if is not None and response and retry_if(response))
+            if transient:
+                if on_retry is not None:
+                    on_retry(response, time.monotonic() - started)
+            else:
+                attempts_used += 1
 
-        raise SerialDeviceError("Max attempts reached without receiving expected response.")
+            sleep(attempt_delay)  # Wait before retrying
+
+            if not transient and attempts_used >= max_attempts:
+                raise SerialDeviceError("Max attempts reached without receiving expected response.")
+            if deadline is not None and time.monotonic() >= deadline:
+                raise SerialDeviceTimeout(self.device_label, command, expected_response, last_response, timeout_s)
 
     def write_and_read(self, command, read_delay=0.1, max_attempts=3, attempt_delay=1):
+        self._require_serial()
         for attempt in range(max_attempts):
             self.serial.write(command.encode())
             time.sleep(read_delay)  # Wait for the command to be sent
@@ -139,15 +264,15 @@ class SerialDevice:
         raise SerialDeviceError("Max attempts reached without receiving response.")
 
     def write(self, command):
+        self._require_serial()
         self.serial.write(command.encode())
 
     def close(self):
-        # Close the serial connection
-        self.serial.close()
-
-
-class SerialDeviceError(RuntimeError):
-    pass
+        # Close the serial connection. Guarded because a device that was never
+        # found leaves self.serial as None, and teardown must not blow up on
+        # exactly the failure it is cleaning up after.
+        if self.serial is not None:
+            self.serial.close()
 
 
 class XLight_Simulation:
@@ -278,6 +403,7 @@ class XLight:
     def _open_serial(self, SN, baudrate):
         """Open serial connection with specified baud rate."""
         self.serial_connection = SerialDevice(
+            device_label="Spinning disk (X-Light/Cicero)",
             SN=SN,
             baudrate=baudrate,
             bytesize=serial.EIGHTBITS,
@@ -482,6 +608,7 @@ class Dragonfly:
     def __init__(self, SN: str):
         self.log = squid.logging.get_logger(self.__class__.__name__)
         self.serial_connection = SerialDevice(
+            device_label="Spinning disk (Dragonfly)",
             SN=SN,
             baudrate=115200,
             bytesize=serial.EIGHTBITS,
@@ -885,6 +1012,7 @@ class LDI(LightSource):
         """
         self.log = squid.logging.get_logger(self.__class__.__name__)
         self.serial_connection = SerialDevice(
+            device_label="LDI laser engine",
             SN=SN,
             baudrate=9600,
             bytesize=serial.EIGHTBITS,
@@ -920,8 +1048,24 @@ class LDI(LightSource):
         }
         self.active_channel = None
 
-    def initialize(self):
-        self.serial_connection.write_and_check("run!\r", "ok")
+    def initialize(self, *, timeout_s=None, cancel_fn=None, on_retry=None, sleep_fn=None):
+        """Put the engine into RUN state, waiting out a warm-up if needed.
+
+        A freshly powered LDI answers 'ERR=System in Warmup State' for up to a
+        minute or so. Treating that as fatal after five attempts is what used
+        to kill startup when the software was launched right after power-on.
+        """
+        if timeout_s is None:
+            timeout_s = control._def.STARTUP_DEVICE_TIMEOUT_S
+        self.serial_connection.write_and_check(
+            "run!\r",
+            "ok",
+            timeout_s=timeout_s,
+            retry_if=_is_warmup_response,
+            cancel_fn=cancel_fn,
+            on_retry=on_retry,
+            sleep_fn=sleep_fn,
+        )
 
     def set_shutter_control_mode(self, mode):
         if mode == ShutterControlMode.TTL:
@@ -1018,7 +1162,8 @@ class LDI_Simulation(LightSource):
         }
         self.active_channel = None
 
-    def initialize(self):
+    def initialize(self, **_):
+        # Accepts the real LDI's keyword arguments so the two are interchangeable.
         pass
 
     def set_shutter_control_mode(self, mode):
@@ -1071,6 +1216,7 @@ class SciMicroscopyLEDArray:
         Provide serial number
         """
         self.serial_connection = SerialDevice(
+            device_label="SciMicroscopy LED array",
             SN=SN,
             baudrate=115200,
             bytesize=serial.EIGHTBITS,
@@ -1224,6 +1370,7 @@ class CellX:
 
     def __init__(self, SN="", initial_modulation=CELLX_MODULATION):
         self.serial_connection = SerialDevice(
+            device_label="CellX laser combiner",
             SN=SN,
             baudrate=115200,
             bytesize=serial.EIGHTBITS,
@@ -1280,7 +1427,11 @@ class CellX_Simulation:
     """Wrapper for communicating with LDI over serial"""
 
     def __init__(self, SN=""):
+        # require_port=False: this is the simulated class, so there is usually
+        # no CellX plugged in at all and a missing port must stay harmless.
         self.serial_connection = SerialDevice(
+            device_label="CellX laser combiner (simulated)",
+            require_port=False,
             SN=SN,
             baudrate=115200,
             bytesize=serial.EIGHTBITS,

--- a/software/control/startup_progress.py
+++ b/software/control/startup_progress.py
@@ -1,0 +1,517 @@
+"""Headless progress tracking for hardware initialization.
+
+Startup used to be a black hole: `Microscope.build_from_global_config` and
+`HighContentScreeningGui.__init__` run back to back with nothing on screen, and
+any failure reached the excepthook in `squid.logging` and killed the process
+without a dialog.  This module is the transport-neutral half of the fix - it
+records what startup is doing, one row per device, and it deliberately imports
+no Qt so it can be used from tests and headless scripts.
+
+`StartupReporter` is a no-op sink.  The module singleton `NULL_REPORTER` is the
+default argument for every `reporter=` parameter added to the build path, so
+existing positional callers keep working unchanged.  The Qt subclass that owns
+the actual window lives in `control.startup_progress_window`.
+"""
+
+import contextlib
+import time
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Callable, Dict, Iterator, List, Optional, Tuple
+
+import squid.logging
+
+log = squid.logging.get_logger(__name__)
+
+
+class StepState(IntEnum):
+    """State of a single startup step.
+
+    Values are ordered from "not started" to "finished"; do not rely on the
+    numbers, they exist only so the enum is comparable and hashable.
+    """
+
+    PENDING = 0
+    CONNECTING = 1
+    WARMING_UP = 2
+    READY = 3
+    WARNING = 4
+    FAILED = 5
+    NOT_FOUND = 6
+    SKIPPED = 7
+
+
+# Labels and colors match control/laser_engine_widget.py, which already renders
+# "Warming up" / "Ready" / "Error" for the laser engine.  Keeping them identical
+# means the startup window and the laser engine tab do not disagree about what
+# amber means.
+_STATE_LABELS = {
+    StepState.PENDING: "Pending",
+    StepState.CONNECTING: "Connecting…",
+    StepState.WARMING_UP: "Warming up",
+    StepState.READY: "Ready",
+    StepState.WARNING: "Warning",
+    StepState.FAILED: "Failed",
+    StepState.NOT_FOUND: "Not found",
+    StepState.SKIPPED: "Skipped",
+}
+
+_STATE_COLORS = {
+    StepState.PENDING: "#888888",
+    StepState.CONNECTING: "#daa520",
+    StepState.WARMING_UP: "#daa520",
+    StepState.READY: "#2e8b57",
+    StepState.WARNING: "#daa520",
+    StepState.FAILED: "#c0392b",
+    StepState.NOT_FOUND: "#c0392b",
+    StepState.SKIPPED: "#888888",
+}
+
+#: States that mean "this device did not come up".  WARNING is deliberately not
+#: in here - it marks the two paths that already swallow failures today
+#: (filter wheel homing, confocal mode sync) and that must keep booting.
+FAILED_STATES = frozenset({StepState.FAILED, StepState.NOT_FOUND})
+
+
+def state_label(state: StepState) -> str:
+    return _STATE_LABELS.get(state, str(state))
+
+
+def state_color(state: StepState) -> str:
+    return _STATE_COLORS.get(state, "#888888")
+
+
+@dataclass
+class StepResult:
+    """One row in the startup window."""
+
+    key: str
+    label: str
+    state: StepState = StepState.PENDING
+    detail: str = ""
+    exception: Optional[BaseException] = None
+    elapsed_s: float = 0.0
+    core: bool = False
+    #: False for steps that block in a driver poll loop with no callback hook
+    #: (stage homing, objective moves).  The window says so, so a frozen window
+    #: reads as honest rather than hung.
+    interruptible: bool = True
+
+    @property
+    def failed(self) -> bool:
+        return self.state in FAILED_STATES
+
+    @property
+    def finished(self) -> bool:
+        return self.state not in (StepState.PENDING, StepState.CONNECTING, StepState.WARMING_UP)
+
+
+class StartupError(Exception):
+    """Base for the three ways initialization can end early."""
+
+
+class StartupAborted(StartupError):
+    """The user pressed Abort.  Carries the step that was in flight."""
+
+    def __init__(self, step_key: str = "", step_label: str = ""):
+        self.step_key = step_key
+        self.step_label = step_label
+        what = step_label or step_key or "startup"
+        super().__init__(f"Initialization aborted while waiting for: {what}")
+
+
+class StartupCoreDeviceError(StartupError):
+    """A device the rest of the system cannot do without failed to come up."""
+
+    def __init__(self, step_key: str, step_label: str, cause: BaseException):
+        self.step_key = step_key
+        self.step_label = step_label
+        self.cause = cause
+        super().__init__(f"{step_label or step_key} failed: {cause}")
+
+
+class StartupFailed(StartupError):
+    """One or more independent devices failed; carries the whole checklist."""
+
+    def __init__(self, results: List[StepResult]):
+        self.results = list(results)
+        self.failures = [r for r in self.results if r.failed]
+        names = ", ".join(r.label for r in self.failures) or "unknown"
+        super().__init__(f"Initialization failed: {names}")
+
+
+class StepHandle:
+    """Handed to the body of `StartupReporter.step()` to annotate a row."""
+
+    def __init__(self, reporter: "StartupReporter", key: str):
+        self._reporter = reporter
+        self._key = key
+
+    @property
+    def key(self) -> str:
+        return self._key
+
+    def detail(self, text: str) -> None:
+        """Update the row's detail text without changing its state."""
+        current = self._reporter.get(self._key)
+        state = current.state if current is not None else StepState.CONNECTING
+        self._reporter.set_state(self._key, state, text)
+
+    def warming_up(self, text: str = "") -> None:
+        self._reporter.set_state(self._key, StepState.WARMING_UP, text)
+
+    def warning(self, text: str) -> None:
+        self._reporter.set_state(self._key, StepState.WARNING, text)
+
+    def not_found(self, text: str) -> None:
+        self._reporter.set_state(self._key, StepState.NOT_FOUND, text)
+
+    def on_warmup_retry(self, response: str, elapsed_s: float) -> None:
+        """Signature matches `SerialDevice.write_and_check(on_retry=...)`.
+
+        Passing this straight through means a driver's literal reply - e.g.
+        'ERR=System in Warmup State' - becomes the row detail with no glue.
+        """
+        self.warming_up(f"{response} ({elapsed_s:.0f}s)")
+
+
+def wait_until(
+    predicate: Callable[[], bool],
+    timeout_s: float,
+    poll_interval_s: float = 0.1,
+    cancel_fn: Callable[[], bool] = lambda: False,
+    on_tick: Optional[Callable[[float], None]] = None,
+    sleep_fn: Callable[[float], None] = time.sleep,
+) -> bool:
+    """Poll `predicate` until it is true, the deadline passes, or cancel fires.
+
+    Generalizes the deadline shape already used by
+    `SquidLaserEngineBase.wait_until_ready`.  Returns True only if the predicate
+    became true.
+    """
+    start = time.monotonic()
+    deadline = start + timeout_s
+    while True:
+        if cancel_fn():
+            return False
+        if predicate():
+            return True
+        now = time.monotonic()
+        if now >= deadline:
+            return False
+        if on_tick is not None:
+            on_tick(now - start)
+        sleep_fn(min(poll_interval_s, max(0.0, deadline - now)))
+
+
+class StartupReporter:
+    """Records startup progress.  The base class does nothing visible.
+
+    Subclasses override `_on_changed` to render, and `pump` / `sleep` to keep a
+    UI alive.  Everything else is transport-neutral bookkeeping.
+    """
+
+    def __init__(self, device_timeout_s: float = 90.0):
+        self._results: Dict[str, StepResult] = {}
+        self._order: List[str] = []
+        self._opened: List[Tuple[str, Callable[[], None]]] = []
+        self._abort_requested = False
+        self._active_key: Optional[str] = None
+        self._device_timeout_s = float(device_timeout_s)
+        self._started_at = time.monotonic()
+
+    # ── declaration ────────────────────────────────────────────────────────
+
+    def declare(self, key: str, label: str, *, core: bool = False, interruptible: bool = True) -> None:
+        """Register a row up front so the full checklist is visible at t=0."""
+        if key in self._results:
+            existing = self._results[key]
+            existing.label = label
+            existing.core = existing.core or core
+            existing.interruptible = existing.interruptible and interruptible
+            return
+        self._results[key] = StepResult(key=key, label=label, core=core, interruptible=interruptible)
+        self._order.append(key)
+        self._on_changed(self._results[key])
+
+    def get(self, key: str) -> Optional[StepResult]:
+        return self._results.get(key)
+
+    @property
+    def results(self) -> List[StepResult]:
+        return [self._results[k] for k in self._order]
+
+    @property
+    def failures(self) -> List[StepResult]:
+        return [r for r in self.results if r.failed]
+
+    @property
+    def device_timeout_s(self) -> float:
+        return self._device_timeout_s
+
+    @property
+    def elapsed_s(self) -> float:
+        return time.monotonic() - self._started_at
+
+    # ── state changes ──────────────────────────────────────────────────────
+
+    def set_state(self, key: str, state: StepState, detail: str = "") -> None:
+        result = self._results.get(key)
+        if result is None:
+            self.declare(key, key)
+            result = self._results[key]
+        result.state = state
+        result.detail = detail
+        self._on_changed(result)
+
+    def skip(self, key: str, reason: str = "") -> None:
+        self.set_state(key, StepState.SKIPPED, reason)
+
+    # ── abort ──────────────────────────────────────────────────────────────
+
+    def request_abort(self) -> None:
+        """Safe to call from a Qt slot: sets a flag and nothing else.
+
+        Teardown must never run here - the initialization call stack below is
+        still live and would be closing devices out from under itself.
+        """
+        if not self._abort_requested:
+            self._abort_requested = True
+            log.warning("Startup abort requested by user.")
+
+    def is_abort_requested(self) -> bool:
+        return self._abort_requested
+
+    def raise_if_aborted(self, key: str = "") -> None:
+        if not self._abort_requested:
+            return
+        target = key or self._active_key or ""
+        result = self._results.get(target)
+        raise StartupAborted(target, result.label if result is not None else "")
+
+    def cancel_fn(self) -> Callable[[], bool]:
+        """Poll function to hand to blocking waits, mirroring `abort_requested_fn`."""
+        return self.is_abort_requested
+
+    # ── opened-device registry ─────────────────────────────────────────────
+
+    def register_opened(self, label: str, closer: Callable[[], None]) -> None:
+        """Record something that must be released if startup does not finish.
+
+        `build_from_global_config` holds every opened device in locals until its
+        very last statement, so on an abort the caller has no reference to any
+        of it.  Registration order equals construction order, so closing in
+        reverse reproduces the teardown order documented in tests/conftest.py.
+
+        An explicit `closer` callable is required rather than duck-typing a
+        `.close()` method: XLight and SciMicroscopyLEDArray have no `close()` at
+        all, and IlluminationController.close() politely shuts down the LDI
+        channel by channel, which takes ~55s against a wedged device.
+        """
+        self._opened.append((label, closer))
+
+    @property
+    def opened(self) -> List[Tuple[str, Callable[[], None]]]:
+        return list(self._opened)
+
+    def close_all(self) -> List[str]:
+        """Close everything registered, newest first.  Never raises."""
+        errors: List[str] = []
+        for label, closer in reversed(self._opened):
+            try:
+                closer()
+                log.info(f"Startup teardown: released {label}")
+            except Exception as e:
+                errors.append(f"{label}: {e}")
+                log.warning(f"Startup teardown: could not release {label}: {e}", exc_info=True)
+        self._opened.clear()
+        return errors
+
+    # ── cooperative UI hooks (no-ops here) ─────────────────────────────────
+
+    def pump(self, force: bool = False) -> None:
+        """Give the UI a chance to repaint.  No-op without a window."""
+
+    def sleep(self, seconds: float) -> None:
+        time.sleep(seconds)
+
+    @property
+    def sleep_fn(self) -> Callable[[float], None]:
+        """Sleep that keeps the UI alive; handed to SerialDevice wait loops."""
+        return self.sleep
+
+    def _on_changed(self, result: StepResult) -> None:
+        """Render hook.  Overridden by the Qt reporter."""
+
+    # ── the main entry point ───────────────────────────────────────────────
+
+    @contextlib.contextmanager
+    def step(
+        self,
+        key: str,
+        *,
+        core: bool = False,
+        label: Optional[str] = None,
+        interruptible: bool = True,
+    ) -> Iterator[StepHandle]:
+        """Wrap one initialization step.
+
+        On a clean exit the row becomes READY (unless the body already set a
+        terminal state).  An exception is recorded as FAILED and then either
+        swallowed - so the sweep continues and the window can show every
+        problem at once - or re-raised as `StartupCoreDeviceError` when
+        `core=True`.  `StartupAborted` always passes straight through.
+        """
+        if key not in self._results:
+            self.declare(key, label or key, core=core, interruptible=interruptible)
+        else:
+            existing = self._results[key]
+            if label:
+                existing.label = label
+            existing.core = existing.core or core
+            existing.interruptible = existing.interruptible and interruptible
+
+        result = self._results[key]
+        self.raise_if_aborted(key)
+        self._active_key = key
+        self.set_state(key, StepState.CONNECTING)
+        started = time.monotonic()
+        try:
+            yield StepHandle(self, key)
+        except StartupAborted:
+            result.elapsed_s = time.monotonic() - started
+            self._active_key = None
+            raise
+        except BaseException as e:  # noqa: BLE001 - deliberately broad, see below
+            result.elapsed_s = time.monotonic() - started
+            result.exception = e
+            self._active_key = None
+            # A driver may already have classified this more precisely (e.g.
+            # NOT_FOUND for an unenumerated port); do not overwrite that.
+            if result.state not in FAILED_STATES:
+                self.set_state(key, StepState.FAILED, f"{type(e).__name__}: {e}")
+            else:
+                self._on_changed(result)
+            log.error(f"Startup step '{result.label}' failed.", exc_info=True)
+            if result.core:
+                raise StartupCoreDeviceError(key, result.label, e) from e
+            return
+        result.elapsed_s = time.monotonic() - started
+        self._active_key = None
+        if not result.finished:
+            # Keep whatever the body chose to say about the device, but drop
+            # transient warm-up chatter - a Ready row must not still read
+            # "ERR=System in Warmup State".
+            detail = "" if result.state == StepState.WARMING_UP else result.detail
+            self.set_state(key, StepState.READY, detail)
+        else:
+            self._on_changed(result)
+
+
+#: Default for every `reporter=` parameter on the build path.  Shared and
+#: stateless enough that existing callers pay nothing for it.
+NULL_REPORTER = StartupReporter()
+
+
+def is_squid_filter_wheel(fw_config) -> bool:
+    """True for the MCU-driven filter wheel, whose failure is unsurvivable.
+
+    Zaber and Optospin own their own serial port, so the rest of the sweep can
+    continue past them.
+    """
+    from squid.config import FilterWheelControllerVariant
+
+    return fw_config.controller_type == FilterWheelControllerVariant.SQUID
+
+
+def declare_expected_steps(reporter: StartupReporter, *, simulated: bool = False, skip_init: bool = False) -> None:
+    """Declare every row this machine's configuration will actually visit.
+
+    Reads the same `control._def` flags the builders read, so the checklist is
+    complete and correctly ordered before the first device is touched.  Devices
+    this machine is not configured for are not declared at all - a row reading
+    "Dragonfly - Skipped" on a machine that has never had one is noise, not
+    information.  `SKIPPED` is reserved for steps that a real run bypasses
+    (--skip-init, simulation).
+    """
+    import control._def as _def
+    import squid.config
+
+    d = reporter.declare
+
+    d("imports", "Loading software modules", core=True)
+    d("microcontroller", "Microcontroller", core=True)
+    d("stage_xy", "Prior XY stage" if _def.USE_PRIOR_STAGE else "XY stage", core=True)
+    if _def.USE_PI_FOCUS_STAGE:
+        d("stage_z", "Z focus stage (PI C-414)", core=True, interruptible=False)
+
+    if _def.ENABLE_SPINNING_DISK_CONFOCAL:
+        d("spinning_disk", "Spinning disk (Dragonfly)" if _def.USE_DRAGONFLY else "Spinning disk (X-Light/Cicero)")
+    if _def.ENABLE_NL5:
+        d("nl5", "NL5 confocal scanner")
+    if _def.ENABLE_CELLX:
+        d("cellx", "CellX laser combiner")
+
+    fw_config = squid.config.get_filter_wheel_config()
+    if fw_config:
+        # The Squid variant rides on the microcontroller and raises hard on a
+        # missing MCU or old firmware; Zaber/Optospin own their own port and a
+        # failure there is survivable for the rest of the sweep.
+        d("filter_wheel", "Emission filter wheel", core=is_squid_filter_wheel(fw_config))
+    if _def.USE_XERYON:
+        d("objective_changer", "Objective changer (Xeryon)")
+    elif _def.USE_OBJECTIVE_TURRET:
+        d("objective_changer", "Objective turret")
+    if _def.SUPPORT_LASER_AUTOFOCUS:
+        d("camera_focus", "Laser autofocus camera")
+    if _def.RUN_FLUIDICS:
+        d("fluidics", "Fluidics")
+    if _def.HAS_OBJECTIVE_PIEZO:
+        d("piezo", "Objective piezo", core=True)
+    if _def.SUPPORT_SCIMICROSCOPY_LED_ARRAY:
+        d("led_array", "SciMicroscopy LED array")
+    if _def.USE_SQUID_LASER_ENGINE:
+        d("laser_engine", "Squid laser engine")
+
+    d("camera", "Main camera", core=True)
+    # The external light sources are only built when not simulated - mirror the
+    # `and not simulated` guards in Microscope.build_from_global_config, or the
+    # row would sit at Pending forever in simulation.
+    if not simulated:
+        if _def.USE_LDI_SERIAL_CONTROL:
+            d("light_source", "LDI laser engine")
+        elif _def.USE_CELESTA_ETHERNET_CONTROL:
+            d("light_source", "CELESTA light engine")
+        elif _def.USE_ANDOR_LASER_CONTROL:
+            d("light_source", "Andor laser")
+    d("illumination_controller", "Illumination controller", core=True)
+    d("config_profiles", "Acquisition configuration", core=True)
+    if _def.ENABLE_SPINNING_DISK_CONFOCAL:
+        d("confocal_sync", "Confocal mode sync")
+
+    if fw_config:
+        d("prep_filter_wheel", "Filter wheel homing")
+    if _def.HAS_OBJECTIVE_PIEZO:
+        d("prep_piezo", "Piezo homing")
+    if _def.USE_SQUID_LASER_ENGINE:
+        d("prep_laser_engine", "Laser engine startup")
+    d("prep_watchdog", "Illumination watchdog")
+    d("prep_camera", "Camera configuration", core=True)
+    if not skip_init:
+        # --skip-init leaves the hardware where it is, so homing never runs.
+        d("prep_home_xyz", "Homing stage", core=True, interruptible=False)
+    if _def.USE_XERYON or _def.USE_OBJECTIVE_TURRET:
+        d("prep_objective", "Objective positioning", interruptible=False)
+
+    d("gui_objects", "Loading controllers", core=True)
+    d("gui_hardware", "Starting camera streams", core=True)
+    d("gui_widgets", "Building interface", core=True, interruptible=False)
+    d("gui_layout", "Arranging layout", core=True, interruptible=False)
+    d("gui_connections", "Connecting signals", core=True, interruptible=False)
+    d("gui_position", "Restoring stage position", interruptible=False)
+
+    if simulated:
+        # Simulated devices return immediately, so nothing is actually stuck in
+        # a driver poll loop and every step is effectively interruptible.
+        for result in reporter.results:
+            result.interruptible = True

--- a/software/control/startup_progress_window.py
+++ b/software/control/startup_progress_window.py
@@ -1,0 +1,461 @@
+"""The startup status window, and the summary dialog shown when startup fails.
+
+Initialization runs on the Qt main thread with no event loop (see main_hcs.py),
+so this window is kept painted and its Abort button clickable by pumping
+`QApplication.processEvents()` from progress updates and from the new serial
+wait loops.  Three things make that safe:
+
+  * The Abort button only sets a flag.  Teardown happens in main_hcs.py after
+    the initialization stack has unwound - closing devices from inside a slot
+    fired mid-`processEvents()` would pull them out from under the call still
+    running below.
+  * An application-level event filter *discards* user input aimed anywhere but
+    this window.  `QEventLoop.ExcludeUserInputEvents` is not good enough: it
+    defers input rather than dropping it, so an impatient user's clicks would
+    be replayed into the main window the moment it appears.
+  * A re-entrancy guard, because `SerialDevice.write_and_check` is also called
+    from GUI slots at runtime and must never recurse into the pump.
+
+`QtStartupReporter` is a context manager and should always be used as one - if
+`finish()` were skipped the event filter would survive and silently swallow
+input in every later widget.
+"""
+
+import os
+import time
+from typing import Callable, List, Optional
+
+from qtpy.QtCore import QEvent, QObject, Qt, QUrl, Signal
+from qtpy.QtGui import QDesktopServices
+from qtpy.QtWidgets import (
+    QApplication,
+    QDialog,
+    QFrame,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QPlainTextEdit,
+    QPushButton,
+    QScrollArea,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
+
+import squid.logging
+from control.startup_progress import (
+    StartupAborted,
+    StartupReporter,
+    StepResult,
+    StepState,
+    state_color,
+    state_label,
+)
+
+log = squid.logging.get_logger(__name__)
+
+_USER_INPUT_EVENTS = frozenset(
+    {
+        QEvent.MouseButtonPress,
+        QEvent.MouseButtonRelease,
+        QEvent.MouseButtonDblClick,
+        QEvent.KeyPress,
+        QEvent.KeyRelease,
+        QEvent.Wheel,
+        QEvent.TouchBegin,
+        QEvent.TouchUpdate,
+        QEvent.TouchEnd,
+        QEvent.ContextMenu,
+    }
+)
+
+
+def format_checklist(results: List[StepResult], width: int = 34) -> str:
+    """Render the checklist as plain text, for the summary dialog and clipboard."""
+    lines = []
+    for r in results:
+        dots = "." * max(1, width - len(r.label))
+        line = f"{r.label} {dots} {state_label(r.state):<12}"
+        if r.state == StepState.READY and r.elapsed_s >= 0.05:
+            line += f"{r.elapsed_s:6.1f} s"
+        if r.detail:
+            line += f"  {r.detail}"
+        lines.append(line.rstrip())
+    return "\n".join(lines)
+
+
+def _remediation_hint(result: StepResult) -> Optional[str]:
+    """Turn a failure into something the person in front of the scope can do."""
+    name = type(result.exception).__name__ if result.exception is not None else ""
+    detail = result.detail or ""
+    if name == "SerialPortNotFoundError" or result.state == StepState.NOT_FOUND:
+        return (
+            f"{result.label}: the device did not appear as a serial port. "
+            "Check that it is powered on and its USB cable is connected, then relaunch."
+        )
+    if name == "SerialDeviceTimeout":
+        if "warm" in detail.lower():
+            return (
+                f"{result.label}: still warming up when the wait expired. Give it about a "
+                "minute and relaunch, or raise Settings > Settings... > Startup device timeout."
+            )
+        return f"{result.label}: the device stopped responding. Power-cycle it and relaunch."
+    if name in ("TimeoutError", "SquidTimeout"):
+        return f"{result.label}: the move never completed. Check for an obstruction on the stage, then relaunch."
+    return None
+
+
+class _StartupInputFilter(QObject):
+    """Discards user input and close requests not aimed at the startup window."""
+
+    def __init__(self, window: QWidget, parent: Optional[QObject] = None):
+        super().__init__(parent)
+        self._window = window
+
+    def _belongs_to_startup(self, obj: QObject) -> bool:
+        window = self._window
+        if window is None:
+            return False
+        if obj is window:
+            return True
+        if isinstance(obj, QWidget):
+            return window.isAncestorOf(obj)
+        handle = window.windowHandle()
+        return handle is not None and obj is handle
+
+    def eventFilter(self, obj: QObject, event: QEvent) -> bool:
+        event_type = event.type()
+        if event_type not in _USER_INPUT_EVENTS and event_type != QEvent.Close:
+            return False
+        if self._belongs_to_startup(obj):
+            return False
+        # True == "handled", which drops the event rather than deferring it.
+        return True
+
+
+class StartupProgressWindow(QDialog):
+    """Live checklist of what initialization is doing, with an Abort button."""
+
+    signal_abort_requested = Signal()
+
+    def __init__(self, log_path: str, parent: Optional[QWidget] = None):
+        super().__init__(parent)
+        self._log_path = log_path
+        self._rows = {}
+        self._allow_close = False
+        self._row_count = 0
+        # No close button: the only way out during startup is Abort, which
+        # unwinds cleanly.  A stray window close would strand open devices.
+        self.setWindowFlags(Qt.Dialog | Qt.CustomizeWindowHint | Qt.WindowTitleHint | Qt.WindowStaysOnTopHint)
+        self.setWindowTitle("Starting Squid")
+        self.setMinimumSize(620, 420)
+        self._setup_ui()
+        self._connect_signals()
+
+    def _setup_ui(self) -> None:
+        layout = QVBoxLayout(self)
+
+        self._headline = QLabel("Initializing hardware…")
+        self._headline.setStyleSheet("font-size: 12pt; font-weight: bold;")
+        layout.addWidget(self._headline)
+
+        self._elapsed_label = QLabel("")
+        self._elapsed_label.setStyleSheet("color: #888888;")
+        layout.addWidget(self._elapsed_label)
+
+        self._grid_host = QWidget()
+        self._grid = QGridLayout(self._grid_host)
+        self._grid.setContentsMargins(0, 4, 0, 4)
+        self._grid.setHorizontalSpacing(10)
+        self._grid.setVerticalSpacing(3)
+        self._grid.setColumnStretch(3, 1)
+
+        self._scroll = QScrollArea()
+        self._scroll.setWidget(self._grid_host)
+        self._scroll.setWidgetResizable(True)
+        self._scroll.setFrameShape(QFrame.StyledPanel)
+        layout.addWidget(self._scroll, 1)
+
+        button_row = QHBoxLayout()
+        self._hint = QLabel("")
+        self._hint.setStyleSheet("color: #888888;")
+        self._hint.setWordWrap(True)
+        button_row.addWidget(self._hint, 1)
+        self.btn_abort = QPushButton("Abort Initialization")
+        button_row.addWidget(self.btn_abort)
+        layout.addLayout(button_row)
+
+    def _connect_signals(self) -> None:
+        self.btn_abort.clicked.connect(self._on_abort_clicked)
+
+    def _on_abort_clicked(self) -> None:
+        self.btn_abort.setEnabled(False)
+        self.btn_abort.setText("Aborting…")
+        self._headline.setText("Aborting — releasing hardware…")
+        self.signal_abort_requested.emit()
+
+    def add_row(self, result: StepResult) -> None:
+        if result.key in self._rows:
+            return
+        dot = QLabel("●")
+        name = QLabel(result.label)
+        state = QLabel(state_label(result.state))
+        detail = QLabel("")
+        detail.setStyleSheet("font-family: monospace; color: #666666;")
+        detail.setWordWrap(True)
+        detail.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Preferred)
+        row = self._row_count
+        self._row_count += 1
+        self._grid.addWidget(dot, row, 0)
+        self._grid.addWidget(name, row, 1)
+        self._grid.addWidget(state, row, 2)
+        self._grid.addWidget(detail, row, 3)
+        self._rows[result.key] = (dot, name, state, detail)
+        self.update_row(result)
+
+    def update_row(self, result: StepResult) -> None:
+        widgets = self._rows.get(result.key)
+        if widgets is None:
+            self.add_row(result)
+            return
+        dot, name, state, detail = widgets
+        color = state_color(result.state)
+        dot.setStyleSheet(f"font-size: 13pt; color: {color};")
+        state.setText(state_label(result.state))
+        state.setStyleSheet(f"color: {color};")
+        name.setText(result.label)
+
+        text = result.detail
+        if result.state == StepState.READY and result.elapsed_s >= 0.05:
+            text = text or f"{result.elapsed_s:.1f} s"
+        elif result.state == StepState.CONNECTING and not result.interruptible:
+            # Say so, rather than let an honestly-blocked window read as hung.
+            text = text or "cannot be interrupted"
+        detail.setText(text)
+
+        if result.state in (StepState.CONNECTING, StepState.WARMING_UP):
+            self._headline.setText(f"{result.label}…")
+            self._scroll.ensureWidgetVisible(name)
+            self._hint.setText(
+                "" if result.interruptible else "This step cannot be interrupted; Abort takes effect when it finishes."
+            )
+
+    def update_elapsed(self, seconds: float) -> None:
+        self._elapsed_label.setText(f"Elapsed {seconds:.0f} s   ·   log: {self._log_path}")
+
+    def allow_close(self) -> None:
+        self._allow_close = True
+
+    def closeEvent(self, event) -> None:
+        if self._allow_close:
+            event.accept()
+        else:
+            event.ignore()
+
+
+class StartupSummaryDialog(QDialog):
+    """Shown when startup could not finish.  Names every problem, then quits."""
+
+    def __init__(
+        self,
+        headline: str,
+        results: List[StepResult],
+        log_path: str,
+        parent: Optional[QWidget] = None,
+    ):
+        super().__init__(parent)
+        self._results = results
+        self._log_path = log_path
+        self._headline_text = headline
+        self.setWindowTitle("Squid could not start")
+        self.setMinimumSize(720, 520)
+        self.setWindowFlags(self.windowFlags() | Qt.WindowStaysOnTopHint)
+        self._setup_ui()
+        self._connect_signals()
+
+    def details_text(self) -> str:
+        parts = [self._headline_text, "", format_checklist(self._results), "", f"Log file: {self._log_path}"]
+        return "\n".join(parts)
+
+    def _setup_ui(self) -> None:
+        layout = QVBoxLayout(self)
+
+        headline = QLabel(self._headline_text)
+        headline.setWordWrap(True)
+        headline.setStyleSheet("font-size: 12pt; font-weight: bold;")
+        layout.addWidget(headline)
+
+        hints = [h for h in (_remediation_hint(r) for r in self._results if r.failed) if h]
+        if hints:
+            hint_label = QLabel("What to check:\n" + "\n".join(f"  • {h}" for h in hints))
+            hint_label.setWordWrap(True)
+            hint_label.setStyleSheet("background-color: #fff3cd; color: #000000; padding: 10px; border-radius: 4px;")
+            layout.addWidget(hint_label)
+
+        self._checklist = QPlainTextEdit(format_checklist(self._results))
+        self._checklist.setReadOnly(True)
+        self._checklist.setStyleSheet("font-family: monospace;")
+        layout.addWidget(self._checklist, 1)
+
+        path_label = QLabel(f"Full log: {self._log_path}")
+        path_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        path_label.setWordWrap(True)
+        path_label.setStyleSheet("color: #666666;")
+        layout.addWidget(path_label)
+
+        button_row = QHBoxLayout()
+        self.btn_copy = QPushButton("Copy details")
+        self.btn_open_log = QPushButton("Open log folder")
+        self.btn_quit = QPushButton("Quit")
+        self.btn_quit.setDefault(True)
+        button_row.addWidget(self.btn_copy)
+        button_row.addWidget(self.btn_open_log)
+        button_row.addStretch(1)
+        button_row.addWidget(self.btn_quit)
+        layout.addLayout(button_row)
+
+    def _connect_signals(self) -> None:
+        self.btn_copy.clicked.connect(self._on_copy)
+        self.btn_open_log.clicked.connect(self._on_open_log)
+        self.btn_quit.clicked.connect(self.accept)
+
+    def _on_copy(self) -> None:
+        QApplication.clipboard().setText(self.details_text())
+        self.btn_copy.setText("Copied")
+
+    def _on_open_log(self) -> None:
+        folder = os.path.dirname(os.path.abspath(self._log_path))
+        QDesktopServices.openUrl(QUrl.fromLocalFile(folder))
+
+
+class QtStartupReporter(StartupReporter):
+    """StartupReporter that drives `StartupProgressWindow`.
+
+    Main-thread only.  Always use as a context manager so the application-level
+    event filter is removed even if the body raises.
+    """
+
+    MIN_PUMP_INTERVAL_S = 0.05
+
+    def __init__(self, app: QApplication, log_path: str, device_timeout_s: float = 90.0):
+        super().__init__(device_timeout_s=device_timeout_s)
+        self._app = app
+        self._log_path = log_path
+        self.window = StartupProgressWindow(log_path)
+        self.window.signal_abort_requested.connect(self.request_abort)
+        self._filter: Optional[_StartupInputFilter] = None
+        self._in_pump = False
+        self._last_pump = 0.0
+        self._finished = False
+        self._laser_engine = None
+        self._prev_quit_on_last_window = app.quitOnLastWindowClosed()
+
+    # ── lifecycle ──────────────────────────────────────────────────────────
+
+    def __enter__(self) -> "QtStartupReporter":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        self.finish()
+        return False
+
+    def show(self) -> None:
+        # show(), never exec_(): a nested event loop would never give control
+        # back to the initialization code below.
+        self._app.setQuitOnLastWindowClosed(False)
+        self._filter = _StartupInputFilter(self.window)
+        self._app.installEventFilter(self._filter)
+        self.window.show()
+        self.pump(force=True)
+
+    def finish(self) -> None:
+        """Remove the fence and close the window.  Idempotent."""
+        if self._finished:
+            return
+        self._finished = True
+        if self._filter is not None:
+            self._app.removeEventFilter(self._filter)
+            self._filter = None
+        self._app.setQuitOnLastWindowClosed(self._prev_quit_on_last_window)
+        self._detach_laser_engine()
+        self.window.allow_close()
+        self.window.close()
+
+    # ── cooperative pumping ────────────────────────────────────────────────
+
+    def pump(self, force: bool = False) -> None:
+        if self._in_pump or self._finished:
+            return
+        now = time.monotonic()
+        if not force and (now - self._last_pump) < self.MIN_PUMP_INTERVAL_S:
+            return
+        self._in_pump = True
+        try:
+            self._last_pump = now
+            self.window.update_elapsed(self.elapsed_s)
+            self._app.processEvents()
+        finally:
+            self._in_pump = False
+
+    def sleep(self, seconds: float) -> None:
+        """Sleep while keeping the window painted and Abort clickable."""
+        if seconds <= 0:
+            self.pump()
+            return
+        deadline = time.monotonic() + seconds
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            self.pump()
+            time.sleep(min(0.02, remaining))
+        self.pump()
+
+    def _on_changed(self, result: StepResult) -> None:
+        self.window.update_row(result)
+        self.pump()
+
+    # ── laser engine live status ───────────────────────────────────────────
+
+    def attach_laser_engine(self, engine) -> None:
+        """Mirror the engine's live per-channel status into its row."""
+        if engine is None:
+            return
+        self._laser_engine = engine
+        engine.status_updated.connect(self._on_laser_engine_status)
+
+    def _on_laser_engine_status(self, status) -> None:
+        result = self.get("laser_engine")
+        if result is None or result.finished:
+            return
+        try:
+            states = sorted({info.display_state.name for info in status.channels.values()})
+            self.set_state("laser_engine", StepState.WARMING_UP, ", ".join(states))
+        except Exception:
+            log.debug("Could not format laser engine status for the startup window.", exc_info=True)
+
+    def _detach_laser_engine(self) -> None:
+        engine = self._laser_engine
+        self._laser_engine = None
+        if engine is None:
+            return
+        try:
+            engine.status_updated.disconnect(self._on_laser_engine_status)
+        except TypeError:
+            # PyQt raises TypeError when the slot wasn't connected. RuntimeError
+            # would mean the C++ object is gone - let that surface.
+            pass
+
+    # ── failure reporting ──────────────────────────────────────────────────
+
+    def show_summary(self, error: BaseException) -> None:
+        """Close the progress window and show the summary.  Blocks until Quit."""
+        if isinstance(error, StartupAborted):
+            what = error.step_label or error.step_key or "startup"
+            headline = f"Initialization was aborted while waiting for: {what}.\nThe software will now exit."
+        else:
+            headline = f"Initialization failed. The software will now exit.\n\n{error}"
+        results = self.results
+        self.finish()
+        dialog = StartupSummaryDialog(headline, results, self._log_path)
+        dialog.exec_()

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -1659,6 +1659,26 @@ class PreferencesDialog(QDialog):
         throttle_group.content.addLayout(throttle_layout)
         layout.addWidget(throttle_group)
 
+        # Startup section
+        startup_group = CollapsibleGroupBox("Startup", collapsed=True)
+        startup_layout = QFormLayout()
+
+        self.startup_timeout_spinbox = QDoubleSpinBox()
+        self.startup_timeout_spinbox.setRange(10.0, 600.0)
+        self.startup_timeout_spinbox.setSingleStep(10.0)
+        self.startup_timeout_spinbox.setValue(
+            self._get_config_float("GENERAL", "startup_device_timeout_s", control._def.STARTUP_DEVICE_TIMEOUT_S)
+        )
+        self.startup_timeout_spinbox.setSuffix(" s")
+        self.startup_timeout_spinbox.setToolTip(
+            "How long to keep retrying a device that reports it is still warming up during startup.\n"
+            "Raise this if a laser engine powered on just before launch is not ready in time."
+        )
+        startup_layout.addRow("Startup Device Timeout:", self.startup_timeout_spinbox)
+
+        startup_group.content.addLayout(startup_layout)
+        layout.addWidget(startup_group)
+
         # Diagnostics section
         diagnostics_group = CollapsibleGroupBox("Diagnostics", collapsed=True)
         diagnostics_layout = QFormLayout()
@@ -2022,6 +2042,7 @@ class PreferencesDialog(QDialog):
         self.config.set("GENERAL", "acquisition_max_pending_jobs", str(self.max_pending_jobs_spinbox.value()))
         self.config.set("GENERAL", "acquisition_max_pending_mb", str(self.max_pending_mb_spinbox.value()))
         self.config.set("GENERAL", "acquisition_throttle_timeout_s", str(self.throttle_timeout_spinbox.value()))
+        self.config.set("GENERAL", "startup_device_timeout_s", str(self.startup_timeout_spinbox.value()))
 
         # Advanced - Position Limits
         self.config.set("SOFTWARE_POS_LIMIT", "x_positive", str(self.limit_x_pos.value()))
@@ -2169,6 +2190,7 @@ class PreferencesDialog(QDialog):
         control._def.ACQUISITION_MAX_PENDING_JOBS = self.max_pending_jobs_spinbox.value()
         control._def.ACQUISITION_MAX_PENDING_MB = self.max_pending_mb_spinbox.value()
         control._def.ACQUISITION_THROTTLE_TIMEOUT_S = self.throttle_timeout_spinbox.value()
+        control._def.STARTUP_DEVICE_TIMEOUT_S = self.startup_timeout_spinbox.value()
 
         # Software position limits
         control._def.SOFTWARE_POS_LIMIT.X_POSITIVE = self.limit_x_pos.value()
@@ -2412,6 +2434,11 @@ class PreferencesDialog(QDialog):
         new_val = self.throttle_timeout_spinbox.value()
         if not self._floats_equal(old_val, new_val):
             changes.append(("Throttle Timeout", f"{old_val} s", f"{new_val} s", False))
+
+        old_val = self._get_config_float("GENERAL", "startup_device_timeout_s", control._def.STARTUP_DEVICE_TIMEOUT_S)
+        new_val = self.startup_timeout_spinbox.value()
+        if not self._floats_equal(old_val, new_val):
+            changes.append(("Startup Device Timeout", f"{old_val} s", f"{new_val} s", False))
 
         # Advanced - Position Limits (live update)
         old_val = self._get_config_float("SOFTWARE_POS_LIMIT", "x_positive", 115)
@@ -5246,7 +5273,16 @@ class NavigationWidget(QFrame):
         self.position_update_timer = QTimer()
         self.position_update_timer.setInterval(100)
         self.position_update_timer.timeout.connect(self._update_position)
-        self.position_update_timer.start()
+        # Deliberately not started here. _update_position calls stage.get_pos(),
+        # and this widget is constructed while the startup window is pumping the
+        # event loop - a tick during initialization would poll a stage that is
+        # still homing (and on a PI stage would block on the lock the reference
+        # sweep holds). The main window starts it from showEvent.
+
+    def start_polling(self):
+        """Begin live position polling. Called once the main window is shown."""
+        if not self.position_update_timer.isActive():
+            self.position_update_timer.start()
 
     def _update_position(self):
         pos = self.stage.get_pos()

--- a/software/main_hcs.py
+++ b/software/main_hcs.py
@@ -15,28 +15,41 @@ import squid.logging
 
 squid.logging.setup_uncaught_exception_logging()
 
-# app specific libraries
-import control.gui_hcs as gui
-from control._def import USE_TERMINAL_CONSOLE, ENABLE_MCP_SERVER_SUPPORT, CONTROL_SERVER_HOST, CONTROL_SERVER_PORT
-import control._def
-import control.utils
-import control.microscope
 from control.single_instance import acquire_single_instance_lock
 
-# Import auto-migration function
-from tools.migrate_acquisition_configs import run_auto_migration
+# NOTE: the heavy application imports (control.gui_hcs and friends) are NOT done
+# here. control/widgets.py imports napari at module scope, which costs several
+# seconds, and doing that before QApplication exists means the desktop icon
+# looks dead for the whole of it with no way to show anything. They are imported
+# inside __main__ instead, once the startup window is up and can say so.
 
 
-if USE_TERMINAL_CONSOLE:
-    from control.console import ConsoleThread
+def _teardown_and_exit(error, reporter, instance_lock, log_path):
+    """Report a failed or aborted startup, release hardware, and exit.
 
-if ENABLE_MCP_SERVER_SUPPORT:
-    from control.microscope_control_server import MicroscopeControlServer
-    from control.widgets_claude import ClaudeApiKeyDialog, load_claude_api_key_from_cache
-    import shlex
-    import subprocess
-    import shutil
-    import tempfile
+    Never returns.
+    """
+    log.error(f"Startup did not complete: {error}", exc_info=error)
+
+    errors = reporter.close_all()
+    for message in errors:
+        log.warning(f"Teardown problem: {message}")
+
+    try:
+        reporter.show_summary(error)
+    except Exception:
+        log.error("Could not show the startup summary dialog.", exc_info=True)
+
+    # aboutToQuit is emitted from Qt's exec() cleanup, and app.exec_() was never
+    # entered on this path - so the lock must be released explicitly or it is
+    # left behind for the next launch to trip over.
+    try:
+        instance_lock.unlock()
+    except Exception:
+        log.warning("Could not release the single-instance lock.", exc_info=True)
+
+    logging.shutdown()
+    sys.exit(1)
 
 
 if __name__ == "__main__":
@@ -84,6 +97,10 @@ if __name__ == "__main__":
     # main_hcs.py exits via os._exit(), which skips destructors. aboutToQuit
     # fires before app.exec_() returns, so unlock() runs and the lock file is
     # removed on a normal exit.
+    #
+    # This only covers exits that reach app.exec_(). A startup failure or abort
+    # happens before that, where Qt never runs its exec() cleanup and this
+    # signal never fires - _teardown_and_exit() unlocks explicitly for that.
     app.aboutToQuit.connect(instance_lock.unlock)
 
     log = squid.logging.get_logger("main_hcs")
@@ -92,45 +109,106 @@ if __name__ == "__main__":
         log.info("Turning on debug logging.")
         squid.logging.set_stdout_log_level(logging.DEBUG)
 
-    if not squid.logging.add_file_logging(f"{squid.logging.get_default_log_directory()}/main_hcs.log"):
+    log_path = f"{squid.logging.get_default_log_directory()}/main_hcs.log"
+    if not squid.logging.add_file_logging(log_path):
         log.error("Couldn't setup logging to file!")
         sys.exit(1)
 
-    log.info(f"Squid Repository State: {control.utils.get_squid_repo_state_description()}")
+    # Only the startup-progress modules are imported before the window exists;
+    # they are small and pull in no Qt beyond what is already loaded.
+    from control.startup_progress import StartupError, StartupFailed, declare_expected_steps
+    from control.startup_progress_window import QtStartupReporter
+    import control._def
 
-    # Auto-migrate legacy acquisition configurations if present
-    run_auto_migration()
+    with QtStartupReporter(app, log_path=log_path, device_timeout_s=control._def.STARTUP_DEVICE_TIMEOUT_S) as reporter:
+        declare_expected_steps(reporter, simulated=args.simulation, skip_init=args.skip_init)
+        reporter.show()
 
-    # This allows shutdown via ctrl+C even after the gui has popped up.
-    signal.signal(signal.SIGINT, signal.SIG_DFL)
+        try:
+            with reporter.step("imports", core=True, interruptible=False):
+                import control.gui_hcs as gui
+                from control._def import (
+                    USE_TERMINAL_CONSOLE,
+                    ENABLE_MCP_SERVER_SUPPORT,
+                    CONTROL_SERVER_HOST,
+                    CONTROL_SERVER_PORT,
+                )
+                import control.utils
+                import control.microscope
+                from tools.migrate_acquisition_configs import run_auto_migration
 
-    microscope = control.microscope.Microscope.build_from_global_config(args.simulation, skip_init=args.skip_init)
-    win = gui.HighContentScreeningGui(
-        microscope=microscope,
-        is_simulation=args.simulation,
-        live_only_mode=args.live_only,
-        skip_init=args.skip_init,
-    )
+                if USE_TERMINAL_CONSOLE:
+                    from control.console import ConsoleThread
 
-    microscope_utils_menu = QMenu("Utils", win)
+                if ENABLE_MCP_SERVER_SUPPORT:
+                    from control.microscope_control_server import MicroscopeControlServer
+                    from control.widgets_claude import ClaudeApiKeyDialog, load_claude_api_key_from_cache
+                    import shlex
+                    import subprocess
+                    import shutil
+                    import tempfile
 
-    stage_utils_action = QAction("Stage Utils", win)
-    stage_utils_action.triggered.connect(win.stageUtils.show)
-    microscope_utils_menu.addAction(stage_utils_action)
+                log.info(f"Squid Repository State: {control.utils.get_squid_repo_state_description()}")
 
-    if control._def.USE_OBJECTIVE_TURRET:
-        reset_turret_action = QAction("Reset Objective Turret", win)
-        reset_turret_action.triggered.connect(win.resetObjectiveTurret)
-        microscope_utils_menu.addAction(reset_turret_action)
+                # Auto-migrate legacy acquisition configurations if present
+                run_auto_migration()
 
-    workflow_runner_action = QAction("Workflow Runner...", win)
-    workflow_runner_action.triggered.connect(win.openWorkflowRunner)
-    microscope_utils_menu.addAction(workflow_runner_action)
+            # This allows shutdown via ctrl+C even after the gui has popped up.
+            signal.signal(signal.SIGINT, signal.SIG_DFL)
 
-    menu_bar = win.menuBar()
-    menu_bar.addMenu(microscope_utils_menu)
+            microscope = control.microscope.Microscope.build_from_global_config(
+                args.simulation, skip_init=args.skip_init, reporter=reporter
+            )
+            if reporter.failures:
+                # Independent device failures were collected rather than raised so
+                # the window could show them all at once. Stop here regardless:
+                # the GUI dereferences several of these unconditionally (e.g.
+                # SpinningDiskConfocalWidget(self.xlight)) and would crash with a
+                # far less useful message than the summary we can show now.
+                raise StartupFailed(reporter.results)
 
-    # Show startup warning if simulated disk I/O mode is enabled
+            reporter.attach_laser_engine(microscope.addons.squid_laser_engine)
+
+            win = gui.HighContentScreeningGui(
+                microscope=microscope,
+                is_simulation=args.simulation,
+                live_only_mode=args.live_only,
+                skip_init=args.skip_init,
+                reporter=reporter,
+            )
+        except StartupError as e:
+            _teardown_and_exit(e, reporter, instance_lock, log_path)
+        except Exception as e:
+            # Anything that escaped the per-step handling still deserves a
+            # dialog rather than a silent death. Deliberately Exception and not
+            # BaseException, so SystemExit and KeyboardInterrupt still pass
+            # straight through.
+            _teardown_and_exit(e, reporter, instance_lock, log_path)
+
+        microscope_utils_menu = QMenu("Utils", win)
+
+        stage_utils_action = QAction("Stage Utils", win)
+        stage_utils_action.triggered.connect(win.stageUtils.show)
+        microscope_utils_menu.addAction(stage_utils_action)
+
+        if control._def.USE_OBJECTIVE_TURRET:
+            reset_turret_action = QAction("Reset Objective Turret", win)
+            reset_turret_action.triggered.connect(win.resetObjectiveTurret)
+            microscope_utils_menu.addAction(reset_turret_action)
+
+        workflow_runner_action = QAction("Workflow Runner...", win)
+        workflow_runner_action.triggered.connect(win.openWorkflowRunner)
+        microscope_utils_menu.addAction(workflow_runner_action)
+
+        menu_bar = win.menuBar()
+        menu_bar.addMenu(microscope_utils_menu)
+
+        win.showMaximized()
+    # Leaving the `with` closes the startup window, now that the main one is up.
+
+    # Show startup warning if simulated disk I/O mode is enabled. Deliberately
+    # after the startup window is gone: this is a modal dialog, and it would
+    # otherwise open underneath an always-on-top window.
     if control._def.SIMULATED_DISK_IO_ENABLED:
         QMessageBox.warning(
             None,
@@ -142,8 +220,6 @@ if __name__ == "__main__":
             "To disable: Settings > Settings... > Dev tab",
             QMessageBox.Ok,
         )
-
-    win.showMaximized()
 
     if USE_TERMINAL_CONSOLE:
         console_locals = {"microscope": win.microscope}

--- a/software/tests/control/test_HighContentScreeningGui.py
+++ b/software/tests/control/test_HighContentScreeningGui.py
@@ -6,6 +6,23 @@ import control.gui_hcs
 from qtpy.QtWidgets import QMessageBox
 
 import control.microscope
+import control.startup_progress_window
+from control.startup_progress import (
+    StartupCoreDeviceError,
+    StartupReporter,
+    StepState,
+    declare_expected_steps,
+)
+
+
+@pytest.fixture(autouse=True)
+def no_stray_startup_dialog(monkeypatch):
+    """A startup summary dialog reaching exec_() in a test would hang CI forever."""
+
+    def fail(self, *args, **kwargs):
+        raise RuntimeError(f"Unexpected startup summary dialog: {self.details_text()}")
+
+    monkeypatch.setattr(control.startup_progress_window.StartupSummaryDialog, "exec_", fail)
 
 
 @pytest.fixture
@@ -139,3 +156,82 @@ def test_cleanup_closes_stage_before_microcontroller(qtbot, monkeypatch, confirm
     gui._cleanup_common(for_restart=True)
 
     assert calls == ["stage", "microcontroller"]
+
+
+def test_startup_reporter_records_every_step(qtbot, confirm_exit_yes):
+    """End-to-end: a healthy simulated startup leaves no row unfinished."""
+    reporter = StartupReporter()
+    scope = control.microscope.Microscope.build_from_global_config(True, reporter=reporter)
+    win = control.gui_hcs.HighContentScreeningGui(microscope=scope, is_simulation=True, reporter=reporter)
+    qtbot.add_widget(win)
+
+    assert reporter.failures == []
+    unfinished = [r.key for r in reporter.results if not r.finished]
+    assert unfinished == [], f"steps left hanging: {unfinished}"
+    assert reporter.get("camera").state is StepState.READY
+    assert reporter.get("gui_widgets").state is StepState.READY
+
+
+def test_independent_failure_does_not_stop_the_sweep(qtbot, monkeypatch, confirm_exit_yes):
+    """The whole point of the feature: report every problem in one pass.
+
+    A dead spinning disk must not prevent the cameras and the illumination
+    controller from being probed, so the operator gets one list instead of
+    discovering the next failure on the next launch.
+    """
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("spinning disk is powered off")
+
+    # Force the peripheral on rather than inheriting it from whatever .ini the run picked up:
+    # the committed configurations all ship enable_spinning_disk_confocal = False, so without
+    # this the step never runs and the assertion below silently has nothing to find.
+    monkeypatch.setattr(control._def, "ENABLE_SPINNING_DISK_CONFOCAL", True)
+    monkeypatch.setattr(control._def, "USE_DRAGONFLY", False)
+    monkeypatch.setattr(control.microscope.serial_peripherals, "XLight_Simulation", boom)
+
+    reporter = StartupReporter()
+    scope = control.microscope.Microscope.build_from_global_config(True, reporter=reporter)
+    try:
+        assert [f.key for f in reporter.failures] == ["spinning_disk"]
+        # Everything after the failure still ran.
+        assert reporter.get("camera").state is StepState.READY
+        assert reporter.get("illumination_controller").state is StepState.READY
+        assert reporter.get("prep_camera").state is StepState.READY
+    finally:
+        scope.close()
+
+
+def test_core_failure_stops_the_sweep(qtbot, monkeypatch, confirm_exit_yes):
+    """A device nothing can work without stops immediately, still legibly."""
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("camera not found")
+
+    monkeypatch.setattr(control.microscope.squid.camera.utils, "get_camera", boom)
+
+    reporter = StartupReporter()
+    # Declare up front, as main_hcs does, so rows for steps that never run still
+    # exist and can be seen sitting at Pending.
+    declare_expected_steps(reporter, simulated=True, skip_init=False)
+    with pytest.raises(StartupCoreDeviceError) as excinfo:
+        control.microscope.Microscope.build_from_global_config(True, reporter=reporter)
+
+    assert excinfo.value.step_key == "camera"
+    # Steps after the core failure never ran, and say so rather than claiming success.
+    assert reporter.get("illumination_controller").state is StepState.PENDING
+
+
+def test_devices_are_registered_for_teardown(qtbot, confirm_exit_yes):
+    """An abort mid-build has no Microscope to close, so the reporter's registry
+    is the only handle on what was opened."""
+    reporter = StartupReporter()
+    scope = control.microscope.Microscope.build_from_global_config(True, reporter=reporter)
+    try:
+        labels = [label for label, _ in reporter.opened]
+        assert "microcontroller" in labels
+        assert "main camera" in labels
+        # Construction order, so reversing it tears down in the required order.
+        assert labels.index("microcontroller") < labels.index("main camera")
+    finally:
+        scope.close()

--- a/software/tests/control/test_serial_peripherals_startup.py
+++ b/software/tests/control/test_serial_peripherals_startup.py
@@ -1,0 +1,267 @@
+"""Tests for the startup-hardening changes to SerialDevice and LDI.
+
+Covers the two failure modes that used to kill startup silently:
+a device that is powered off (no COM port at all), and a device that answers
+"still warming up" for longer than the old five-attempt retry allowed.
+"""
+
+import time
+
+import pytest
+
+import control._def
+from control.serial_peripherals import (
+    LDI,
+    SerialDevice,
+    SerialDeviceAborted,
+    SerialDeviceError,
+    SerialDeviceTimeout,
+    SerialPortNotFoundError,
+    _is_warmup_response,
+)
+
+
+class FakePort:
+    """Minimal stand-in for serial.Serial driven by a scripted reply list."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.written = []
+        self.closed = False
+        self.is_open = True
+        self.in_waiting = 0
+
+    def write(self, data):
+        self.written.append(data)
+
+    def readline(self):
+        if self._responses:
+            reply = self._responses.pop(0)
+        else:
+            reply = ""
+        return (reply + "\n").encode()
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture
+def no_comports(monkeypatch):
+    monkeypatch.setattr("control.serial_peripherals.list_ports.comports", lambda: [])
+
+
+def make_device(responses, **kwargs):
+    """A SerialDevice with a fake port bolted on.
+
+    Constructed with no port and require_port=False so __init__ never touches
+    real hardware, then handed the fake.
+    """
+    device = SerialDevice(require_port=False, device_label="Test device", **kwargs)
+    device.serial = FakePort(responses)
+    return device
+
+
+# ── an absent device is named, not an AttributeError later ──────────────────
+
+
+def test_missing_port_raises_named_error_at_construction(no_comports):
+    with pytest.raises(SerialPortNotFoundError) as excinfo:
+        SerialDevice(SN="NOPE", device_label="Spinning disk (X-Light/Cicero)")
+    message = str(excinfo.value)
+    assert "Spinning disk (X-Light/Cicero)" in message
+    assert "NOPE" in message
+    assert "powered off" in message
+
+
+def test_missing_port_can_be_tolerated_for_simulation(no_comports):
+    device = SerialDevice(SN="NOPE", device_label="sim", require_port=False)
+    assert device.serial is None
+
+
+def test_open_ser_raises_when_port_still_absent(no_comports):
+    device = SerialDevice(SN="NOPE", device_label="sim", require_port=False)
+    with pytest.raises(SerialPortNotFoundError):
+        device.open_ser(require_port=True)
+
+
+def test_write_paths_raise_named_error_not_attribute_error(no_comports):
+    device = SerialDevice(SN="NOPE", device_label="LDI laser engine", require_port=False)
+    for call in (
+        lambda: device.write("x\r"),
+        lambda: device.write_and_read("x\r"),
+        lambda: device.write_and_check("x\r", "ok"),
+    ):
+        with pytest.raises(SerialPortNotFoundError):
+            call()
+
+
+def test_close_is_safe_when_port_was_never_found(no_comports):
+    device = SerialDevice(SN="NOPE", device_label="sim", require_port=False)
+    device.close()  # must not raise - this is the teardown path for this failure
+
+
+# ── the legacy retry contract is unchanged ─────────────────────────────────
+
+
+def test_legacy_behaviour_is_unchanged(monkeypatch):
+    """With no new kwargs: exactly max_attempts tries, then SerialDeviceError."""
+    slept = []
+    monkeypatch.setattr(time, "sleep", lambda s: slept.append(s))
+    device = make_device(["nope"] * 20)
+
+    with pytest.raises(SerialDeviceError) as excinfo:
+        device.write_and_check("go\r", "ok", max_attempts=5, attempt_delay=1)
+
+    assert "Max attempts reached" in str(excinfo.value)
+    assert len(device.serial.written) == 5
+    assert slept.count(1) == 5  # one attempt_delay per attempt, as before
+
+
+def test_matching_response_returns_immediately(monkeypatch):
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+    device = make_device(["ok"])
+    assert device.write_and_check("go\r", "ok") == "ok"
+    assert len(device.serial.written) == 1
+
+
+def test_prefix_match_still_accepted(monkeypatch):
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+    device = make_device(["ok-and-then-some"])
+    assert device.write_and_check("go\r", "ok") == "ok-and-then-some"
+
+
+# ── warm-up replies are waited out ─────────────────────────────────────────
+
+
+def test_warmup_is_retried_past_max_attempts_then_succeeds(monkeypatch):
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+    warmups = ["ERR=System in Warmup State"] * 12
+    device = make_device(warmups + ["ok"])
+    seen = []
+
+    result = device.write_and_check(
+        "run!\r",
+        "ok",
+        max_attempts=5,
+        timeout_s=90.0,
+        retry_if=_is_warmup_response,
+        on_retry=lambda response, elapsed: seen.append(response),
+    )
+
+    assert result == "ok"
+    # 12 warm-up replies is well past the old 5-attempt budget that killed startup.
+    assert len(seen) == 12
+    assert seen[0] == "ERR=System in Warmup State"
+
+
+def test_warmup_that_never_clears_times_out_with_the_last_reply(monkeypatch):
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+    clock = {"t": 0.0}
+
+    def fake_monotonic():
+        clock["t"] += 1.0
+        return clock["t"]
+
+    monkeypatch.setattr(time, "monotonic", fake_monotonic)
+    device = make_device(["ERR=System in Warmup State"] * 500)
+
+    with pytest.raises(SerialDeviceTimeout) as excinfo:
+        device.write_and_check("run!\r", "ok", timeout_s=10.0, retry_if=_is_warmup_response)
+
+    message = str(excinfo.value)
+    assert "ERR=System in Warmup State" in message
+    assert "Test device" in message
+
+
+def test_a_wrong_reply_still_fails_fast_even_with_a_long_timeout(monkeypatch):
+    """A genuinely wrong answer must not burn the whole 90s budget."""
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+    device = make_device(["ERR=Bad Command"] * 20)
+
+    with pytest.raises(SerialDeviceError) as excinfo:
+        device.write_and_check("run!\r", "ok", max_attempts=5, timeout_s=90.0, retry_if=_is_warmup_response)
+
+    assert not isinstance(excinfo.value, SerialDeviceTimeout)
+    assert len(device.serial.written) == 5
+
+
+def test_silence_fails_fast_rather_than_waiting_out_the_timeout(monkeypatch):
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+    device = make_device([])  # device says nothing at all
+
+    with pytest.raises(SerialDeviceError):
+        device.write_and_check("run!\r", "ok", max_attempts=3, timeout_s=90.0, retry_if=_is_warmup_response)
+
+    assert len(device.serial.written) == 3
+
+
+def test_cancel_fn_aborts_promptly(monkeypatch):
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+    device = make_device(["ERR=System in Warmup State"] * 100)
+    calls = {"n": 0}
+
+    def cancel():
+        calls["n"] += 1
+        return calls["n"] > 3
+
+    with pytest.raises(SerialDeviceAborted):
+        device.write_and_check("run!\r", "ok", timeout_s=90.0, retry_if=_is_warmup_response, cancel_fn=cancel)
+
+    assert len(device.serial.written) == 3
+
+
+def test_sleep_fn_is_used_instead_of_time_sleep():
+    """The reporter injects a pumping sleep so the window stays alive."""
+    device = make_device(["ok"])
+    pumped = []
+    device.write_and_check("go\r", "ok", sleep_fn=lambda s: pumped.append(s))
+    assert pumped, "sleep_fn was never called"
+
+
+# ── the warm-up matcher ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "response",
+    ["ERR=System in Warmup State", "err=system in warm up state", "Warming up, please wait"],
+)
+def test_warmup_matcher_accepts_expected_wordings(response):
+    assert _is_warmup_response(response)
+
+
+@pytest.mark.parametrize("response", ["ok", "ERR=Bad Command", "", "ERR=Interlock Open"])
+def test_warmup_matcher_rejects_everything_else(response):
+    assert not _is_warmup_response(response)
+
+
+# ── LDI.initialize wiring ──────────────────────────────────────────────────
+
+
+def test_ldi_initialize_waits_out_warmup(monkeypatch):
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+    ldi = LDI.__new__(LDI)  # bypass __init__, which would go looking for hardware
+    ldi.serial_connection = make_device(["ERR=System in Warmup State"] * 8 + ["ok"])
+    seen = []
+
+    ldi.initialize(timeout_s=90.0, on_retry=lambda response, elapsed: seen.append(response))
+
+    assert len(seen) == 8
+
+
+def test_ldi_initialize_defaults_to_the_configured_timeout(monkeypatch):
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+    monkeypatch.setattr(control._def, "STARTUP_DEVICE_TIMEOUT_S", 123.0)
+    captured = {}
+
+    class RecordingDevice:
+        def write_and_check(self, command, expected, **kwargs):
+            captured.update(kwargs)
+            return "ok"
+
+    ldi = LDI.__new__(LDI)
+    ldi.serial_connection = RecordingDevice()
+    ldi.initialize()
+
+    # Read live from control._def, not the star-imported snapshot, so the
+    # Preferences dialog can change it without a restart.
+    assert captured["timeout_s"] == 123.0

--- a/software/tests/control/test_startup_progress.py
+++ b/software/tests/control/test_startup_progress.py
@@ -1,0 +1,303 @@
+"""Tests for the transport-neutral half of startup progress reporting."""
+
+import time
+
+import pytest
+
+from control.startup_progress import (
+    NULL_REPORTER,
+    StartupAborted,
+    StartupCoreDeviceError,
+    StartupFailed,
+    StartupReporter,
+    StepState,
+    declare_expected_steps,
+    state_color,
+    state_label,
+    wait_until,
+)
+
+
+@pytest.fixture
+def reporter():
+    return StartupReporter(device_timeout_s=90.0)
+
+
+# ── step() outcomes ────────────────────────────────────────────────────────
+
+
+def test_successful_step_becomes_ready(reporter):
+    with reporter.step("a", label="Device A"):
+        pass
+    assert reporter.get("a").state is StepState.READY
+    assert reporter.failures == []
+
+
+def test_independent_failure_is_recorded_and_swallowed(reporter):
+    """The whole point: one dead device must not stop the sweep."""
+    with reporter.step("a", label="Device A"):
+        raise RuntimeError("boom")
+    # Execution continues here - no exception escaped.
+    with reporter.step("b", label="Device B"):
+        pass
+
+    assert reporter.get("a").state is StepState.FAILED
+    assert "RuntimeError: boom" in reporter.get("a").detail
+    assert reporter.get("b").state is StepState.READY
+    assert [f.key for f in reporter.failures] == ["a"]
+
+
+def test_core_failure_stops_the_sweep(reporter):
+    with pytest.raises(StartupCoreDeviceError) as excinfo:
+        with reporter.step("mcu", label="Microcontroller", core=True):
+            raise RuntimeError("no such port")
+
+    assert excinfo.value.step_key == "mcu"
+    assert isinstance(excinfo.value.cause, RuntimeError)
+    assert reporter.get("mcu").state is StepState.FAILED
+
+
+def test_step_keeps_a_terminal_state_the_body_already_set(reporter):
+    """A driver that classified the failure itself must not be overwritten."""
+    with reporter.step("a", label="Device A") as progress:
+        progress.not_found("no serial port found for SN='X'")
+        raise RuntimeError("stand-in for SerialPortNotFoundError")
+
+    result = reporter.get("a")
+    assert result.state is StepState.NOT_FOUND
+    assert "no serial port" in result.detail
+
+
+def test_abort_passes_through_unswallowed(reporter):
+    reporter.request_abort()
+    with pytest.raises(StartupAborted) as excinfo:
+        with reporter.step("a", label="Device A"):
+            pytest.fail("body must not run once abort was requested")
+
+    assert excinfo.value.step_key == "a"
+    assert "Device A" in str(excinfo.value)
+
+
+def test_abort_mid_step_is_not_recorded_as_a_device_failure(reporter):
+    with pytest.raises(StartupAborted):
+        with reporter.step("a", label="Device A"):
+            reporter.request_abort()
+            reporter.raise_if_aborted("a")
+
+    # Aborting is a user action, not a broken device.
+    assert reporter.failures == []
+
+
+def test_warmup_detail_is_cleared_once_ready(reporter):
+    with reporter.step("ldi", label="LDI") as progress:
+        progress.on_warmup_retry("ERR=System in Warmup State", 12.0)
+        assert reporter.get("ldi").state is StepState.WARMING_UP
+
+    result = reporter.get("ldi")
+    assert result.state is StepState.READY
+    assert result.detail == "", "a Ready row must not still show warm-up chatter"
+
+
+def test_informational_detail_survives_a_successful_step(reporter):
+    with reporter.step("engine", label="Laser engine") as progress:
+        progress.detail("started; warms up in the background")
+    assert reporter.get("engine").detail == "started; warms up in the background"
+
+
+def test_warning_is_not_a_failure(reporter):
+    """The paths that already swallow errors and boot anyway must keep booting."""
+    with reporter.step("fw", label="Filter wheel") as progress:
+        progress.warning("homing failed - position unknown")
+
+    assert reporter.get("fw").state is StepState.WARNING
+    assert reporter.failures == []
+
+
+def test_elapsed_is_recorded(reporter, monkeypatch):
+    # A settable clock rather than a fixed sequence, so the test does not depend
+    # on how many times step() happens to read the clock.
+    clock = {"t": 100.0}
+    monkeypatch.setattr(time, "monotonic", lambda: clock["t"])
+    with reporter.step("a", label="Device A"):
+        clock["t"] = 103.5
+    assert reporter.get("a").elapsed_s == pytest.approx(3.5)
+
+
+# ── declaration and ordering ───────────────────────────────────────────────
+
+
+def test_declared_order_is_preserved(reporter):
+    for key in ("c", "a", "b"):
+        reporter.declare(key, key.upper())
+    assert [r.key for r in reporter.results] == ["c", "a", "b"]
+
+
+def test_step_on_an_undeclared_key_appends_a_row(reporter):
+    reporter.declare("a", "A")
+    with reporter.step("late", label="Late arrival"):
+        pass
+    assert [r.key for r in reporter.results] == ["a", "late"]
+
+
+def test_declare_expected_steps_matches_the_machine_config():
+    reporter = StartupReporter()
+    declare_expected_steps(reporter, simulated=False, skip_init=False)
+    keys = [r.key for r in reporter.results]
+
+    # Always present regardless of configuration.
+    for expected in ("imports", "microcontroller", "stage_xy", "camera", "illumination_controller"):
+        assert expected in keys
+    # Ordering matters: the checklist should read in the order things happen.
+    assert keys.index("microcontroller") < keys.index("camera")
+    assert keys.index("camera") < keys.index("gui_widgets")
+    assert all(r.state is StepState.PENDING for r in reporter.results)
+
+
+def test_skip_init_drops_the_homing_row():
+    with_homing = StartupReporter()
+    declare_expected_steps(with_homing, simulated=False, skip_init=False)
+    without = StartupReporter()
+    declare_expected_steps(without, simulated=False, skip_init=True)
+
+    assert "prep_home_xyz" in [r.key for r in with_homing.results]
+    assert "prep_home_xyz" not in [r.key for r in without.results]
+
+
+def test_simulation_declares_no_external_light_source():
+    """Nothing may sit at Pending forever: simulation never builds the LDI."""
+    reporter = StartupReporter()
+    declare_expected_steps(reporter, simulated=True, skip_init=False)
+    assert "light_source" not in [r.key for r in reporter.results]
+
+
+def test_simulation_marks_everything_interruptible():
+    reporter = StartupReporter()
+    declare_expected_steps(reporter, simulated=True, skip_init=False)
+    assert all(r.interruptible for r in reporter.results)
+
+
+# ── the opened-device registry ─────────────────────────────────────────────
+
+
+def test_close_all_runs_in_reverse_registration_order(reporter):
+    closed = []
+    for name in ("microcontroller", "stage", "camera"):
+        reporter.register_opened(name, lambda n=name: closed.append(n))
+
+    assert reporter.close_all() == []
+    # Reverse of construction order, which is what the teardown ordering in
+    # tests/conftest.py requires.
+    assert closed == ["camera", "stage", "microcontroller"]
+
+
+def test_close_all_continues_past_a_failing_closer(reporter):
+    closed = []
+    reporter.register_opened("microcontroller", lambda: closed.append("microcontroller"))
+    reporter.register_opened("wedged device", lambda: (_ for _ in ()).throw(RuntimeError("port stuck")))
+    reporter.register_opened("camera", lambda: closed.append("camera"))
+
+    errors = reporter.close_all()
+
+    assert closed == ["camera", "microcontroller"], "one bad closer must not strand the rest"
+    assert len(errors) == 1
+    assert "wedged device" in errors[0]
+
+
+def test_close_all_is_idempotent(reporter):
+    calls = []
+    reporter.register_opened("camera", lambda: calls.append(1))
+    reporter.close_all()
+    reporter.close_all()
+    assert len(calls) == 1
+
+
+# ── abort plumbing ─────────────────────────────────────────────────────────
+
+
+def test_cancel_fn_tracks_the_abort_flag(reporter):
+    cancel = reporter.cancel_fn()
+    assert cancel() is False
+    reporter.request_abort()
+    assert cancel() is True
+
+
+def test_raise_if_aborted_is_quiet_until_requested(reporter):
+    reporter.declare("a", "A")
+    reporter.raise_if_aborted("a")  # must not raise
+    reporter.request_abort()
+    with pytest.raises(StartupAborted):
+        reporter.raise_if_aborted("a")
+
+
+# ── wait_until ─────────────────────────────────────────────────────────────
+
+
+def test_wait_until_returns_true_when_the_predicate_fires():
+    calls = {"n": 0}
+
+    def ready():
+        calls["n"] += 1
+        return calls["n"] >= 3
+
+    assert wait_until(ready, timeout_s=10.0, sleep_fn=lambda s: None) is True
+
+
+def test_wait_until_returns_false_at_the_deadline(monkeypatch):
+    clock = {"t": 0.0}
+
+    def fake_monotonic():
+        clock["t"] += 1.0
+        return clock["t"]
+
+    monkeypatch.setattr(time, "monotonic", fake_monotonic)
+    assert wait_until(lambda: False, timeout_s=3.0, sleep_fn=lambda s: None) is False
+
+
+def test_wait_until_returns_false_on_cancel():
+    assert wait_until(lambda: False, timeout_s=10.0, cancel_fn=lambda: True, sleep_fn=lambda s: None) is False
+
+
+def test_wait_until_reports_progress_on_each_tick():
+    ticks = []
+    calls = {"n": 0}
+
+    def ready():
+        calls["n"] += 1
+        return calls["n"] >= 4
+
+    wait_until(ready, timeout_s=10.0, on_tick=ticks.append, sleep_fn=lambda s: None)
+    assert len(ticks) == 3
+
+
+# ── the no-op default ──────────────────────────────────────────────────────
+
+
+def test_null_reporter_is_usable_and_inert():
+    """Existing positional callers get this and must pay nothing for it."""
+    with NULL_REPORTER.step("anything"):
+        pass
+    assert NULL_REPORTER.is_abort_requested() is False
+    NULL_REPORTER.pump()
+    NULL_REPORTER.sleep(0)
+
+
+# ── presentation helpers ───────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("state", list(StepState))
+def test_every_state_has_a_label_and_a_colour(state):
+    assert state_label(state) and not state_label(state).startswith("StepState")
+    assert state_color(state).startswith("#")
+
+
+def test_startup_failed_summarises_only_the_failures():
+    reporter = StartupReporter()
+    with reporter.step("a", label="Device A"):
+        raise RuntimeError("boom")
+    with reporter.step("b", label="Device B"):
+        pass
+
+    error = StartupFailed(reporter.results)
+    assert [r.key for r in error.failures] == ["a"]
+    assert "Device A" in str(error)
+    assert "Device B" not in str(error)

--- a/software/tests/control/test_startup_progress_window.py
+++ b/software/tests/control/test_startup_progress_window.py
@@ -1,0 +1,273 @@
+"""Tests for the startup window, its input fence, and the summary dialog."""
+
+import pytest
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QApplication, QPushButton, QWidget
+
+from control.startup_progress import StartupAborted, StepResult, StepState, declare_expected_steps
+from control.startup_progress_window import (
+    QtStartupReporter,
+    StartupProgressWindow,
+    StartupSummaryDialog,
+    _remediation_hint,
+    format_checklist,
+)
+
+
+@pytest.fixture
+def reporter(qtbot):
+    """A QtStartupReporter that is always torn down, even if a test fails."""
+    instance = QtStartupReporter(QApplication.instance(), log_path=r"C:\tmp\main_hcs.log", device_timeout_s=90.0)
+    qtbot.add_widget(instance.window)
+    yield instance
+    instance.finish()
+
+
+# ── the window ─────────────────────────────────────────────────────────────
+
+
+def test_rows_render_each_state(qtbot):
+    window = StartupProgressWindow(log_path="somewhere/main_hcs.log")
+    qtbot.add_widget(window)
+
+    for index, state in enumerate(StepState):
+        result = StepResult(key=f"k{index}", label=f"Device {index}", state=state)
+        window.update_row(result)
+
+    assert len(window._rows) == len(list(StepState))
+
+
+def test_uninterruptible_step_says_so(qtbot):
+    window = StartupProgressWindow(log_path="somewhere/main_hcs.log")
+    qtbot.add_widget(window)
+    result = StepResult(key="home", label="Homing stage", state=StepState.CONNECTING, interruptible=False)
+    window.update_row(result)
+
+    _, _, _, detail = window._rows["home"]
+    assert "cannot be interrupted" in detail.text()
+
+
+def test_window_refuses_to_close_until_allowed(qtbot):
+    window = StartupProgressWindow(log_path="somewhere/main_hcs.log")
+    qtbot.add_widget(window)
+    window.show()
+
+    window.close()
+    assert window.isVisible(), "closing mid-startup would strand open devices"
+
+    window.allow_close()
+    window.close()
+    assert not window.isVisible()
+
+
+# ── abort ──────────────────────────────────────────────────────────────────
+
+
+def test_abort_click_only_sets_a_flag(qtbot, reporter):
+    """Teardown must never run from the slot - the init stack is still live."""
+    closed = []
+    reporter.register_opened("camera", lambda: closed.append("camera"))
+    reporter.show()
+
+    qtbot.mouseClick(reporter.window.btn_abort, Qt.LeftButton)
+
+    assert reporter.is_abort_requested() is True
+    assert closed == [], "the abort slot must not close anything"
+    assert not reporter.window.btn_abort.isEnabled()
+
+
+def test_abort_surfaces_at_the_next_step(qtbot, reporter):
+    reporter.show()
+    qtbot.mouseClick(reporter.window.btn_abort, Qt.LeftButton)
+
+    with pytest.raises(StartupAborted):
+        with reporter.step("next_device", label="Next device"):
+            pytest.fail("body must not run after abort")
+
+
+# ── the input fence ────────────────────────────────────────────────────────
+
+
+def test_input_aimed_elsewhere_is_discarded_not_deferred(qtbot, reporter):
+    """ExcludeUserInputEvents would defer these and replay them into the main
+    window later; the filter must drop them instead."""
+    stray = QPushButton("Somewhere else")
+    qtbot.add_widget(stray)
+    stray.show()
+    presses = []
+    stray.clicked.connect(lambda: presses.append(1))
+
+    reporter.show()
+    qtbot.mouseClick(stray, Qt.LeftButton)
+    QApplication.instance().processEvents()
+    assert presses == [], "input outside the startup window must be dropped"
+
+    # And it must not come back once the fence is removed.
+    reporter.finish()
+    QApplication.instance().processEvents()
+    assert presses == [], "a dropped event must not be replayed after finish()"
+
+
+def test_the_abort_button_still_receives_clicks_through_the_fence(qtbot, reporter):
+    reporter.show()
+    qtbot.mouseClick(reporter.window.btn_abort, Qt.LeftButton)
+    assert reporter.is_abort_requested() is True
+
+
+def test_context_manager_removes_the_fence_even_when_the_body_raises(qtbot):
+    app = QApplication.instance()
+    stray = QPushButton("Somewhere else")
+    qtbot.add_widget(stray)
+    stray.show()
+    presses = []
+    stray.clicked.connect(lambda: presses.append(1))
+
+    with pytest.raises(ValueError):
+        with QtStartupReporter(app, log_path="x.log") as instance:
+            qtbot.add_widget(instance.window)
+            instance.show()
+            raise ValueError("something went wrong during startup")
+
+    # A leaked filter would silently swallow input in every later widget.
+    qtbot.mouseClick(stray, Qt.LeftButton)
+    app.processEvents()
+    assert presses == [1]
+
+
+def test_finish_is_idempotent(qtbot, reporter):
+    reporter.show()
+    reporter.finish()
+    reporter.finish()
+
+
+def test_quit_on_last_window_closed_is_restored(qtbot, reporter):
+    app = QApplication.instance()
+    before = app.quitOnLastWindowClosed()
+    reporter.show()
+    assert app.quitOnLastWindowClosed() is False
+    reporter.finish()
+    assert app.quitOnLastWindowClosed() == before
+
+
+# ── pumping ────────────────────────────────────────────────────────────────
+
+
+def test_pump_does_not_recurse(qtbot, reporter):
+    """write_and_check is also called from GUI slots; the guard must hold."""
+    reporter.show()
+    depth = {"max": 0, "current": 0}
+    original = reporter._app.processEvents
+
+    def counting_process_events(*a, **kw):
+        depth["current"] += 1
+        depth["max"] = max(depth["max"], depth["current"])
+        reporter.pump(force=True)  # re-entrant call, must be a no-op
+        depth["current"] -= 1
+        return original(*a, **kw)
+
+    reporter._app.processEvents = counting_process_events
+    try:
+        reporter.pump(force=True)
+    finally:
+        reporter._app.processEvents = original
+
+    assert depth["max"] == 1
+
+
+def test_sleep_pumps_and_returns(qtbot, reporter):
+    reporter.show()
+    pumps = []
+    original = reporter.pump
+    reporter.pump = lambda force=False: pumps.append(1) or original(force)
+    reporter.sleep(0.1)
+    assert pumps, "sleep must keep the window painted"
+
+
+def test_state_changes_reach_the_window(qtbot, reporter):
+    reporter.show()
+    with reporter.step("camera", label="Main camera"):
+        pass
+    _, name, state, _ = reporter.window._rows["camera"]
+    assert name.text() == "Main camera"
+    assert state.text() == "Ready"
+
+
+# ── the summary dialog ─────────────────────────────────────────────────────
+
+
+def make_failed_results():
+    from control.startup_progress import StartupReporter
+
+    reporter = StartupReporter()
+    with reporter.step("microcontroller", label="Microcontroller"):
+        pass
+    with reporter.step("spinning_disk", label="Spinning disk (Cicero)") as progress:
+        progress.not_found("no serial port found for SN='A5065KURA'")
+        raise RuntimeError("stand-in")
+    return reporter.results
+
+
+def test_summary_lists_every_row_and_the_log_path(qtbot):
+    results = make_failed_results()
+    dialog = StartupSummaryDialog("Initialization failed.", results, r"C:\logs\main_hcs.log")
+    qtbot.add_widget(dialog)
+
+    text = dialog.details_text()
+    assert "Microcontroller" in text
+    assert "Spinning disk (Cicero)" in text
+    assert "no serial port found" in text
+    assert r"C:\logs\main_hcs.log" in text
+
+
+def test_missing_device_gets_a_power_and_cable_hint():
+    result = StepResult(key="spinning_disk", label="Spinning disk (Cicero)", state=StepState.NOT_FOUND)
+    hint = _remediation_hint(result)
+    assert "powered on" in hint
+    assert "Spinning disk (Cicero)" in hint
+
+
+def test_warmup_timeout_gets_a_wait_and_retry_hint():
+    class SerialDeviceTimeout(Exception):
+        pass
+
+    result = StepResult(
+        key="light_source",
+        label="LDI laser engine",
+        state=StepState.FAILED,
+        detail="'run!' still returning 'ERR=System in Warmup State' after 90.0s",
+        exception=SerialDeviceTimeout(),
+    )
+    hint = _remediation_hint(result)
+    assert "warming up" in hint
+    assert "Startup device timeout" in hint
+
+
+def test_a_healthy_row_gets_no_hint():
+    assert _remediation_hint(StepResult(key="camera", label="Main camera", state=StepState.READY)) is None
+
+
+def test_summary_shows_the_hint_panel_only_when_there_is_something_to_say(qtbot):
+    from qtpy.QtWidgets import QLabel
+
+    def hint_text(results):
+        dialog = StartupSummaryDialog("headline", results, "log.txt")
+        qtbot.add_widget(dialog)
+        return " ".join(label.text() for label in dialog.findChildren(QLabel))
+
+    assert "What to check" in hint_text(make_failed_results())
+
+    from control.startup_progress import StartupReporter
+
+    clean = StartupReporter()
+    with clean.step("camera", label="Main camera"):
+        pass
+    assert "What to check" not in hint_text(clean.results)
+
+
+def test_checklist_formatting_is_aligned():
+    results = make_failed_results()
+    text = format_checklist(results)
+    lines = text.splitlines()
+    assert len(lines) == 2
+    assert all("." in line for line in lines)
+    assert "Not found" in text


### PR DESCRIPTION
Startup used to be a black hole. Between building the Microscope and showing
the main window, nothing was on screen and no Qt event loop ran, so any
hardware failure reached the excepthook, logged "Uncaught Exception" and killed
the process with no dialog. From the operator's seat the desktop icon simply
did nothing.

This bit us during a live customer demo on 2026-07-31: the LDI was still
warming up and answered the "run" handshake with ERR=System in Warmup State.
SerialDevice.write_and_check allowed 5 attempts a second apart, about 5.5
seconds of patience, then raised and killed startup. Two launches died that
way; the third, 35 seconds later, worked with no warning. The remedy was time,
not anything the operator did.

What this adds:

- A startup window listing every device this machine is configured for, with
  live per-device state (Pending / Connecting / Warming up / Ready / Warning /
  Failed / Not found), open from as early as possible until the main GUI draws.
- An Abort Initialization button. Abort only sets a flag; teardown happens
  after the initialization stack unwinds, walking a registry of everything
  opened, in reverse. That registry is necessary because
  build_from_global_config holds every device in locals until its last
  statement, so before this there was nothing for a caller to close.
- Transient "still warming up" replies are retried until
  startup_device_timeout_s (default 90s, also exposed in Preferences) instead
  of failing after ~5.5s. Any other wrong reply still fails fast against
  max_attempts, so a genuinely broken device does not cost the full timeout.
- A device that is powered off now raises SerialPortNotFoundError naming the
  device and its serial number at construction, instead of surfacing much later
  as an AttributeError on None from inside whichever driver method happened to
  talk first.
- Independent devices are all attempted so one summary dialog can list every
  problem at once; core devices stop the sweep immediately. The summary names
  what failed, suggests what to check, and shows the log path.

Implementation notes:

- Initialization stays on the Qt main thread. A worker thread is not viable
  because Microscope builds LiveController QObjects and the GUI builds
  napari/vispy viewers that must live on the main thread. The window is kept
  painted by pumping processEvents from progress updates and from the new
  serial wait loops, fenced by an application-level event filter that discards
  input aimed elsewhere. QEventLoop.ExcludeUserInputEvents is deliberately not
  used: it defers input rather than dropping it, so an impatient operator's
  clicks would be replayed into the main window the moment it appeared.
- Heavy imports moved into __main__ so the window can appear before the
  multi-second napari import rather than after it.
- The movement updater and NavigationWidget position timers now start from
  showEvent instead of during construction. Their 100ms stage polling would
  otherwise fire into a half-built GUI once the event loop is pumped.
- Abort cannot interrupt stage homing, the cached-position restore, or an
  objective move: those block in driver poll loops with no callback hook. Those
  rows say so rather than looking hung.
- Every new reporter parameter is keyword-only and defaults to a no-op
  reporter, so existing positional callers and tests are unchanged.

Adds 86 tests across four files covering the retry contract (including a
regression test that the legacy path is byte-for-byte unchanged), the
opened-device registry and teardown order, the input fence, and end-to-end
simulated startup with an independent failure and a core failure.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
