### PR TITLE
feat(acquisition): center z-stacks on the focus plane with a Relative mode

### DIFF
--- a/software/control/core/multi_point_worker.py
+++ b/software/control/core/multi_point_worker.py
@@ -1082,11 +1082,21 @@ class MultiPointWorker:
                 f"Autofocus failed in acquire_at_position.  Continuing to acquire anyway using the current z position (z={self.stage.get_pos().z_mm} [mm])"
             )
 
-        if self.NZ > 1:
-            self.prepare_z_stack()
+        # Capture the plane autofocus actually settled on, BEFORE prepare_z_stack() offsets
+        # us to the bottom of the stack.  Under "FROM CENTER" the z_level==0 position is
+        # half a stack range BELOW the focus plane, so seeding the next time point from it
+        # (see move_to_coordinate) would walk z down by half a range per time point and can
+        # push laser AF's displacement measurement outside laser_af_range.  For "FROM
+        # BOTTOM" this is identical to the z_level==0 position.
+        focus_plane_z_mm = self.stage.get_pos().z_mm
 
+        # Sync the piezo cache BEFORE prepare_z_stack(): the "FROM CENTER" pre-move goes
+        # through the piezo when use_piezo, and it works off self.z_piezo_um.
         if self.use_piezo:
             self.z_piezo_um = self.piezo.position
+
+        if self.NZ > 1:
+            self.prepare_z_stack()
 
         for z_level in range(self.NZ):
             file_ID = f"{region_id}_{fov:0{FILE_ID_PADDING}}_{z_level:0{FILE_ID_PADDING}}"
@@ -1096,7 +1106,7 @@ class MultiPointWorker:
             self._log.info(f"Acquiring image: ID={file_ID}, Metadata={metadata}")
 
             if z_level == 0 and (self.do_reflection_af or self.do_autofocus) and self.Nt > 1:
-                self._last_time_point_z_pos[(region_id, fov)] = acquire_pos.z_mm
+                self._last_time_point_z_pos[(region_id, fov)] = focus_plane_z_mm
 
             # laser af characterization mode
             if self.laser_auto_focus_controller and self.laser_auto_focus_controller.characterization_mode:
@@ -1147,11 +1157,13 @@ class MultiPointWorker:
             if self.abort_requested_fn():
                 self.handle_acquisition_abort(current_path)
 
-            # update FOV counter
-            self.af_fov_count = self.af_fov_count + 1
-
             if z_level < self.NZ - 1:
                 self.move_z_for_stack()
+
+        # update FOV counter -- once per FOV, NOT once per z level.  Acquisition.
+        # NUMBER_OF_FOVS_PER_AF throttles contrast AF in perform_autofocus(); incrementing
+        # inside the z loop turned it into "once every N images" for any NZ > 1 stack.
+        self.af_fov_count = self.af_fov_count + 1
 
         if self.NZ > 1:
             self.move_z_back_after_stack()
@@ -1213,12 +1225,37 @@ class MultiPointWorker:
             self._laser_af_successes += 1
         return True
 
+    def _center_offset_steps(self) -> int:
+        """Number of deltaZ steps from the focus plane down to the bottom of the stack.
+
+        Zero unless z_stacking_config is "FROM CENTER".  The GUI forces NZ odd in Relative
+        mode so this is exactly (NZ - 1) / 2 and the stack straddles the focus plane
+        symmetrically; for an even NZ the extra slice lands above the plane.
+        """
+        if self.z_stacking_config != "FROM CENTER":
+            return 0
+        return round((self.NZ - 1) / 2.0)
+
     def prepare_z_stack(self):
         # move to bottom of the z stack
-        if self.z_stacking_config == "FROM CENTER":
-            self.stage.move_z(-self.deltaZ * round((self.NZ - 1) / 2.0))
+        steps = self._center_offset_steps()
+        if steps:
+            # Must go through the same actuator the z loop steps with: move_z_for_stack()
+            # drives the piezo when use_piezo, so pre-moving the stage here would leave the
+            # stage half a stack range low at every FOV with nothing to undo it.
+            self._move_z_for_stack_actuator(-self.deltaZ * steps)
             self._sleep(SCAN_STABILIZATION_TIME_MS_Z / 1000)
         self._sleep(SCAN_STABILIZATION_TIME_MS_Z / 1000)
+
+    def _move_z_for_stack_actuator(self, delta_mm: float) -> None:
+        """Relative z move on whichever actuator the z stack steps with."""
+        if self.use_piezo:
+            self.z_piezo_um = self.z_piezo_um + delta_mm * 1000
+            self.piezo.move_to(self.z_piezo_um)
+            if self.liveController.trigger_mode == TriggerMode.SOFTWARE:
+                self._sleep(MULTIPOINT_PIEZO_DELAY_MS / 1000)
+        else:
+            self.stage.move_z(delta_mm)
 
     def _move_z_for_offset(self, delta_um: float) -> float:
         """Dispatch a relative z move via piezo when use_piezo, otherwise via stage.
@@ -1689,29 +1726,14 @@ class MultiPointWorker:
         self._wait_for_outstanding_callback_images()
 
     def move_z_for_stack(self):
-        if self.use_piezo:
-            self.z_piezo_um += self.deltaZ * 1000
-            self.piezo.move_to(self.z_piezo_um)
-            if (
-                self.liveController.trigger_mode == TriggerMode.SOFTWARE
-            ):  # for hardware trigger, delay is in waiting for the last row to start exposure
-                self._sleep(MULTIPOINT_PIEZO_DELAY_MS / 1000)
-        else:
-            self.stage.move_z(self.deltaZ)
+        # for hardware trigger, the piezo delay is in waiting for the last row to start exposure
+        self._move_z_for_stack_actuator(self.deltaZ)
+        if not self.use_piezo:
             self._sleep(SCAN_STABILIZATION_TIME_MS_Z / 1000)
 
     def move_z_back_after_stack(self):
-        if self.use_piezo:
-            self.z_piezo_um = self.z_piezo_um - self.deltaZ * 1000 * (self.NZ - 1)
-            self.piezo.move_to(self.z_piezo_um)
-            if (
-                self.liveController.trigger_mode == TriggerMode.SOFTWARE
-            ):  # for hardware trigger, delay is in waiting for the last row to start exposure
-                self._sleep(MULTIPOINT_PIEZO_DELAY_MS / 1000)
-        else:
-            if self.z_stacking_config == "FROM CENTER":
-                rel_z_to_start = -self.deltaZ * (self.NZ - 1) + self.deltaZ * round((self.NZ - 1) / 2)
-            else:
-                rel_z_to_start = -self.deltaZ * (self.NZ - 1)
-
-            self.stage.move_z(rel_z_to_start)
+        # Undo the (NZ - 1) steps taken by the z loop, then undo the "FROM CENTER" pre-move
+        # from prepare_z_stack() so we land back on the focus plane rather than the stack
+        # bottom.  Both terms must go through the same actuator the loop stepped with.
+        rel_z_to_start = -self.deltaZ * (self.NZ - 1) + self.deltaZ * self._center_offset_steps()
+        self._move_z_for_stack_actuator(rel_z_to_start)

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -57,6 +57,45 @@ from control._def import *
 from PIL import Image, ImageDraw, ImageFont
 
 
+# Z-stack modes offered by the multipoint tabs.  These map onto the backend's
+# Z_STACKING_CONFIG_MAP indices via z_mode_to_stacking_index() below.
+#   From Bottom -- stack starts at the focus plane and runs upward (the historical behavior)
+#   Set Range   -- absolute Z-min/Z-max; incompatible with laser AF, which is disabled
+#   Relative    -- stack is CENTRED on the focus plane, so the laser AF / contrast AF /
+#                  focus map / stored-point reference can sit mid-sample
+Z_MODE_FROM_BOTTOM = "From Bottom"
+Z_MODE_SET_RANGE = "Set Range"
+Z_MODE_RELATIVE = "Relative"
+Z_MODES = [Z_MODE_FROM_BOTTOM, Z_MODE_SET_RANGE, Z_MODE_RELATIVE]
+
+
+def z_mode_to_stacking_index(z_mode: str) -> int:
+    """Map a GUI z-mode label to a control._def.Z_STACKING_CONFIG_MAP index."""
+    return 1 if z_mode == Z_MODE_RELATIVE else 0  # 1 = "FROM CENTER", 0 = "FROM BOTTOM"
+
+
+# Slack allowed when rounding the half-stack up, in units of half-steps.  set_deltaZ snaps
+# dz to a whole Z microstep (~0.094 um), so a nominal 5.000 um becomes 4.969 and a plain
+# ceil() of range/(2*dz) tips just past the integer -- turning a requested 20 um / 5 um
+# stack from 5 slices into 7.  Absorbing that costs at most 0.1 * dz of coverage.
+_RELATIVE_STACK_RATIO_TOLERANCE = 0.05
+
+
+def relative_stack_Nz(z_range_um: float, dz_um: float) -> int:
+    """Number of slices covering z_range_um at dz_um, forced ODD.
+
+    An odd Nz puts exactly one slice on the focus plane and makes the stack symmetric
+    about it, which is what MultiPointWorker's round((NZ - 1) / 2) offset assumes.  The
+    count is rounded up, so the range actually covered -- (Nz - 1) * dz -- normally
+    exceeds the requested range, by up to one step.  The tolerance below means it can also
+    fall short, but never by more than 0.1 * dz.
+    """
+    if dz_um <= 0:
+        return 1
+    half_steps = z_range_um / (2 * dz_um) - _RELATIVE_STACK_RATIO_TOLERANCE
+    return 2 * max(1, math.ceil(half_steps)) + 1
+
+
 def error_dialog(message: str, title: str = "Error"):
     msg = QMessageBox()
     msg.setIcon(QMessageBox.Warning)
@@ -6167,6 +6206,24 @@ class FlexibleMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMixi
         self.entry_NZ.setValue(1)
         self.entry_NZ.setKeyboardTracking(False)
 
+        # "Relative" mode: total z travel the stack covers, centred on whatever plane the
+        # active focus method (laser AF, contrast AF, focus map, stored point z) lands on.
+        self.entry_zRange = QDoubleSpinBox()
+        self.entry_zRange.setKeyboardTracking(False)
+        self.entry_zRange.setMinimum(0.1)
+        self.entry_zRange.setMaximum(2000)
+        self.entry_zRange.setSingleStep(1)
+        self.entry_zRange.setValue(Acquisition.DZ * 4)
+        self.entry_zRange.setDecimals(3)
+        self.entry_zRange.setSuffix(" μm")
+        self.entry_zRange.setToolTip(
+            "Total z range the stack covers, centred on the focus plane.\n"
+            "Nz is rounded up to the next odd number so one slice sits exactly on it."
+        )
+        self.label_zRange = QLabel("range")
+        self.label_actual_range = QLabel("")
+        self.label_actual_range.setToolTip("Actual z range covered: (Nz - 1) x dz")
+
         self.entry_dt = QDoubleSpinBox()
         self.entry_dt.setKeyboardTracking(False)
         self.entry_dt.setMinimum(0)
@@ -6242,8 +6299,12 @@ class FlexibleMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMixi
         self.checkbox_skipSaving = QCheckBox("Skip Saving")
         self.checkbox_skipSaving.setChecked(False)
 
-        self.checkbox_set_z_range = QCheckBox("Set Z-range")
-        self.checkbox_set_z_range.toggled.connect(self.toggle_z_range_controls)
+        # Z mode: replaces the old two-state "Set Z-range" checkbox so "Relative"
+        # (stack centred on the focus plane) can be offered alongside it.
+        self.label_z_mode = QLabel("Z mode")
+        self.combobox_z_mode = QComboBox()
+        self.combobox_z_mode.addItems(Z_MODES)
+        self.combobox_z_mode.currentTextChanged.connect(self.on_z_mode_changed)
 
         # Add new components for Z-range
         self.entry_minZ = QDoubleSpinBox()
@@ -6267,9 +6328,6 @@ class FlexibleMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMixi
         # self.entry_maxZ.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         self.set_maxZ_button = QPushButton("Set")
         self.set_maxZ_button.clicked.connect(self.set_z_max)
-
-        self.combobox_z_stack = QComboBox()
-        self.combobox_z_stack.addItems(["From Bottom (Z-min)", "From Center", "From Top (Z-max)"])
 
         self.btn_startAcquisition = QPushButton("Start\n Acquisition ")
         self.btn_startAcquisition.setStyleSheet("background-color: #C2C2FF")
@@ -6356,11 +6414,14 @@ class FlexibleMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMixi
 
         # Create second row layouts
         dz_half = QHBoxLayout()
+        dz_half.addWidget(self.label_zRange)
+        dz_half.addWidget(self.entry_zRange)
         dz_half.addWidget(QLabel("dz"))
         dz_half.addWidget(self.entry_deltaZ)
         dz_half.addStretch(1)
         dz_half.addWidget(QLabel("Nz"))
         dz_half.addWidget(self.entry_NZ)
+        dz_half.addWidget(self.label_actual_range)
         dz_half.addSpacerItem(edge_spacer)
 
         dt_half = QHBoxLayout()
@@ -6409,7 +6470,11 @@ class FlexibleMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMixi
             if IS_PIEZO_ONLY:
                 self.checkbox_usePiezo.setChecked(True)
                 self.checkbox_usePiezo.setVisible(False)
-        grid_af.addWidget(self.checkbox_set_z_range)
+        z_mode_row = QHBoxLayout()
+        z_mode_row.setContentsMargins(0, 0, 0, 0)
+        z_mode_row.addWidget(self.label_z_mode)
+        z_mode_row.addWidget(self.combobox_z_mode)
+        grid_af.addLayout(z_mode_row)
         grid_af.addWidget(self.checkbox_skipSaving)
 
         grid_config = QHBoxLayout()
@@ -6487,7 +6552,6 @@ class FlexibleMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMixi
         self.btn_startAcquisition.clicked.connect(self.toggle_acquisition)
         self.multipointController.acquisition_finished.connect(self.acquisition_is_finished)
         self.list_configurations.itemSelectionChanged.connect(self.emit_selected_channels)
-        # self.combobox_z_stack.currentIndexChanged.connect(self.signal_z_stacking.emit)
 
         self.multipointController.signal_acquisition_progress.connect(self.update_acquisition_progress)
         self.multipointController.signal_region_progress.connect(self.update_region_progress)
@@ -6512,7 +6576,7 @@ class FlexibleMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMixi
         self.shortcut = QShortcut(QKeySequence(";"), self)
         self.shortcut.activated.connect(self.btn_add.click)
 
-        self.toggle_z_range_controls(False)
+        self._apply_z_mode_ui()  # hides Z-min/Z-max and the Relative range entry initially
         self.multipointController.set_use_piezo(self.checkbox_usePiezo.isChecked())
         self._update_apply_channel_offset_enable_state(self.checkbox_withReflectionAutofocus.isChecked())
 
@@ -6573,6 +6637,58 @@ class FlexibleMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMixi
         self.updateGeometry()
         self.update()
 
+    def on_z_mode_changed(self, mode):
+        """Handle Z mode dropdown change"""
+        self._apply_z_mode_ui(mode)
+        self._log.debug(f"Z mode changed to: {mode}")
+
+    def _apply_z_mode_ui(self, mode=None):
+        """Bring every z control into the state the given z mode requires."""
+        if mode is None:
+            mode = self.combobox_z_mode.currentText()
+
+        # Z-min/Z-max belong to "Set Range" only.  toggle_z_range_controls also owns the
+        # laser-AF force-off and the Nz enablement for that mode.
+        self.toggle_z_range_controls(mode == Z_MODE_SET_RANGE)
+
+        is_relative = mode == Z_MODE_RELATIVE
+        for widget in (self.label_zRange, self.entry_zRange, self.label_actual_range):
+            widget.setVisible(is_relative)
+
+        # In Relative mode Nz is derived from range and dz, so it is display-only -- but
+        # unlike "Set Range", laser AF is exactly the point of the mode and stays available.
+        if is_relative:
+            self.entry_NZ.setEnabled(False)
+            self.checkbox_withReflectionAutofocus.setEnabled(True)
+        elif mode == Z_MODE_FROM_BOTTOM:
+            self.entry_NZ.setEnabled(True)
+
+        self._connect_relative_z_signals(is_relative)
+        if is_relative:
+            self.update_Nz_relative()
+
+    def _connect_relative_z_signals(self, connect):
+        """Wire (or unwire) the range/dz -> Nz recompute for Relative mode."""
+        for signal in (self.entry_zRange.valueChanged, self.entry_deltaZ.valueChanged):
+            # Always drop first: _apply_z_mode_ui runs from several entry points, and Qt
+            # happily stacks duplicate connections.
+            try:
+                signal.disconnect(self.update_Nz_relative)
+            except TypeError:
+                pass
+            if connect:
+                signal.connect(self.update_Nz_relative)
+
+    def update_Nz_relative(self):
+        """Recompute the read-only Nz for Relative mode, and show the range actually covered."""
+        dz = self.entry_deltaZ.value()
+        if dz <= 0:
+            self.label_actual_range.setText("")
+            return
+        nz = relative_stack_Nz(self.entry_zRange.value(), dz)
+        self.entry_NZ.setValue(nz)
+        self.label_actual_range.setText(f"(± {(nz - 1) * dz / 2:.2f} μm)")
+
     def init_z(self, z_pos_mm=None):
         if z_pos_mm is None:
             z_pos_mm = self.stage.get_pos().z_mm
@@ -6631,6 +6747,8 @@ class FlexibleMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMixi
         z_min = self.entry_minZ.value()
         z_max = self.entry_maxZ.value()
         dz = self.entry_deltaZ.value()
+        if dz <= 0:
+            return  # entry_deltaZ has minimum 0; don't blow up mid-edit
         nz = math.ceil((z_max - z_min) / dz) + 1
         self.entry_NZ.setValue(nz)
 
@@ -6777,16 +6895,24 @@ class FlexibleMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMixi
         No dialogs, no start_new_experiment, no run - the Start button and the fluidics protocol's
         "Apply current settings" share this. Returns None, or a reason nothing further should happen.
         """
-        if self.checkbox_set_z_range.isChecked():
+        z_mode = self.combobox_z_mode.currentText()
+        if z_mode == Z_MODE_SET_RANGE:
             # Set Z-range (convert from μm to mm)
             minZ = self.entry_minZ.value() / 1000
             maxZ = self.entry_maxZ.value() / 1000
             self.multipointController.set_z_range(minZ, maxZ)
+        elif z_mode == Z_MODE_RELATIVE:
+            # The stack is centred on whatever plane autofocus / the focus map / the
+            # stored per-point z lands on, so there is no absolute range to set.
+            # z_range[0] is only the per-time-point seed (initialize_z_stack).
+            z = self.stage.get_pos().z_mm
+            self.multipointController.set_z_range(z, z)
         else:
             z = self.stage.get_pos().z_mm
             dz = self.entry_deltaZ.value()
             Nz = self.entry_NZ.value()
             self.multipointController.set_z_range(z, z + dz / 1000 * (Nz - 1))
+        self.multipointController.set_z_stacking_config(z_mode_to_stacking_index(z_mode))
 
         if self.checkbox_useFocusMap.isChecked():
             self.focusMapWidget.fit_surface()
@@ -7271,6 +7397,9 @@ class FlexibleMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMixi
 
         z = self.stage.get_pos().z_mm
         self.multipointController.set_z_range(z, z)
+        # NZ is 1 here so the stacking config is inert, but the controller keeps it between
+        # runs -- reset it so a snap after a Relative acquisition can't inherit FROM CENTER.
+        self.multipointController.set_z_stacking_config(0)
 
         # Start the acquisition process for the single FOV
         self.multipointController.start_new_experiment("snapped images" + self.lineEdit_experimentID.text())
@@ -7345,7 +7474,15 @@ class FlexibleMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMixi
         self.checkbox_withAutofocus.setEnabled(enabled)
         self.checkbox_withReflectionAutofocus.setEnabled(enabled)
         self.checkbox_stitchOutput.setEnabled(enabled)
-        self.checkbox_set_z_range.setEnabled(enabled)
+        self.combobox_z_mode.setEnabled(enabled)
+        self.entry_zRange.setEnabled(enabled)
+
+        # Nz is derived (read-only) in "Set Range" and "Relative"; the blanket
+        # entry_NZ.setEnabled(enabled) above would otherwise hand it back to the user.
+        # Deliberately not a full _apply_z_mode_ui() -- this runs after every acquisition,
+        # and re-applying "Set Range" would re-reference the laser AF as a side effect.
+        if enabled and self.combobox_z_mode.currentText() in (Z_MODE_SET_RANGE, Z_MODE_RELATIVE):
+            self.entry_NZ.setEnabled(False)
 
         if exclude_btn_startAcquisition is not True:
             self.btn_startAcquisition.setEnabled(enabled)
@@ -7402,8 +7539,10 @@ class FlexibleMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMixi
             self.entry_NY,
             self.entry_NZ,
             self.entry_deltaZ,
+            self.entry_zRange,
             self.entry_Nt,
             self.entry_dt,
+            self.combobox_z_mode,
             self.list_configurations,
             self.checkbox_withAutofocus,
             self.checkbox_withReflectionAutofocus,
@@ -7435,6 +7574,18 @@ class FlexibleMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMixi
             self.entry_NZ.setValue(yaml_data.nz)
             self.entry_deltaZ.setValue(yaml_data.delta_z_um)
 
+            z_mode_map = {
+                "FROM BOTTOM": Z_MODE_FROM_BOTTOM,
+                "SET RANGE": Z_MODE_SET_RANGE,
+                "FROM CENTER": Z_MODE_RELATIVE,
+            }
+            z_mode = z_mode_map.get(yaml_data.z_stacking_config, Z_MODE_FROM_BOTTOM)
+            self.combobox_z_mode.setCurrentText(z_mode)
+            if z_mode == Z_MODE_RELATIVE:
+                # The YAML carries nz/dz, not a range; derive the range the stack covers so
+                # the (read-only) Nz recompute reproduces the same nz.
+                self.entry_zRange.setValue(max(0.1, (yaml_data.nz - 1) * yaml_data.delta_z_um))
+
             # Piezo setting
             self.checkbox_usePiezo.setChecked(yaml_data.use_piezo)
 
@@ -7458,6 +7609,9 @@ class FlexibleMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMixi
             # Unblock all signals
             for widget in widgets_to_block:
                 widget.blockSignals(False)
+
+            # Signals were blocked, so bring the z controls in line with the loaded mode
+            self._apply_z_mode_ui()
 
             # Update FOV positions to reflect new NX, NY, delta values
             self.update_fov_positions()
@@ -7589,7 +7743,14 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMix
         self.cached_loaded_file_path = None
 
         # Add state tracking for Z parameters
-        self.stored_z_params = {"dz": None, "nz": None, "z_min": None, "z_max": None, "z_mode": "From Bottom"}
+        self.stored_z_params = {
+            "dz": None,
+            "nz": None,
+            "z_min": None,
+            "z_max": None,
+            "z_range": None,
+            "z_mode": Z_MODE_FROM_BOTTOM,
+        }
 
         # Add state tracking for Time parameters
         self.stored_time_params = {"dt": None, "nt": None}
@@ -7705,6 +7866,25 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMix
         self.entry_NZ.setValue(1)
         self.entry_NZ.setEnabled(False)
 
+        # "Relative" mode: total z travel the stack covers, centred on whatever plane the
+        # active focus method (laser AF, contrast AF, focus map, stored point z) lands on.
+        self.entry_zRange = QDoubleSpinBox()
+        self.entry_zRange.setKeyboardTracking(False)
+        self.entry_zRange.setMinimum(0.1)
+        self.entry_zRange.setMaximum(2000)
+        self.entry_zRange.setSingleStep(1)
+        self.entry_zRange.setValue(Acquisition.DZ * 4)
+        self.entry_zRange.setDecimals(3)
+        self.entry_zRange.setSuffix(" μm")
+        self.entry_zRange.setToolTip(
+            "Total z range the stack covers, centred on the focus plane.\n"
+            "Nz is rounded up to the next odd number so one slice sits exactly on it."
+        )
+        self.entry_zRange.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self.label_zRange = QLabel("range")
+        self.label_actual_range = QLabel("")
+        self.label_actual_range.setToolTip("Actual z range covered: (Nz - 1) x dz")
+
         self.entry_dt = QDoubleSpinBox()
         self.entry_dt.setKeyboardTracking(False)
         self.entry_dt.setMinimum(0)
@@ -7719,10 +7899,6 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMix
         self.entry_Nt.setMaximum(5000)
         self.entry_Nt.setSingleStep(1)
         self.entry_Nt.setValue(1)
-
-        self.combobox_z_stack = QComboBox()
-        self.combobox_z_stack.addItems(["From Bottom (Z-min)", "From Center", "From Top (Z-max)"])
-        self.combobox_z_stack.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
 
         self.list_configurations = QListWidget()
         self.channel_sequence = enable_channel_sequence(
@@ -7817,7 +7993,7 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMix
         self.checkbox_z.setChecked(False)
 
         self.combobox_z_mode = QComboBox()
-        self.combobox_z_mode.addItems(["From Bottom", "Set Range"])
+        self.combobox_z_mode.addItems(Z_MODES)
         self.combobox_z_mode.setEnabled(False)  # Initially disabled since Z is unchecked
 
         z_layout = QHBoxLayout()
@@ -7904,10 +8080,13 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMix
 
         self.dz_layout = QHBoxLayout()
         self.dz_layout.setContentsMargins(4, 2, 4, 2)
+        self.dz_layout.addWidget(self.label_zRange)
+        self.dz_layout.addWidget(self.entry_zRange)
         self.dz_layout.addWidget(QLabel("dz"))
         self.dz_layout.addWidget(self.entry_deltaZ)
         self.dz_layout.addWidget(QLabel("Nz"))
         self.dz_layout.addWidget(self.entry_NZ)
+        self.dz_layout.addWidget(self.label_actual_range)
 
         self.z_controls_dz_frame.setLayout(self.dz_layout)
         grid.addWidget(self.z_controls_dz_frame, 0, 0)
@@ -8159,6 +8338,7 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMix
                 "nt": self.entry_Nt.value(),
                 "dz": self.entry_deltaZ.value(),
                 "nz": self.entry_NZ.value(),
+                "z_range_um": self.entry_zRange.value(),
                 "contrast_af": self.checkbox_withAutofocus.isChecked(),
                 "laser_af": self.checkbox_withReflectionAutofocus.isChecked(),
             }
@@ -8190,6 +8370,7 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMix
             self.entry_Nt.blockSignals(True)
             self.entry_deltaZ.blockSignals(True)
             self.entry_NZ.blockSignals(True)
+            self.entry_zRange.blockSignals(True)
             self.list_configurations.blockSignals(True)
             self.checkbox_withAutofocus.blockSignals(True)
             self.checkbox_withReflectionAutofocus.blockSignals(True)
@@ -8216,8 +8397,8 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMix
 
             self.checkbox_z.setChecked(settings.get("z_enabled", False))
 
-            z_mode = settings.get("z_mode", "From Bottom")
-            if z_mode in ["From Bottom", "Set Range"]:
+            z_mode = settings.get("z_mode", Z_MODE_FROM_BOTTOM)
+            if z_mode in Z_MODES:
                 self.combobox_z_mode.setCurrentText(z_mode)
 
             self.checkbox_time.setChecked(settings.get("time_enabled", False))
@@ -8226,6 +8407,7 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMix
             self.entry_Nt.setValue(settings.get("nt", 1))
             self.entry_deltaZ.setValue(settings.get("dz", 1.0))
             self.entry_NZ.setValue(settings.get("nz", 1))
+            self.entry_zRange.setValue(settings.get("z_range_um", self.entry_zRange.value()))
 
             # Restore autofocus settings
             self.checkbox_withAutofocus.setChecked(settings.get("contrast_af", False))
@@ -8242,6 +8424,7 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMix
             self.entry_Nt.blockSignals(False)
             self.entry_deltaZ.blockSignals(False)
             self.entry_NZ.blockSignals(False)
+            self.entry_zRange.blockSignals(False)
             self.list_configurations.blockSignals(False)
             self.checkbox_withAutofocus.blockSignals(False)
             self.checkbox_withReflectionAutofocus.blockSignals(False)
@@ -8257,10 +8440,9 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMix
             # Ensure Z controls and Z mode combobox are properly enabled based on loaded Z state
             self.combobox_z_mode.setEnabled(self.checkbox_z.isChecked())
             if self.checkbox_z.isChecked():
+                # show_z_controls defers the per-mode wiring to _apply_z_mode_ui, so the
+                # loaded Z mode is honoured here without a special case per mode.
                 self.show_z_controls(True)
-                # Also ensure Z range controls are properly toggled based on loaded Z mode
-                if self.combobox_z_mode.currentText() == "Set Range":
-                    self.toggle_z_range_controls(True)
 
             # Ensure Time controls are properly shown based on loaded Time state
             if self.checkbox_time.isChecked():
@@ -8580,9 +8762,55 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMix
 
     def on_z_mode_changed(self, mode):
         """Handle Z mode dropdown change"""
-        # Show/hide Z-min/Z-max controls based on mode
-        self.toggle_z_range_controls(mode == "Set Range")
+        self._apply_z_mode_ui(mode)
         self._log.debug(f"Z mode changed to: {mode}")
+
+    def _apply_z_mode_ui(self, mode=None):
+        """Bring every z control into the state the given z mode requires.
+
+        Single source of truth for the three-way mode UI, so on_z_mode_changed, the
+        cache-load path and show_z_controls cannot drift apart.  setEnabled_all
+        deliberately re-applies only the Nz enablement -- see the note there.
+        """
+        if mode is None:
+            mode = self.combobox_z_mode.currentText()
+
+        # Z-min/Z-max belong to "Set Range" only.  toggle_z_range_controls also owns the
+        # laser-AF force-off and the Nz enablement for that mode.
+        self.toggle_z_range_controls(mode == Z_MODE_SET_RANGE)
+
+        is_relative = mode == Z_MODE_RELATIVE
+        z_enabled = self.checkbox_z.isChecked()
+        for widget in (self.label_zRange, self.entry_zRange, self.label_actual_range):
+            widget.setVisible(is_relative and z_enabled)
+
+        # In Relative mode Nz is derived from range and dz, so it is display-only -- but
+        # unlike "Set Range", laser AF is exactly the point of the mode and stays available.
+        if is_relative:
+            self.entry_NZ.setEnabled(False)
+            self.checkbox_withReflectionAutofocus.setEnabled(True)
+        elif mode == Z_MODE_FROM_BOTTOM:
+            self.entry_NZ.setEnabled(True)
+
+        self._connect_relative_z_signals(is_relative)
+        if is_relative:
+            self.update_Nz_relative()
+
+    def _connect_relative_z_signals(self, connect):
+        """Wire (or unwire) the range/dz -> Nz recompute for Relative mode.
+
+        Guarded the same way as the Set Range connections in toggle_z_range_controls, since
+        Qt raises TypeError when disconnecting a slot that was never connected.
+        """
+        for signal in (self.entry_zRange.valueChanged, self.entry_deltaZ.valueChanged):
+            # Always drop first: _apply_z_mode_ui runs from several entry points, and Qt
+            # happily stacks duplicate connections.
+            try:
+                signal.disconnect(self.update_Nz_relative)
+            except TypeError:
+                pass
+            if connect:
+                signal.connect(self.update_Nz_relative)
 
     def on_time_toggled(self, checked):
         """Handle Time checkbox toggle"""
@@ -8657,6 +8885,7 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMix
         self.stored_z_params["nz"] = self.entry_NZ.value()
         self.stored_z_params["z_min"] = self.entry_minZ.value()
         self.stored_z_params["z_max"] = self.entry_maxZ.value()
+        self.stored_z_params["z_range"] = self.entry_zRange.value()
         self.stored_z_params["z_mode"] = self.combobox_z_mode.currentText()
 
     def restore_z_parameters(self):
@@ -8669,6 +8898,8 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMix
             self.entry_minZ.setValue(self.stored_z_params["z_min"])
         if self.stored_z_params["z_max"] is not None:
             self.entry_maxZ.setValue(self.stored_z_params["z_max"])
+        if self.stored_z_params["z_range"] is not None:
+            self.entry_zRange.setValue(self.stored_z_params["z_range"])
         self.combobox_z_mode.setCurrentText(self.stored_z_params["z_mode"])
 
     def hide_z_controls(self):
@@ -8686,13 +8917,18 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMix
                 if widget:
                     widget.setVisible(False)
 
+        # Relative mode's range entry lives in dz_layout, but the loop above only hides the
+        # widgets it owns directly -- make sure the recompute is unwired while Z is off so a
+        # stray dz edit cannot overwrite the forced Nz=1 below.
+        self._connect_relative_z_signals(False)
+
         # Set single-slice parameters
         current_z = self.stage.get_pos().z_mm * 1000  # Convert to μm
         self.entry_NZ.setValue(1)
         self.entry_minZ.setValue(current_z)
         self.entry_maxZ.setValue(current_z)
         self.combobox_z_mode.blockSignals(True)
-        self.combobox_z_mode.setCurrentText("From Bottom")
+        self.combobox_z_mode.setCurrentText(Z_MODE_FROM_BOTTOM)
         self.combobox_z_mode.blockSignals(False)
 
     def show_z_controls(self, visible):
@@ -8703,10 +8939,12 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMix
             if widget:
                 widget.setVisible(visible)
 
-        # Show/hide Z-min/Z-max based on dropdown selection AND visibility
-        # Only show range controls if Z is enabled (visible=True) AND mode is "Set Range"
-        show_range = visible and self.combobox_z_mode.currentText() == "Set Range"
-        self.toggle_z_range_controls(show_range)
+        if visible:
+            # Applies Z-min/Z-max visibility, the range entry, Nz enablement and the laser
+            # AF availability for the current mode.
+            self._apply_z_mode_ui()
+        else:
+            self.toggle_z_range_controls(False)
 
     def store_time_parameters(self):
         """Store current Time parameters before hiding controls"""
@@ -9022,8 +9260,20 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMix
         z_min = self.entry_minZ.value()
         z_max = self.entry_maxZ.value()
         dz = self.entry_deltaZ.value()
+        if dz <= 0:
+            return  # entry_deltaZ has minimum 0; don't blow up mid-edit
         nz = math.ceil((z_max - z_min) / dz) + 1
         self.entry_NZ.setValue(nz)
+
+    def update_Nz_relative(self):
+        """Recompute the read-only Nz for Relative mode, and show the range actually covered."""
+        dz = self.entry_deltaZ.value()
+        if dz <= 0:
+            self.label_actual_range.setText("")
+            return
+        nz = relative_stack_Nz(self.entry_zRange.value(), dz)
+        self.entry_NZ.setValue(nz)
+        self.label_actual_range.setText(f"(± {(nz - 1) * dz / 2:.2f} μm)")
 
     def set_z_min(self):
         z_value = self.stage.get_pos().z_mm * 1000  # Convert to μm
@@ -9189,17 +9439,27 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMix
 
         self.scanCoordinates.sort_coordinates()
 
-        if self.combobox_z_mode.currentText() == "Set Range":
+        z_mode = self.combobox_z_mode.currentText()
+        if z_mode == Z_MODE_SET_RANGE:
             # Set Z-range (convert from μm to mm)
             minZ = self.entry_minZ.value() / 1000  # Convert from μm to mm
             maxZ = self.entry_maxZ.value() / 1000  # Convert from μm to mm
             self.multipointController.set_z_range(minZ, maxZ)
             self._log.debug(f"Set z-range: ({minZ}, {maxZ})")
+        elif z_mode == Z_MODE_RELATIVE:
+            # The stack is centred on whatever plane autofocus / the focus map lands on,
+            # so there is no absolute range to set.  z_range[0] is only the per-time-point
+            # seed position (MultiPointWorker.initialize_z_stack); the real centre comes
+            # from perform_autofocus() and prepare_z_stack() offsets half a stack below it.
+            z = self.stage.get_pos().z_mm
+            self.multipointController.set_z_range(z, z)
+            self._log.debug(f"Relative z-stack centred on focus plane, seed z={z} [mm]")
         else:
             z = self.stage.get_pos().z_mm
-            dz = self.entry_deltaZ.value()
+            dz = self.entry_deltaZ.value()  # μm
             Nz = self.entry_NZ.value()
-            self.multipointController.set_z_range(z, z + dz * (Nz - 1))
+            self.multipointController.set_z_range(z, z + dz / 1000 * (Nz - 1))
+        self.multipointController.set_z_stacking_config(z_mode_to_stacking_index(z_mode))
 
         if self.checkbox_useFocusMap.isChecked():
             # Try to fit the surface; on success set the surface fitter in the controller
@@ -9364,9 +9624,12 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMix
             self.combobox_xy_mode.setEnabled(self.checkbox_xy.isChecked())
             self.combobox_z_mode.setEnabled(self.checkbox_z.isChecked())
 
-            # Restore Z controls based on Z mode
-            if self.checkbox_z.isChecked() and self.combobox_z_mode.currentText() == "Set Range":
-                # In Set Range mode, Nz should be disabled
+            # Restore Z controls based on Z mode (Nz is derived, so read-only, in both
+            # "Set Range" and "Relative")
+            if self.checkbox_z.isChecked() and self.combobox_z_mode.currentText() in (
+                Z_MODE_SET_RANGE,
+                Z_MODE_RELATIVE,
+            ):
                 self.entry_NZ.setEnabled(False)
 
             # Restore coverage based on XY mode
@@ -9410,6 +9673,9 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMix
 
         z = self.stage.get_pos().z_mm
         self.multipointController.set_z_range(z, z)
+        # NZ is 1 here so the stacking config is inert, but the controller keeps it between
+        # runs -- reset it so a snap after a Relative acquisition can't inherit FROM CENTER.
+        self.multipointController.set_z_stacking_config(0)
         # Start the acquisition process for the single FOV
         self.multipointController.start_new_experiment("snapped images" + self.lineEdit_experimentID.text())
         self.multipointController.run_acquisition(acquire_current_fov=True)
@@ -9562,6 +9828,7 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMix
         widgets_to_block = [
             self.entry_NZ,
             self.entry_deltaZ,
+            self.entry_zRange,
             self.entry_Nt,
             self.entry_dt,
             self.entry_overlap,
@@ -9589,11 +9856,16 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMix
 
             # Z mode - map YAML config to combobox text
             z_mode_map = {
-                "FROM BOTTOM": "From Bottom",
-                "SET RANGE": "Set Range",
+                "FROM BOTTOM": Z_MODE_FROM_BOTTOM,
+                "SET RANGE": Z_MODE_SET_RANGE,
+                "FROM CENTER": Z_MODE_RELATIVE,
             }
-            z_mode = z_mode_map.get(yaml_data.z_stacking_config, "From Bottom")
+            z_mode = z_mode_map.get(yaml_data.z_stacking_config, Z_MODE_FROM_BOTTOM)
             self.combobox_z_mode.setCurrentText(z_mode)
+            if z_mode == Z_MODE_RELATIVE:
+                # The YAML carries nz/dz, not a range; derive the range the stack covers so
+                # the (read-only) Nz recompute reproduces the same nz.
+                self.entry_zRange.setValue(max(0.1, (yaml_data.nz - 1) * yaml_data.delta_z_um))
 
             # Piezo setting
             self.checkbox_usePiezo.setChecked(yaml_data.use_piezo)

--- a/software/tests/control/test_relative_z_stack.py
+++ b/software/tests/control/test_relative_z_stack.py
@@ -1,0 +1,306 @@
+"""Tests for the "Relative" z-stack mode -- a stack centred on the focus plane.
+
+Covers both halves of the feature:
+  * the GUI arithmetic and control enablement (widgets.py), and
+  * the worker's "FROM CENTER" stack geometry (multi_point_worker.py), which the GUI
+    reaches via MultiPointController.set_z_stacking_config(1).
+"""
+
+import pytest
+
+import control._def
+import control.gui_hcs
+import control.microscope
+import control.widgets
+from control.core.multi_point_worker import MultiPointWorker
+from control.widgets import (
+    Z_MODE_FROM_BOTTOM,
+    Z_MODE_RELATIVE,
+    Z_MODE_SET_RANGE,
+    relative_stack_Nz,
+    z_mode_to_stacking_index,
+)
+from qtpy.QtWidgets import QMessageBox
+
+
+# ---------------------------------------------------------------------------
+# Pure arithmetic
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "z_range_um, dz_um, expected_nz",
+    [
+        (20.0, 3.0, 9),  # ceil(20/6)=4 -> 9 slices, covering 24 um
+        (20.0, 5.0, 5),  # ceil(20/10)=2 -> 5 slices, covering exactly 20 um
+        (20.0, 10.0, 3),
+        (0.1, 10.0, 3),  # a range far below one step still yields the focus plane +/- 1
+        (10.0, 1.0, 11),
+    ],
+)
+def test_relative_stack_Nz(z_range_um, dz_um, expected_nz):
+    assert relative_stack_Nz(z_range_um, dz_um) == expected_nz
+
+
+def test_relative_stack_Nz_is_always_odd():
+    """An odd Nz is what makes the stack symmetric about the focus plane."""
+    for z_range_um in (0.5, 1.0, 7.3, 20.0, 101.7):
+        for dz_um in (0.3, 1.0, 1.5, 3.0, 25.0):
+            assert relative_stack_Nz(z_range_um, dz_um) % 2 == 1
+
+
+def test_relative_stack_Nz_covers_at_least_the_requested_range():
+    """Up to a tenth of a step of slack -- see _RELATIVE_STACK_RATIO_TOLERANCE."""
+    for z_range_um in (0.5, 7.3, 20.0, 101.7):
+        for dz_um in (0.3, 1.5, 3.0):
+            nz = relative_stack_Nz(z_range_um, dz_um)
+            assert (nz - 1) * dz_um >= z_range_um - 0.1 * dz_um
+
+
+def test_microstep_quantized_dz_does_not_add_a_slice_pair():
+    """set_deltaZ snaps dz to the Z microstep grid; 5.000 um becomes ~4.969.
+
+    A naive ceil() would turn a 20 um / 5 um stack into 7 slices covering 29.8 um.
+    """
+    assert relative_stack_Nz(20.0, 5.0) == 5
+    assert relative_stack_Nz(20.0, 4.968594731414643) == 5
+
+
+def test_relative_stack_Nz_guards_zero_dz():
+    """entry_deltaZ has a minimum of 0, so a mid-edit 0 must not raise."""
+    assert relative_stack_Nz(20.0, 0.0) == 1
+
+
+def test_z_mode_to_stacking_index():
+    # 1 == "FROM CENTER", 0 == "FROM BOTTOM" in control._def.Z_STACKING_CONFIG_MAP
+    assert control._def.Z_STACKING_CONFIG_MAP[z_mode_to_stacking_index(Z_MODE_RELATIVE)] == "FROM CENTER"
+    assert control._def.Z_STACKING_CONFIG_MAP[z_mode_to_stacking_index(Z_MODE_FROM_BOTTOM)] == "FROM BOTTOM"
+    assert control._def.Z_STACKING_CONFIG_MAP[z_mode_to_stacking_index(Z_MODE_SET_RANGE)] == "FROM BOTTOM"
+
+
+# ---------------------------------------------------------------------------
+# GUI behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def gui(qapp):
+    """One simulated GUI for the whole module.
+
+    Deliberately module-scoped: each HighContentScreeningGui brings up simulated cameras
+    and their streaming threads, and building a dozen of them in one pytest process is
+    enough to tip Windows into a heap fault.  Every test below sets the z mode it needs
+    up-front, so sharing the instance is safe.
+    """
+    with pytest.MonkeyPatch.context() as mp:
+
+        def confirm_exit(parent, title, text, *args, **kwargs):
+            if title == "Confirm Exit":
+                return QMessageBox.Yes
+            raise RuntimeError(f"Unexpected QMessageBox: {title} - {text}")
+
+        mp.setattr(QMessageBox, "question", confirm_exit)
+        # Switching to "Set Range" with laser AF checked re-references the laser AF, which
+        # fails (and pops a modal) on simulated hardware.  Pre-existing behavior; a modal
+        # here would hang the run, so swallow it.
+        mp.setattr(control.widgets, "error_dialog", lambda *args, **kwargs: None)
+
+        scope = control.microscope.Microscope.build_from_global_config(True)
+        window = control.gui_hcs.HighContentScreeningGui(microscope=scope, is_simulation=True)
+        try:
+            yield window
+        finally:
+            window.close()
+
+
+@pytest.fixture(params=["wellplate", "flexible"])
+def z_widget(request, gui):
+    """Both multipoint tabs offer Relative and must behave identically."""
+    if request.param == "wellplate":
+        widget = gui.wellplateMultiPointWidget
+        widget.checkbox_z.setChecked(True)
+    else:
+        widget = gui.flexibleMultiPointWidget
+    # Shared GUI: start every test from a known mode rather than the previous test's.
+    widget.combobox_z_mode.setCurrentText(Z_MODE_FROM_BOTTOM)
+    widget.checkbox_withReflectionAutofocus.setChecked(False)
+    return widget
+
+
+def test_relative_mode_is_offered(z_widget):
+    modes = [z_widget.combobox_z_mode.itemText(i) for i in range(z_widget.combobox_z_mode.count())]
+    assert modes == [Z_MODE_FROM_BOTTOM, Z_MODE_SET_RANGE, Z_MODE_RELATIVE]
+
+
+def test_relative_mode_computes_nz_and_keeps_it_read_only(z_widget):
+    z_widget.combobox_z_mode.setCurrentText(Z_MODE_RELATIVE)
+    z_widget.entry_zRange.setValue(20.0)
+    z_widget.entry_deltaZ.setValue(3.0)
+
+    assert z_widget.entry_NZ.value() == 9
+    assert not z_widget.entry_NZ.isEnabled()
+
+    # Nz tracks dz changes without the user touching it
+    z_widget.entry_deltaZ.setValue(5.0)
+    assert z_widget.entry_NZ.value() == 5
+
+    # ...and range changes too
+    z_widget.entry_zRange.setValue(40.0)
+    assert z_widget.entry_NZ.value() == 9
+
+
+def test_relative_mode_shows_the_range_entry_only_in_relative(z_widget):
+    z_widget.combobox_z_mode.setCurrentText(Z_MODE_RELATIVE)
+    assert z_widget.entry_zRange.isVisibleTo(z_widget)
+
+    z_widget.combobox_z_mode.setCurrentText(Z_MODE_FROM_BOTTOM)
+    assert not z_widget.entry_zRange.isVisibleTo(z_widget)
+    # Nz goes back to being the user's to set
+    assert z_widget.entry_NZ.isEnabled()
+
+
+def test_relative_mode_keeps_laser_af_available(z_widget):
+    """The whole point of Relative is a mid-sample laser AF reference.
+
+    "Set Range" force-unchecks and disables laser AF; Relative must not.
+    """
+    z_widget.checkbox_withReflectionAutofocus.setChecked(True)
+
+    # (Only the wellplate tab also force-unchecks it; both disable it.)
+    z_widget.combobox_z_mode.setCurrentText(Z_MODE_SET_RANGE)
+    assert not z_widget.checkbox_withReflectionAutofocus.isEnabled()
+
+    z_widget.checkbox_withReflectionAutofocus.setChecked(True)
+    z_widget.combobox_z_mode.setCurrentText(Z_MODE_RELATIVE)
+    assert z_widget.checkbox_withReflectionAutofocus.isEnabled()
+    assert z_widget.checkbox_withReflectionAutofocus.isChecked()
+
+
+def test_zero_dz_does_not_raise_in_relative_mode(z_widget):
+    z_widget.combobox_z_mode.setCurrentText(Z_MODE_RELATIVE)
+    z_widget.entry_deltaZ.setValue(0.0)  # must not ZeroDivisionError
+    z_widget.entry_zRange.setValue(15.0)
+
+
+def test_switching_modes_repeatedly_does_not_stack_connections(z_widget):
+    """Duplicate valueChanged connections would recompute Nz N times per edit."""
+    for _ in range(4):
+        z_widget.combobox_z_mode.setCurrentText(Z_MODE_RELATIVE)
+        z_widget.combobox_z_mode.setCurrentText(Z_MODE_FROM_BOTTOM)
+
+    z_widget.combobox_z_mode.setCurrentText(Z_MODE_RELATIVE)
+    z_widget.entry_zRange.setValue(20.0)
+    z_widget.entry_deltaZ.setValue(3.0)
+    assert z_widget.entry_NZ.value() == 9
+
+
+def test_from_bottom_mode_leaves_nz_editable(z_widget):
+    z_widget.combobox_z_mode.setCurrentText(Z_MODE_FROM_BOTTOM)
+    assert z_widget.entry_NZ.isEnabled()
+    z_widget.entry_NZ.setValue(7)
+    assert z_widget.entry_NZ.value() == 7
+
+
+def test_relative_mode_sets_from_center_on_the_controller(z_widget, monkeypatch):
+    """The whole feature hinges on this call -- nothing else ever set the stacking config."""
+    recorded = {}
+    monkeypatch.setattr(
+        z_widget.multipointController,
+        "set_z_stacking_config",
+        lambda index: recorded.update(index=index),
+    )
+
+    z_widget.combobox_z_mode.setCurrentText(Z_MODE_RELATIVE)
+    z_widget.multipointController.set_z_stacking_config(z_mode_to_stacking_index(Z_MODE_RELATIVE))
+    assert control._def.Z_STACKING_CONFIG_MAP[recorded["index"]] == "FROM CENTER"
+
+
+# ---------------------------------------------------------------------------
+# Worker stack geometry ("FROM CENTER")
+# ---------------------------------------------------------------------------
+
+
+class _RecordingStage:
+    """Records absolute z after each relative move, in mm."""
+
+    def __init__(self, z_mm=0.0):
+        self.z_mm = z_mm
+        self.moves = []
+
+    def move_z(self, delta_mm):
+        self.z_mm += delta_mm
+        self.moves.append(delta_mm)
+
+
+class _ZStackStub:
+    """MultiPointWorker-shaped stub exercising the stack geometry in isolation."""
+
+    def __init__(self, NZ, deltaZ_mm, z_stacking_config, start_z_mm=5.0):
+        self.NZ = NZ
+        self.deltaZ = deltaZ_mm
+        self.z_stacking_config = z_stacking_config
+        self.use_piezo = False
+        self.stage = _RecordingStage(start_z_mm)
+
+    def _sleep(self, _seconds):
+        pass
+
+    _center_offset_steps = MultiPointWorker._center_offset_steps
+    _move_z_for_stack_actuator = MultiPointWorker._move_z_for_stack_actuator
+    prepare_z_stack = MultiPointWorker.prepare_z_stack
+    move_z_for_stack = MultiPointWorker.move_z_for_stack
+    move_z_back_after_stack = MultiPointWorker.move_z_back_after_stack
+
+
+def _run_stack(NZ, deltaZ_mm, z_stacking_config, start_z_mm=5.0):
+    """Walk a full stack the way acquire_at_position does; return the z of each slice."""
+    worker = _ZStackStub(NZ, deltaZ_mm, z_stacking_config, start_z_mm)
+    if NZ > 1:
+        worker.prepare_z_stack()
+    slice_zs = []
+    for z_level in range(NZ):
+        slice_zs.append(worker.stage.z_mm)
+        if z_level < NZ - 1:
+            worker.move_z_for_stack()
+    if NZ > 1:
+        worker.move_z_back_after_stack()
+    return slice_zs, worker.stage.z_mm
+
+
+def test_from_center_stack_is_symmetric_about_the_focus_plane():
+    focus_z = 5.0
+    dz = 0.003  # mm
+    slice_zs, _ = _run_stack(NZ=5, deltaZ_mm=dz, z_stacking_config="FROM CENTER", start_z_mm=focus_z)
+
+    assert len(slice_zs) == 5
+    assert slice_zs[0] == pytest.approx(focus_z - 2 * dz)
+    assert slice_zs[2] == pytest.approx(focus_z)  # the middle slice IS the focus plane
+    assert slice_zs[-1] == pytest.approx(focus_z + 2 * dz)
+
+
+def test_from_center_stack_returns_to_the_focus_plane():
+    """Any residual here accumulates across every FOV of the acquisition."""
+    focus_z = 5.0
+    dz = 0.003
+    for nz in (3, 5, 9, 21):
+        _, final_z = _run_stack(NZ=nz, deltaZ_mm=dz, z_stacking_config="FROM CENTER", start_z_mm=focus_z)
+        assert final_z == pytest.approx(focus_z), f"drift after NZ={nz}"
+
+
+def test_from_bottom_stack_is_unchanged():
+    """FROM BOTTOM must still start at the focus plane and run upward."""
+    focus_z = 5.0
+    dz = 0.003
+    slice_zs, final_z = _run_stack(NZ=5, deltaZ_mm=dz, z_stacking_config="FROM BOTTOM", start_z_mm=focus_z)
+
+    assert slice_zs[0] == pytest.approx(focus_z)
+    assert slice_zs[-1] == pytest.approx(focus_z + 4 * dz)
+    assert final_z == pytest.approx(focus_z)
+
+
+def test_center_offset_steps():
+    stub = _ZStackStub(NZ=9, deltaZ_mm=0.003, z_stacking_config="FROM CENTER")
+    assert stub._center_offset_steps() == 4
+
+    stub = _ZStackStub(NZ=9, deltaZ_mm=0.003, z_stacking_config="FROM BOTTOM")
+    assert stub._center_offset_steps() == 0


### PR DESCRIPTION
The GUI could only build stacks that start at the plane the focus method
lands on, forcing the laser AF reference to be the bottom of the stack. In
practice it is far more convenient to reference a mid-sample plane and have
the stack extend symmetrically around it.

The worker already implemented "FROM CENTER" -- prepare_z_stack() pre-moved
half a stack after autofocus and move_z_back_after_stack() returned to the
centre -- but it was unreachable: set_z_stacking_config() had no callers, and
the two "From Center" comboboxes were never laid out or connected.

Add a third Z mode, "Relative", to both the Wellplate and Flexible multipoint
tabs. The user sets a total range and dz; Nz is derived, read-only, and forced
odd so exactly one slice sits on the focus plane and round((NZ-1)/2) is
symmetric. Laser AF stays enabled, unlike "Set Range" which disables it.
Laser AF, contrast AF, the focus map and Flexible's stored per-point z all
become the stack centre without further plumbing, since acquire_at_position()
already autofocuses before prepare_z_stack().

Nz needs a rounding tolerance rather than a bare ceil: set_deltaZ snaps dz to
a whole Z microstep (0.09375 um), so a typed 5.000 um becomes 4.9686 and
ceil(range/(2*dz)) tips past the integer -- a requested 20/5 um stack would
come out as 7 slices covering 29.8 um instead of 5 covering 20.

Flexible's two-state "Set Z-range" checkbox becomes a matching dropdown, since
a checkbox cannot express three modes.

Also fix three defects that only bite once FROM CENTER is reachable:

  - _last_time_point_z_pos recorded the stack bottom instead of the focus
    plane, so a time-lapse walked z down half a range per time point and could
    push laser AF outside its measurement range.
  - prepare_z_stack() always moved the stage even under use_piezo, while the z
    loop stepped the piezo -- an accumulating half-range drift per FOV. All
    three stack moves now route through one _move_z_for_stack_actuator() helper
    so the centre offset and its undo cannot diverge.
  - af_fov_count incremented per z slice, turning NUMBER_OF_FOVS_PER_AF into
    "every N images" for exactly the NZ > 1 case being enabled.

_configure_controller_from_yaml parsed z_stack.config and then discarded it,
so headless runs always stacked from the bottom; it now applies the setting.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
