### PR TITLE
feat(squidxplorer): trade the mosaic view for the run, and hand the result off

### DIFF
--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -1017,6 +1017,14 @@ SAVE_DOWNSAMPLED_WELL_IMAGES = True
 # Left empty, the launcher falls back to a `squidmip-view` executable on PATH.
 SQUIDXPLORER_PYTHON = ""
 
+# SquidXplorer enforces a single GUI instance with a lock directory that defaults to
+# ~/.cache/squidmip, which every SquidXplorer checkout on a machine shares - so a viewer
+# opened from a desktop shortcut and one opened from here fight over the one slot and the
+# second launch silently no-ops. Set this to the same lock directory the shortcut's launcher
+# uses (it is exported there as SQUIDMIP_GUI_LOCK_DIR) to give this handoff its own slot.
+# Left empty, SquidXplorer's default is used.
+SQUIDXPLORER_GUI_LOCK_DIR = ""
+
 # Plate view zoom limits
 # MIN_VISIBLE_PIXELS: At maximum zoom, ensure at least this many pixels are visible
 # in the smallest dimension. 500 pixels allows inspecting cellular-level details.
@@ -1518,6 +1526,9 @@ if CACHED_CONFIG_FILE_PATH and os.path.exists(CACHED_CONFIG_FILE_PATH):
             if _general_config.has_option("GENERAL", "squidxplorer_python"):
                 SQUIDXPLORER_PYTHON = _general_config.get("GENERAL", "squidxplorer_python").strip()
                 log.info(f"Loaded SQUIDXPLORER_PYTHON={SQUIDXPLORER_PYTHON} from config")
+            if _general_config.has_option("GENERAL", "squidxplorer_gui_lock_dir"):
+                SQUIDXPLORER_GUI_LOCK_DIR = _general_config.get("GENERAL", "squidxplorer_gui_lock_dir").strip()
+                log.info(f"Loaded SQUIDXPLORER_GUI_LOCK_DIR={SQUIDXPLORER_GUI_LOCK_DIR} from config")
     except Exception as e:
         log.warning(f"Failed to load GENERAL settings from config: {e}")
 

--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -1010,6 +1010,13 @@ MOSAIC_VIEW_TARGET_PIXEL_SIZE_UM = 2
 SAVE_DOWNSAMPLED_OVERVIEW = True
 SAVE_DOWNSAMPLED_WELL_IMAGES = True
 
+# SquidXplorer handoff. SquidXplorer lives in its own repository and its own venv
+# (it needs a newer Python than the acquisition software runs on), so it can only
+# be launched out of process. Point this at that venv's interpreter, e.g.
+#   C:\\path\\to\\SquidXplorer\\.venv\\Scripts\\python.exe
+# Left empty, the launcher falls back to a `squidmip-view` executable on PATH.
+SQUIDXPLORER_PYTHON = ""
+
 # Plate view zoom limits
 # MIN_VISIBLE_PIXELS: At maximum zoom, ensure at least this many pixels are visible
 # in the smallest dimension. 500 pixels allows inspecting cellular-level details.
@@ -1508,6 +1515,9 @@ if CACHED_CONFIG_FILE_PATH and os.path.exists(CACHED_CONFIG_FILE_PATH):
                 LIVE_VIEW_Z_STEP_UM = _general_config.getfloat("GENERAL", "live_view_z_step_um")
             if _general_config.has_option("GENERAL", "live_view_z_step_fast_um"):
                 LIVE_VIEW_Z_STEP_FAST_UM = _general_config.getfloat("GENERAL", "live_view_z_step_fast_um")
+            if _general_config.has_option("GENERAL", "squidxplorer_python"):
+                SQUIDXPLORER_PYTHON = _general_config.get("GENERAL", "squidxplorer_python").strip()
+                log.info(f"Loaded SQUIDXPLORER_PYTHON={SQUIDXPLORER_PYTHON} from config")
     except Exception as e:
         log.warning(f"Failed to load GENERAL settings from config: {e}")
 

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -670,6 +670,13 @@ class HighContentScreeningGui(QMainWindow):
         self.is_live_scan_grid_on = False
         self.live_scan_grid_was_on = None
         self.performance_mode = False
+        # Resource-allocation handoff: state for a run whose mosaic view did not fit in RAM.
+        # _performance_mode_forced records whether *we* turned Performance Mode on, so a run
+        # started with it already on manually is left alone when the run ends.
+        self._mosaic_disabled_for_run = False
+        self._performance_mode_forced = False
+        self._squidxplorer_prompt_suppressed = False
+        self._last_acquisition_save_target = None
         self.napari_connections = {}
         self.well_selector_visible = False  # Add this line to track well selector visibility
 
@@ -1470,11 +1477,13 @@ class HighContentScreeningGui(QMainWindow):
         if ENABLE_FLEXIBLE_MULTIPOINT:
             self.flexibleMultiPointWidget.signal_acquisition_started.connect(self.toggleAcquisitionStart)
             self.signal_performance_mode_changed.connect(self.flexibleMultiPointWidget.set_performance_mode)
+            self.flexibleMultiPointWidget.signal_request_mosaic_disable.connect(self.enterPerformanceModeForRun)
 
         if ENABLE_WELLPLATE_MULTIPOINT:
             self.wellplateMultiPointWidget.signal_acquisition_started.connect(self.toggleAcquisitionStart)
             self.wellplateMultiPointWidget.signal_toggle_live_scan_grid.connect(self.toggle_live_scan_grid)
             self.signal_performance_mode_changed.connect(self.wellplateMultiPointWidget.set_performance_mode)
+            self.wellplateMultiPointWidget.signal_request_mosaic_disable.connect(self.enterPerformanceModeForRun)
 
         self.profileWidget.signal_profile_changed.connect(self.liveControlWidget.refresh_mode_list)
 
@@ -1514,6 +1523,10 @@ class HighContentScreeningGui(QMainWindow):
         # Laser engine readiness gate — modal progress dialog while waiting at timepoint boundaries.
         self.multipointController.signal_laser_engine_waiting.connect(self._show_laser_engine_dialog)
         self.multipointController.signal_laser_engine_ready.connect(self._hide_laser_engine_dialog)
+
+        # Resource-allocation handoff: restore Performance Mode and offer SquidXplorer after
+        # a run whose mosaic view was traded away.
+        self.multipointController.acquisition_finished.connect(self._on_resource_limited_run_finished)
 
         # RAM monitor widget connections - use controller signals which fire AFTER memory monitor is created
         self.multipointController.signal_acquisition_start.connect(self._connect_ram_monitor_widget)
@@ -1857,14 +1870,157 @@ class HighContentScreeningGui(QMainWindow):
         self.signal_performance_mode_changed.emit(self.performance_mode)
         print(f"Performance mode {'enabled' if self.performance_mode else 'disabled'}")
 
+    def setPerformanceMode(self, enabled: bool):
+        """Drive the Performance Mode toggle programmatically.
+
+        QPushButton.setChecked() does not emit clicked(), so togglePerformanceMode has to
+        be invoked explicitly — otherwise the button changes appearance and nothing else
+        happens.
+        """
+        toggle = getattr(self, "performanceModeToggle", None)
+        if toggle is None:
+            # live_only_mode never builds the toggle.
+            return
+        if toggle.isChecked() == enabled:
+            return
+        toggle.setChecked(enabled)
+        self.togglePerformanceMode()
+
+    def enterPerformanceModeForRun(self):
+        """A run whose mosaic view will not fit in RAM is starting.
+
+        Remember whether Performance Mode was ours to turn on, force it on, and flag the
+        run so the finish handler can restore the toggle and offer SquidXplorer.
+        """
+        self._mosaic_disabled_for_run = True
+        self._performance_mode_forced = not self.performance_mode
+        self.setPerformanceMode(True)
+        self.log.info("Mosaic view disabled for this run; Performance Mode enabled.")
+
     def _on_acquisition_save_target(self, save_target):
         """Route the controller's per-run save dir to the unified widget."""
+        # Also stash it: the finish handler needs this run's output folder to hand to
+        # SquidXplorer, and this is the one signal that already carries it.
+        self._last_acquisition_save_target = save_target
         if self.unifiedMosaicWidget is not None:
             self.unifiedMosaicWidget.set_acquisition_save_target(save_target)
 
     def _on_timepoint_finished(self, time_point: int):
         if self.unifiedMosaicWidget is not None:
             self.unifiedMosaicWidget.save_for_timepoint(time_point)
+
+    def _on_resource_limited_run_finished(self):
+        """A run that traded away mosaic view has ended."""
+        if not self._mosaic_disabled_for_run:
+            return
+        self._mosaic_disabled_for_run = False
+        # sic — upstream spelling. Only ever assigned inside run_acquisition(), so read it
+        # defensively in case the run failed before it was set.
+        aborted = getattr(self.multipointController, "abort_acqusition_requested", False)
+        run_dir = self._last_acquisition_save_target
+        # Defer past the rest of the acquisition_finished slots. A modal exec_() here would
+        # spin a nested event loop while the z-plot, NDViewer and the monitor widgets are
+        # still queued behind us on the same signal.
+        QTimer.singleShot(0, lambda: self._finish_resource_limited_run(run_dir, aborted))
+
+    def _finish_resource_limited_run(self, run_dir, aborted):
+        if self._performance_mode_forced:
+            self._performance_mode_forced = False
+            self.setPerformanceMode(False)
+            self.log.info("Run finished; Performance Mode restored.")
+
+        if aborted:
+            # "Run complete" would not be true.
+            return
+        if self._squidxplorer_prompt_suppressed:
+            return
+        if not run_dir or not os.path.isdir(run_dir):
+            self.log.warning(f"Skipping the SquidXplorer prompt: no run folder at {run_dir!r}.")
+            return
+
+        # The instance form, not QMessageBox.question — only it carries a checkbox.
+        box = QMessageBox(self)
+        box.setIcon(QMessageBox.Question)
+        box.setWindowTitle("Run Complete")
+        box.setText("Run complete — open in SquidXplorer?")
+        box.setInformativeText(run_dir)
+        box.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
+        box.setDefaultButton(QMessageBox.Yes)
+        dont_ask = QCheckBox("Don't ask again this session")
+        box.setCheckBox(dont_ask)
+        reply = box.exec_()
+
+        # Honored whichever button was pressed.
+        if dont_ask.isChecked():
+            self._squidxplorer_prompt_suppressed = True
+            self.log.info("SquidXplorer prompt suppressed for the rest of this session.")
+
+        if reply == QMessageBox.Yes:
+            self._launch_squidxplorer(run_dir)
+
+    def _launch_squidxplorer(self, run_dir):
+        """Open a finished run in SquidXplorer, reporting anything that goes wrong."""
+        from control.squidxplorer_launcher import launch_squidxplorer
+
+        try:
+            process, stderr_path = launch_squidxplorer(run_dir)
+        except FileNotFoundError:
+            self._squidxplorer_failure_dialog(
+                run_dir,
+                "SquidXplorer could not be found.\n\n"
+                "Set 'squidxplorer_python' under [GENERAL] in the configuration file to the "
+                "Python interpreter of the SquidXplorer virtual environment, or put "
+                "'squidmip-view' on PATH.",
+            )
+            return
+        except Exception as e:
+            self.log.error(f"Failed to launch SquidXplorer: {e}")
+            self._squidxplorer_failure_dialog(run_dir, f"Failed to launch SquidXplorer:\n\n{e}")
+            return
+
+        # SquidXplorer allows only one window at a time and exits 1 when a second is asked
+        # for, so a launch that dies within a few seconds is the case worth reporting.
+        QTimer.singleShot(3000, lambda: self._check_squidxplorer_launch(process, stderr_path, run_dir))
+
+    def _check_squidxplorer_launch(self, process, stderr_path, run_dir):
+        returncode = process.poll()
+        if returncode is None or returncode == 0:
+            if returncode == 0:
+                self._cleanup_launch_log(stderr_path)
+            return
+
+        from control.squidxplorer_launcher import read_launch_error
+
+        details = read_launch_error(stderr_path)
+        self._cleanup_launch_log(stderr_path)
+        self.log.error(f"SquidXplorer exited with code {returncode}. {details}")
+        message = "SquidXplorer did not open."
+        if "GuiAlreadyOpen" in details or "already" in details.lower():
+            message = "A SquidXplorer window is already open.\n\nOpen this run from that window instead."
+        elif details:
+            message = f"SquidXplorer did not open.\n\n{details}"
+        self._squidxplorer_failure_dialog(run_dir, message)
+
+    def _cleanup_launch_log(self, stderr_path):
+        try:
+            os.unlink(stderr_path)
+        except OSError as e:
+            self.log.debug(f"Could not remove SquidXplorer launch log {stderr_path}: {e}")
+
+    def _squidxplorer_failure_dialog(self, run_dir, message):
+        """Report a failed handoff and leave the run folder on the clipboard.
+
+        SquidXplorer accepts a dropped folder, so a path on the clipboard is a working
+        recovery path whether it is already open or not yet installed.
+        """
+        clipboard_note = ""
+        try:
+            QApplication.clipboard().setText(run_dir)
+            clipboard_note = f"\n\nThe run folder has been copied to the clipboard:\n{run_dir}"
+        except Exception as e:
+            self.log.debug(f"Could not copy the run folder to the clipboard: {e}")
+            clipboard_note = f"\n\nRun folder:\n{run_dir}"
+        QMessageBox.warning(self, "SquidXplorer", message + clipboard_note)
 
     def _on_live_controller_warning(self, message: str) -> None:
         """Non-modal warning from LiveController. 5s rate-limit; one popup max."""

--- a/software/control/squidxplorer_launcher.py
+++ b/software/control/squidxplorer_launcher.py
@@ -9,6 +9,9 @@ Resolution order:
   1. ``SQUIDXPLORER_PYTHON`` from the config, if it points at a real file.
   2. A ``squidmip-view`` executable on PATH.
   3. Nothing — the caller tells the operator how to configure it.
+
+``SQUIDXPLORER_GUI_LOCK_DIR``, if set, is passed to the viewer as ``SQUIDMIP_GUI_LOCK_DIR``
+so this handoff does not contend with a SquidXplorer already opened from a desktop shortcut.
 """
 
 import os
@@ -29,6 +32,23 @@ _log = squid.logging.get_logger(__name__)
 # opens empty with no error at all.
 _VIEWER_MODULE = "squidmip._viewer"
 _VIEWER_SCRIPT = "squidmip-view"
+_GUI_LOCK_DIR_ENV = "SQUIDMIP_GUI_LOCK_DIR"
+
+
+def squidxplorer_environment() -> Optional[dict]:
+    """Environment for the viewer process, or None to inherit ours unchanged.
+
+    SquidXplorer allows one GUI at a time per lock directory, and that directory defaults to
+    ~/.cache/squidmip for every checkout on the machine. Handing the viewer its own directory
+    is what lets a run open here while another SquidXplorer window is already up.
+    """
+    lock_dir = (getattr(control._def, "SQUIDXPLORER_GUI_LOCK_DIR", "") or "").strip()
+    if not lock_dir:
+        return None
+
+    env = os.environ.copy()
+    env[_GUI_LOCK_DIR_ENV] = lock_dir
+    return env
 
 
 def resolve_squidxplorer_command(run_dir: str) -> Optional[List[str]]:
@@ -67,12 +87,15 @@ def launch_squidxplorer(run_dir: str) -> Tuple[subprocess.Popen, str]:
     fd, stderr_path = tempfile.mkstemp(suffix=".log", prefix="squidxplorer_launch_")
     stderr_file = os.fdopen(fd, "w")
     try:
-        _log.info(f"Launching SquidXplorer: {command}")
+        env = squidxplorer_environment()
+        lock_note = f" with {_GUI_LOCK_DIR_ENV}={env[_GUI_LOCK_DIR_ENV]}" if env else ""
+        _log.info(f"Launching SquidXplorer: {command}{lock_note}")
         process = subprocess.Popen(
             command,
             stdout=subprocess.DEVNULL,
             stderr=stderr_file,
             shell=False,
+            env=env,
         )
     except Exception:
         stderr_file.close()

--- a/software/control/squidxplorer_launcher.py
+++ b/software/control/squidxplorer_launcher.py
@@ -1,0 +1,99 @@
+"""Launch SquidXplorer on a finished acquisition folder.
+
+SquidXplorer (the ``squidmip`` package) lives in a separate repository with its own
+virtual environment and a newer Python than the acquisition software runs on, so it
+can only ever be started as a separate process. This module resolves the command to
+run and starts it; the GUI owns everything the operator sees.
+
+Resolution order:
+  1. ``SQUIDXPLORER_PYTHON`` from the config, if it points at a real file.
+  2. A ``squidmip-view`` executable on PATH.
+  3. Nothing — the caller tells the operator how to configure it.
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+from typing import List, Optional, Tuple
+
+import control._def
+import squid.logging
+
+_log = squid.logging.get_logger(__name__)
+
+# SquidXplorer's GUI entry point reads its dataset from a bare sys.argv[1] with no
+# argument parser, so the folder must arrive as exactly one argv element. Every call
+# below uses the list form of Popen with shell=False for that reason: a path with a
+# space in it that goes through a shell splits across argv, and SquidXplorer then
+# opens empty with no error at all.
+_VIEWER_MODULE = "squidmip._viewer"
+_VIEWER_SCRIPT = "squidmip-view"
+
+
+def resolve_squidxplorer_command(run_dir: str) -> Optional[List[str]]:
+    """Build the argv that opens *run_dir* in SquidXplorer, or None if it isn't installed."""
+    configured_python = (getattr(control._def, "SQUIDXPLORER_PYTHON", "") or "").strip()
+    if configured_python:
+        if os.path.isfile(configured_python):
+            return [configured_python, "-m", _VIEWER_MODULE, run_dir]
+        _log.warning(
+            f"SQUIDXPLORER_PYTHON is set to '{configured_python}', which is not a file. "
+            f"Falling back to '{_VIEWER_SCRIPT}' on PATH."
+        )
+
+    on_path = shutil.which(_VIEWER_SCRIPT)
+    if on_path:
+        return [on_path, run_dir]
+
+    return None
+
+
+def launch_squidxplorer(run_dir: str) -> Tuple[subprocess.Popen, str]:
+    """Start SquidXplorer on *run_dir*.
+
+    Returns the process and the path of the file its stderr is redirected to, so the
+    caller can report why it died if it exits immediately (the usual cause being
+    SquidXplorer's single-instance lock refusing a second window).
+
+    Raises FileNotFoundError if no SquidXplorer installation could be resolved.
+    """
+    command = resolve_squidxplorer_command(run_dir)
+    if command is None:
+        raise FileNotFoundError("No SquidXplorer installation found.")
+
+    # A real file rather than a pipe: nothing reads this process's output while it
+    # runs, and a pipe nobody drains would eventually block the viewer on write.
+    fd, stderr_path = tempfile.mkstemp(suffix=".log", prefix="squidxplorer_launch_")
+    stderr_file = os.fdopen(fd, "w")
+    try:
+        _log.info(f"Launching SquidXplorer: {command}")
+        process = subprocess.Popen(
+            command,
+            stdout=subprocess.DEVNULL,
+            stderr=stderr_file,
+            shell=False,
+        )
+    except Exception:
+        stderr_file.close()
+        try:
+            os.unlink(stderr_path)
+        except OSError as cleanup_err:
+            _log.debug(f"Failed to remove {stderr_path} after a failed launch: {cleanup_err}")
+        raise
+    finally:
+        # The child holds its own duplicate of the descriptor.
+        if not stderr_file.closed:
+            stderr_file.close()
+
+    return process, stderr_path
+
+
+def read_launch_error(stderr_path: str, max_chars: int = 1000) -> str:
+    """Read back what a failed launch wrote to stderr. Never raises."""
+    try:
+        with open(stderr_path, "r", errors="replace") as f:
+            return f.read().strip()[-max_chars:]
+    except OSError as e:
+        _log.debug(f"Could not read SquidXplorer launch stderr at {stderr_path}: {e}")
+        return ""

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -94,19 +94,35 @@ def check_space_available_with_error_dialog(
     return True
 
 
-def check_ram_available_with_error_dialog(
+def resource_allocation_dialog(parent=None):
+    """Tell the operator that mosaic view is being traded away for this run."""
+    msg = QMessageBox(parent)
+    msg.setIcon(QMessageBox.Information)
+    msg.setText("Mosaic View will be disabled for this Run.")
+    msg.setWindowTitle("Resource Allocation")
+    msg.setStandardButtons(QMessageBox.Ok)
+    msg.setDefaultButton(QMessageBox.Ok)
+    msg.exec_()
+
+
+def mosaic_ram_exceeds_available(
     multi_point_controller: MultiPointController,
     logger: logging.Logger,
     factor_of_safety: float = 1.15,
     performance_mode: bool = False,
 ) -> bool:
-    """Check if enough RAM is available for mosaic view."""
+    """True if this acquisition's mosaic view would not fit in available RAM.
+
+    This only reports the condition — it does not veto the acquisition. Only the live
+    mosaic preview is unaffordable in this situation, not the run itself, so the caller
+    turns Performance Mode on for the run instead of refusing to start.
+    """
     import psutil
 
-    # Skip check if performance mode is enabled (mosaic view is disabled)
+    # Mosaic view is already off in performance mode, so there is nothing to fit.
     if performance_mode:
         logger.info("Performance mode enabled, skipping RAM check for mosaic view")
-        return True
+        return False
 
     ram_required = factor_of_safety * multi_point_controller.get_estimated_mosaic_ram_bytes()
     available_ram = psutil.virtual_memory().available
@@ -116,15 +132,13 @@ def check_ram_available_with_error_dialog(
     if ram_required > available_ram:
         mb_required = int(ram_required / 1024 / 1024)
         mb_available = int(available_ram / 1024 / 1024)
-        error_message = (
-            f"This acquisition's mosaic view will require approximately {mb_required:,} MB RAM, "
-            f"but only {mb_available:,} MB is currently available.\n\n"
-            f"Consider enabling Performance Mode to disable mosaic view during acquisition."
+        logger.warning(
+            f"This acquisition's mosaic view would require approximately {mb_required:,} MB RAM, "
+            f"but only {mb_available:,} MB is currently available. "
+            f"Enabling Performance Mode for this run."
         )
-        logger.error(error_message)
-        error_dialog(error_message, title="Not Enough RAM")
-        return False
-    return True
+        return True
+    return False
 
 
 def get_last_used_saving_path() -> str:
@@ -6025,6 +6039,10 @@ class FlexibleMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMixi
     signal_acquisition_started = Signal(bool)  # true = started, false = finished
     signal_acquisition_channels = Signal(list)  # list channels
     signal_acquisition_shape = Signal(int, float)  # Nz, dz
+    # This run's mosaic view will not fit in RAM; ask the GUI to enter Performance Mode
+    # for the duration of the run. Emitted before run_acquisition() so the connection
+    # (direct, same thread) has taken effect by the time the acquisition starts.
+    signal_request_mosaic_disable = Signal()
 
     def __init__(
         self,
@@ -6843,12 +6861,13 @@ class FlexibleMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMixi
                 self.btn_startAcquisition.setChecked(False)
                 return
 
-            if not check_ram_available_with_error_dialog(
+            # Not enough RAM for the live mosaic is not a reason to refuse the run — only
+            # the preview is unaffordable. Trade it away and carry on.
+            if mosaic_ram_exceeds_available(
                 self.multipointController, self._log, performance_mode=self.performance_mode
             ):
-                self._log.error("Failed to start acquisition.  Not enough RAM available.")
-                self.btn_startAcquisition.setChecked(False)
-                return
+                resource_allocation_dialog(self)
+                self.signal_request_mosaic_disable.emit()
 
             # Update UI to show acquisition is running
             self._set_ui_acquisition_running(self.entry_NZ.value(), self.entry_deltaZ.value())
@@ -7534,6 +7553,10 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMix
     signal_acquisition_shape = Signal(int, float)  # acquisition Nz, dz
     signal_manual_shape_mode = Signal(bool)  # enable manual shape layer on mosaic display
     signal_toggle_live_scan_grid = Signal(bool)  # enable/disable live scan grid
+    # This run's mosaic view will not fit in RAM; ask the GUI to enter Performance Mode
+    # for the duration of the run. Emitted before run_acquisition() so the connection
+    # (direct, same thread) has taken effect by the time the acquisition starts.
+    signal_request_mosaic_disable = Signal()
     # Signal to set acquisition running state from any thread (used by TCP server)
     signal_set_acquisition_running = Signal(bool, int, float)  # is_running, nz, delta_z_um
 
@@ -9259,12 +9282,13 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMix
                 self._log.error("Failed to start acquisition.  Not enough disk space available.")
                 return
 
-            if not check_ram_available_with_error_dialog(
+            # Not enough RAM for the live mosaic is not a reason to refuse the run — only
+            # the preview is unaffordable. Trade it away and carry on.
+            if mosaic_ram_exceeds_available(
                 self.multipointController, self._log, performance_mode=self.performance_mode
             ):
-                self.btn_startAcquisition.setChecked(False)
-                self._log.error("Failed to start acquisition.  Not enough RAM available.")
-                return
+                resource_allocation_dialog(self)
+                self.signal_request_mosaic_disable.emit()
 
             # Update UI to show acquisition is running
             self._set_ui_acquisition_running(self.entry_NZ.value(), self.entry_deltaZ.value())

--- a/software/tests/control/test_widgets.py
+++ b/software/tests/control/test_widgets.py
@@ -17,8 +17,8 @@ import control.widgets
 from control.core import core as core_module
 from control.core.scan_coordinates import ScanCoordinates
 from control.widgets import (
-    check_ram_available_with_error_dialog,
     FocusMapWidget,
+    mosaic_ram_exceeds_available,
     NDViewerTab,
     RecordingWidget,
     SurfacePlotWidget,
@@ -29,19 +29,19 @@ from squid.config import CameraPixelFormat
 import tests.control.test_stubs as ts
 
 
-def test_check_ram_available_with_error_dialog_performance_mode():
-    """Test that RAM check is skipped when performance mode is enabled."""
+def test_mosaic_ram_exceeds_available_performance_mode():
+    """Test that the check is skipped when performance mode is already enabled."""
     scope = control.microscope.Microscope.build_from_global_config(True)
     mpc = ts.get_test_multi_point_controller(microscope=scope)
     logger = logging.getLogger("test")
 
-    # When performance mode is enabled, should always return True (skip check)
-    result = check_ram_available_with_error_dialog(mpc, logger, performance_mode=True)
-    assert result is True
+    # Mosaic view is already off, so there is nothing that could fail to fit.
+    result = mosaic_ram_exceeds_available(mpc, logger, performance_mode=True)
+    assert result is False
 
 
-def test_check_ram_available_with_error_dialog_sufficient_ram():
-    """Test that check passes when sufficient RAM is available."""
+def test_mosaic_ram_exceeds_available_sufficient_ram():
+    """Test that the mosaic fits when sufficient RAM is available."""
     scope = control.microscope.Microscope.build_from_global_config(True)
     mpc = ts.get_test_multi_point_controller(microscope=scope)
     logger = logging.getLogger("test")
@@ -61,16 +61,16 @@ def test_check_ram_available_with_error_dialog_sufficient_ram():
         mpc.scanCoordinates.add_flexible_region(1, x_min, y_min, z_mid, 3, 3, 0)
         mpc.set_selected_configurations(all_configuration_names[0:1])
 
-        # With a small scan area and real available RAM, should pass
-        result = check_ram_available_with_error_dialog(mpc, logger, performance_mode=False)
-        assert result is True
+        # With a small scan area and real available RAM, the mosaic fits
+        result = mosaic_ram_exceeds_available(mpc, logger, performance_mode=False)
+        assert result is False
 
     finally:
         control._def.USE_NAPARI_FOR_MOSAIC_DISPLAY = original_use_napari
 
 
-def test_check_ram_available_with_error_dialog_insufficient_ram():
-    """Test that check fails when insufficient RAM is available."""
+def test_mosaic_ram_exceeds_available_insufficient_ram():
+    """Test that the shortfall is reported when insufficient RAM is available."""
     scope = control.microscope.Microscope.build_from_global_config(True)
     mpc = ts.get_test_multi_point_controller(microscope=scope)
     logger = logging.getLogger("test")
@@ -94,17 +94,17 @@ def test_check_ram_available_with_error_dialog_insufficient_ram():
         mock_vmem = MagicMock()
         mock_vmem.available = 1024  # Only 1KB available
 
+        # No dialog patch needed: the predicate only logs now, it never opens a window.
         with patch("psutil.virtual_memory", return_value=mock_vmem):
-            with patch("control.widgets.error_dialog"):  # Mock dialog to avoid GUI
-                result = check_ram_available_with_error_dialog(mpc, logger, performance_mode=False)
-                assert result is False
+            result = mosaic_ram_exceeds_available(mpc, logger, performance_mode=False)
+            assert result is True
 
     finally:
         control._def.USE_NAPARI_FOR_MOSAIC_DISPLAY = original_use_napari
 
 
-def test_check_ram_available_with_error_dialog_zero_estimate():
-    """Test that check passes when RAM estimate is 0 (no regions or napari disabled)."""
+def test_mosaic_ram_exceeds_available_zero_estimate():
+    """Test that a 0-byte estimate fits (no regions, or napari disabled)."""
     scope = control.microscope.Microscope.build_from_global_config(True)
     mpc = ts.get_test_multi_point_controller(microscope=scope)
     logger = logging.getLogger("test")
@@ -112,12 +112,12 @@ def test_check_ram_available_with_error_dialog_zero_estimate():
     # Clear regions so estimate returns 0
     mpc.scanCoordinates.clear_regions()
 
-    # Should pass since 0 bytes required
-    result = check_ram_available_with_error_dialog(mpc, logger, performance_mode=False)
-    assert result is True
+    # Fits, since 0 bytes are required
+    result = mosaic_ram_exceeds_available(mpc, logger, performance_mode=False)
+    assert result is False
 
 
-def test_check_ram_available_with_error_dialog_factor_of_safety():
+def test_mosaic_ram_exceeds_available_factor_of_safety():
     """Test that factor of safety is applied to RAM estimate."""
     scope = control.microscope.Microscope.build_from_global_config(True)
     mpc = ts.get_test_multi_point_controller(microscope=scope)
@@ -148,22 +148,58 @@ def test_check_ram_available_with_error_dialog_factor_of_safety():
         mock_vmem.available = base_estimate  # Exactly equal to base estimate
 
         with patch("psutil.virtual_memory", return_value=mock_vmem):
-            with patch("control.widgets.error_dialog"):
-                # With default factor_of_safety=1.15, should fail (needs 15% more)
-                result = check_ram_available_with_error_dialog(
-                    mpc, logger, factor_of_safety=1.15, performance_mode=False
-                )
-                assert result is False
+            # With default factor_of_safety=1.15, this does not fit (needs 15% more)
+            result = mosaic_ram_exceeds_available(mpc, logger, factor_of_safety=1.15, performance_mode=False)
+            assert result is True
 
-                # With factor_of_safety=1.0, should pass (exact match)
-                mock_vmem.available = base_estimate
-                result = check_ram_available_with_error_dialog(
-                    mpc, logger, factor_of_safety=1.0, performance_mode=False
-                )
-                assert result is True
+            # With factor_of_safety=1.0, this fits (exact match)
+            mock_vmem.available = base_estimate
+            result = mosaic_ram_exceeds_available(mpc, logger, factor_of_safety=1.0, performance_mode=False)
+            assert result is False
 
     finally:
         control._def.USE_NAPARI_FOR_MOSAIC_DISPLAY = original_use_napari
+
+
+# ============================================================================
+# SquidXplorer launcher tests
+# ============================================================================
+
+
+def test_resolve_squidxplorer_command_configured_python(tmp_path, monkeypatch):
+    """A configured interpreter runs the viewer module with the run folder as one argv element."""
+    from control.squidxplorer_launcher import resolve_squidxplorer_command
+
+    fake_python = tmp_path / "python.exe"
+    fake_python.write_text("")
+    monkeypatch.setattr(control._def, "SQUIDXPLORER_PYTHON", str(fake_python), raising=False)
+
+    run_dir = r"C:\data\WELLPLATE 2026-07-30_10-00-00"
+    command = resolve_squidxplorer_command(run_dir)
+    assert command == [str(fake_python), "-m", "squidmip._viewer", run_dir]
+    # The dataset path must survive as a single element — SquidXplorer reads a bare argv[1].
+    assert command[-1] == run_dir
+
+
+def test_resolve_squidxplorer_command_path_fallback(monkeypatch):
+    """An unset (or bogus) interpreter falls back to squidmip-view on PATH."""
+    from control import squidxplorer_launcher
+
+    monkeypatch.setattr(control._def, "SQUIDXPLORER_PYTHON", "", raising=False)
+    monkeypatch.setattr(squidxplorer_launcher.shutil, "which", lambda name: r"C:\bin\squidmip-view.exe")
+
+    command = squidxplorer_launcher.resolve_squidxplorer_command(r"C:\data\run")
+    assert command == [r"C:\bin\squidmip-view.exe", r"C:\data\run"]
+
+
+def test_resolve_squidxplorer_command_not_installed(monkeypatch):
+    """Neither configured nor on PATH resolves to nothing, so the caller can explain."""
+    from control import squidxplorer_launcher
+
+    monkeypatch.setattr(control._def, "SQUIDXPLORER_PYTHON", "", raising=False)
+    monkeypatch.setattr(squidxplorer_launcher.shutil, "which", lambda name: None)
+
+    assert squidxplorer_launcher.resolve_squidxplorer_command(r"C:\data\run") is None
 
 
 # ============================================================================

--- a/software/tests/control/test_widgets.py
+++ b/software/tests/control/test_widgets.py
@@ -202,6 +202,28 @@ def test_resolve_squidxplorer_command_not_installed(monkeypatch):
     assert squidxplorer_launcher.resolve_squidxplorer_command(r"C:\data\run") is None
 
 
+def test_squidxplorer_environment_sets_lock_dir(monkeypatch):
+    """A configured lock dir reaches the viewer, so it can open alongside another SquidXplorer."""
+    from control.squidxplorer_launcher import squidxplorer_environment
+
+    monkeypatch.setattr(control._def, "SQUIDXPLORER_GUI_LOCK_DIR", r"C:\viewer\.venv\gui-locks", raising=False)
+    monkeypatch.setenv("SOME_UNRELATED_VAR", "kept")
+
+    env = squidxplorer_environment()
+    assert env["SQUIDMIP_GUI_LOCK_DIR"] == r"C:\viewer\.venv\gui-locks"
+    # The rest of the environment has to come along - the viewer needs PATH and friends.
+    assert env["SOME_UNRELATED_VAR"] == "kept"
+
+
+def test_squidxplorer_environment_unset_inherits(monkeypatch):
+    """No configured lock dir means no env override at all, so SquidXplorer's default applies."""
+    from control.squidxplorer_launcher import squidxplorer_environment
+
+    monkeypatch.setattr(control._def, "SQUIDXPLORER_GUI_LOCK_DIR", "", raising=False)
+
+    assert squidxplorer_environment() is None
+
+
 # ============================================================================
 # SurfacePlotWidget Tests
 # ============================================================================


### PR DESCRIPTION
Two commits, five files. Split out of a customer build branch; the branch is cut from current master and contains nothing else.

When a run will not fit in RAM alongside the napari mosaic view, the mosaic is traded away for the duration of the run instead of the run being refused outright — the operator gets the acquisition rather than a dialog. When it ends, the finished folder is offered to SquidXplorer.

`3b7be3c6` follows up by giving the handoff its own GUI lock directory, so launching SquidXplorer cannot collide with the main application's single-instance lock.

Note for review: `mosaic_ram_exceeds_available()` is the old `check_ram_available_with_error_dialog()` renamed — it now reports whether the mosaic fits rather than showing a dialog, because the caller decides what to do about it.