### PR TITLE
feat(acquisition): run every requested time point, and let the operator measure a run before committing to it

### DIFF
--- a/software/control/core/multi_point_controller.py
+++ b/software/control/core/multi_point_controller.py
@@ -1,15 +1,18 @@
+import collections
+import contextlib
 import dataclasses
 import json
 import math
 import os
 import pathlib
+import shutil
 import tempfile
 import time
 import yaml
 from datetime import datetime
 from enum import Enum
 from threading import Thread
-from typing import Optional, Tuple, Any
+from typing import List, Optional, Tuple, Any
 
 import numpy as np
 import pandas as pd
@@ -168,6 +171,48 @@ def _save_acquisition_yaml(
     except (OSError, yaml.YAMLError) as exc:
         _log = squid.logging.get_logger(__name__)
         _log.error("Failed to write acquisition YAML file '%s': %s", yaml_path, exc)
+
+
+def _noop(*_args, **_kwargs):
+    return None
+
+
+# Every callback the worker can fire, silenced.  A timing probe must not reach
+# QtMultiPointController's signal bridge, or it would trigger the whole
+# acquisition-finished fan-out: mosaic auto-save, NDViewer end_acquisition, the RAM and
+# backpressure monitor teardown, the z-plot, and the workflow runner.
+_QUIET_CALLBACKS = MultiPointControllerFunctions(
+    signal_acquisition_start=_noop,
+    signal_acquisition_finished=_noop,
+    signal_new_image=_noop,
+    signal_current_configuration=_noop,
+    signal_current_fov=_noop,
+    signal_overall_progress=_noop,
+    signal_region_progress=_noop,
+)
+
+
+@dataclasses.dataclass
+class TimingProbeResult:
+    """Outcome of a no-illumination timing probe.  See run_timing_probe()."""
+
+    ok: bool
+    per_fov_s: Optional[float] = None
+    move_s: Optional[float] = None
+    acquire_s: Optional[float] = None
+    af_s: Optional[float] = None
+    n_fovs_probed: int = 0
+    laser_af_failures: int = 0
+    aborted: bool = False
+    note: str = ""
+
+    def usable(self) -> bool:
+        """True when this measurement should be trusted as a per-FOV duration.
+
+        An aborted probe measured a partial FOV, and a probe whose autofocus failed did
+        not do the work a real FOV will do -- neither is representative.
+        """
+        return bool(self.ok and self.per_fov_s and not self.aborted and not self.laser_af_failures)
 
 
 class MultiPointController:
@@ -630,6 +675,305 @@ class MultiPointController:
             # We don't init all fields in __init__, so it's easy to get attribute errors.  We
             # consider this "not configured" and want it to be a ValueError.
             raise ValueError("Not properly configured for an acquisition, cannot estimate time point duration.")
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # Timing probe: measure per-FOV duration on real hardware, without illuminating
+    # ─────────────────────────────────────────────────────────────────────────────
+
+    _TIMING_PROBE_DIR_PREFIX = "_timing_probe_"
+
+    def _flatten_planned_fovs(self) -> List[Tuple[str, Tuple[float, ...]]]:
+        """Planned FOVs in the order run_coordinate_acquisition() will visit them."""
+        flattened = []
+        for region_id, coords in self.scanCoordinates.region_fov_coordinates.items():
+            for coord in coords:
+                flattened.append((region_id, tuple(coord)))
+        return flattened
+
+    def timing_probe_refusal_reason(self) -> Optional[str]:
+        """None if a no-illumination timing probe is safe here, else an operator-facing reason."""
+        if self.acquisition_in_progress():
+            return "An acquisition is already running."
+        if not self.base_path:
+            return "No saving directory set."
+        if not self.selected_configurations:
+            return "No channels selected."
+        if not self._flatten_planned_fovs():
+            return "No FOVs planned."
+        if not self.validate_acquisition_settings():
+            return "Laser autofocus has no reference position."
+        if control._def.ENABLE_NL5 and control._def.NL5_USE_DOUT:
+            # nl5.start_acquisition() fires the laser and triggers the camera together.
+            return "NL5 confocal has no non-illuminating acquisition path."
+        if (
+            self.liveController.trigger_mode == control._def.TriggerMode.HARDWARE
+            and control._def.HARDWARE_TRIGGER_MODE == control._def.HardwareTriggerMode.LEVEL
+        ):
+            # Under LEVEL the camera trigger pulse width IS illumination_on_time, so we cannot
+            # zero the strobe without also destroying the trigger.
+            return "Hardware LEVEL trigger cannot be run without illumination."
+        if self.do_autofocus and not self.do_reflection_af:
+            # Contrast AF is a contrast search: run dark it never early-exits and parks z at
+            # the bottom of its range.  Laser AF uses a separate reflection laser and is fine.
+            return "Contrast autofocus needs illumination; simulate with laser AF or AF off."
+        if self.protocol_info is not None:
+            # A fluidics protocol run is queued: the ProtocolRunner drives reagents in step with
+            # imaging, and a dry run would advance the sequence without acquiring anything.
+            return "Fluidics runs are not simulated."
+        return None
+
+    @contextlib.contextmanager
+    def _illumination_fuse(self):
+        """Make every illumination-opening path RAISE for the duration of a dry run.
+
+        Suppression by flag is only as good as the last refactor, and the failure mode here
+        is silent: a leak bleaches the operator's sample with no error.  This turns any
+        unanticipated attempt to open the light into a loud abort instead.
+
+        Deliberately NOT fused: microcontroller.turn_on_AF_laser().  That is the separate
+        reflection-autofocus laser, which must fire for laser AF to run at all.
+        """
+        live_controller = self.liveController
+        microcontroller = self.microcontroller
+
+        def _blocked(name):
+            def _raise(*_args, **_kwargs):
+                raise RuntimeError(f"Timing probe attempted to open illumination via {name}")
+
+            return _raise
+
+        live_controller.turn_on_illumination = _blocked("LiveController.turn_on_illumination")
+        microcontroller.turn_on_illumination = _blocked("Microcontroller.turn_on_illumination")
+        try:
+            # Start from a known-dark state so nothing can re-assert a gate pin mid-probe.
+            microcontroller.turn_off_illumination()
+            microcontroller.wait_till_operation_is_completed()
+            yield
+        finally:
+            # These are instance attributes shadowing the bound methods; deleting restores them.
+            for obj, name in ((live_controller, "turn_on_illumination"), (microcontroller, "turn_on_illumination")):
+                try:
+                    delattr(obj, name)
+                except AttributeError:
+                    pass
+            try:
+                microcontroller.turn_off_illumination()
+                microcontroller.wait_till_operation_is_completed()
+            except Exception:
+                self._log.exception("Timing probe: failed to force illumination off on exit")
+
+    def _build_probe_scan_plan(self, probe_fovs) -> ScanPositionInformation:
+        """A two-FOV scan plan built directly, so the real plan is never touched.
+
+        run_acquisition() applies the focus map by mutating the live ScanCoordinates; a probe
+        must not do that, so the z interpolation is applied to this copy only.
+        """
+        fov_coords = collections.OrderedDict()
+        for region_id, coord in probe_fovs:
+            fov_coords.setdefault(region_id, []).append(coord)
+
+        if self.focus_map:
+            for region_id, coords in fov_coords.items():
+                fov_coords[region_id] = [
+                    (c[0], c[1], self.focus_map.interpolate(c[0], c[1], region_id)) for c in coords
+                ]
+
+        return ScanPositionInformation(
+            scan_region_coords_mm=[self.scanCoordinates.region_centers[r] for r in fov_coords],
+            scan_region_names=list(fov_coords),
+            scan_region_fov_coords_mm=fov_coords,
+        )
+
+    def _harvest_probe_timing(self, worker, n_probed: int) -> TimingProbeResult:
+        """Turn the worker's timers into a per-FOV duration.
+
+        Uses the SECOND FOV when there is one, because its move_to_coordinate is a real
+        inter-FOV hop at the true scan step; the first FOV's move starts from wherever the
+        stage happened to be and also absorbs job-runner cold start.
+        """
+        timing = worker._timing
+        moves = timing.get_intervals("move_to_coordinate")
+        acquires = timing.get_intervals("acquire_at_position")
+        autofocuses = timing.get_intervals("perform_autofocus")
+
+        if not moves or not acquires:
+            return TimingProbeResult(
+                ok=False, aborted=worker.abort_requested_fn(), note="Simulation produced no timings"
+            )
+
+        index = 1 if (len(moves) > 1 and len(acquires) > 1) else 0
+        move_s = moves[index]
+        acquire_s = acquires[index]
+        af_s = autofocuses[index] if len(autofocuses) > index else 0.0
+        per_fov_s = move_s + acquire_s
+
+        note = ""
+        if index == 0:
+            # Only one FOV was planned, so its move was a no-op.  Fall back to the model's
+            # XY term so the number stays comparable with a multi-FOV estimate.
+            per_fov_s += (
+                control._def.SCAN_STABILIZATION_TIME_MS_X + control._def.SCAN_STABILIZATION_TIME_MS_Y
+            ) / 1000.0 + self._EST_XY_MOVE_OVERHEAD_S
+            note = "single-FOV plan: XY move modelled, not measured"
+
+        return TimingProbeResult(
+            ok=True,
+            per_fov_s=per_fov_s,
+            move_s=move_s,
+            acquire_s=acquire_s,
+            af_s=af_s,
+            n_fovs_probed=n_probed,
+            laser_af_failures=getattr(worker, "_laser_af_failures", 0),
+            aborted=worker.abort_requested_fn(),
+            note=note,
+        )
+
+    def _finish_timing_probe(self, probe_dir: str, saved: dict) -> None:
+        """Always runs: restore the stage, the live view, the settings, and delete the folder."""
+        try:
+            if self._start_position:
+                position = self._start_position
+                self._log.info(f"Timing probe: returning to {position}")
+                self.stage.move_x_to(position.x_mm)
+                self.stage.move_y_to(position.y_mm)
+                self.stage.move_z_to(position.z_mm)
+                self._start_position = None
+        except Exception:
+            self._log.exception("Timing probe: failed to restore the stage position")
+
+        try:
+            self.camera.enable_callbacks(self.camera_callback_was_enabled_before_multipoint)
+            if self.configuration_before_running_multipoint is not None:
+                self.liveController.set_microscope_mode(self.configuration_before_running_multipoint)
+            if self.liveController_was_live_before_multipoint and control._def.RESUME_LIVE_AFTER_ACQUISITION:
+                self.liveController.start_live()
+        except Exception:
+            self._log.exception("Timing probe: failed to restore the live/camera state")
+
+        try:
+            shutil.rmtree(probe_dir, ignore_errors=True)
+        except Exception:
+            self._log.exception(f"Timing probe: failed to delete {probe_dir}")
+
+        for attribute, value in saved.items():
+            setattr(self, attribute, value)
+        self.multiPointWorker = None
+        self.thread = None
+
+    def sweep_stale_timing_probe_dirs(self, older_than_s: float = 3600.0) -> None:
+        """Delete timing-probe folders orphaned by a crash mid-probe."""
+        if not self.base_path or not os.path.isdir(self.base_path):
+            return
+        try:
+            for name in os.listdir(self.base_path):
+                if not name.startswith(self._TIMING_PROBE_DIR_PREFIX):
+                    continue
+                path = os.path.join(self.base_path, name)
+                if os.path.isdir(path) and (time.time() - os.path.getmtime(path)) > older_than_s:
+                    self._log.info(f"Removing stale timing probe folder {path}")
+                    shutil.rmtree(path, ignore_errors=True)
+        except Exception:
+            self._log.exception("Failed to sweep stale timing probe folders")
+
+    def run_timing_probe(self, on_finished) -> Optional[str]:
+        """Run the first two planned FOVs on real hardware, dark, and time the second.
+
+        Every real cost is exercised -- stage moves, autofocus, channel switching (including
+        the emission filter wheel), exposures and disk writes -- so the resulting per-FOV
+        duration reflects this instrument rather than a table of constants.  The sample is
+        never illuminated; see MultiPointWorker._illumination_on_for_frame().
+
+        KNOWN LIMIT: two FOVs measure write dispatch and first-touch latency but not
+        steady-state disk backpressure, so on a slow or network volume the number still reads
+        optimistic.
+
+        Returns None once the probe thread is running (on_finished(TimingProbeResult) is
+        called when it ends), or a refusal string if the probe cannot safely run.
+        """
+        reason = self.timing_probe_refusal_reason()
+        if reason:
+            return reason
+
+        probe_fovs = self._flatten_planned_fovs()[:2]
+        probe_scan_plan = self._build_probe_scan_plan(probe_fovs)
+        experiment_id = self._TIMING_PROBE_DIR_PREFIX + datetime.now().strftime("%Y-%m-%d_%H-%M-%S.%f")
+        probe_dir = os.path.join(self.base_path, experiment_id)
+
+        saved = {
+            "Nt": self.Nt,
+            "deltat": self.deltat,
+            "experiment_ID": self.experiment_ID,
+            "dry_run": self.dry_run,
+            "z_range": self.z_range,
+        }
+
+        try:
+            self.Nt = 1
+            self.deltat = 0
+            self.dry_run = True
+            self.experiment_ID = experiment_id
+            utils.ensure_directory_exists(probe_dir)
+
+            self.abort_acqusition_requested = False
+            self._start_position = self.stage.get_pos()
+            if self.z_range is None:
+                self.z_range = (
+                    self._start_position.z_mm,
+                    self._start_position.z_mm + self.deltaZ * (self.NZ - 1),
+                )
+
+            self.configuration_before_running_multipoint = self.liveController.currentConfiguration
+            self.liveController_was_live_before_multipoint = self.liveController.is_live
+            if self.liveController.is_live:
+                self.liveController.stop_live()
+            self.camera_callback_was_enabled_before_multipoint = self.camera.get_callbacks_enabled()
+            self.camera.enable_callbacks(True)
+
+            self.timestamp_acquisition_started = time.time()
+            acquisition_params = self.build_params(
+                scan_position_information=probe_scan_plan,
+                # Read, do NOT consume: run_acquisition() clears these because it owns the run.
+                region_laser_af_offsets=dict(self.region_laser_af_offsets),
+            )
+
+            prewarmed_runner, prewarmed_bp_values = self.get_prewarmed_job_runner()
+            self.multiPointWorker = MultiPointWorker(
+                scope=self.microscope,
+                live_controller=self.liveController,
+                auto_focus_controller=self.autofocusController,
+                laser_auto_focus_controller=self.laserAutoFocusController,
+                objective_store=self.objectiveStore,
+                acquisition_parameters=acquisition_params,
+                callbacks=_QUIET_CALLBACKS,
+                abort_requested_fn=lambda: self.abort_acqusition_requested,
+                request_abort_fn=self.request_abort_aquisition,
+                extra_job_classes=[],
+                alignment_widget=self._alignment_widget,
+                slack_notifier=None,  # no Slack traffic for a probe
+                prewarmed_job_runner=prewarmed_runner,
+                prewarmed_bp_values=prewarmed_bp_values,
+                run_state_writer=None,  # -> NullRunStateWriter, no watchdog breadcrumb
+            )
+            worker = self.multiPointWorker
+        except Exception:
+            self._finish_timing_probe(probe_dir, saved)
+            raise
+
+        def _probe_thread():
+            result = TimingProbeResult(ok=False, note="Simulation failed")
+            try:
+                with self._illumination_fuse():
+                    worker.run()
+                result = self._harvest_probe_timing(worker, len(probe_fovs))
+            except Exception:
+                self._log.exception("Timing probe failed")
+            finally:
+                self._finish_timing_probe(probe_dir, saved)
+                on_finished(result)
+
+        self.thread = Thread(target=_probe_thread, name="Timing probe thread", daemon=True)
+        self.thread.start()
+        return None
 
     def _temporary_get_an_image_hack(self) -> Tuple[np.array, bool]:
         was_streaming = self.camera.get_is_streaming()

--- a/software/control/core/multi_point_controller.py
+++ b/software/control/core/multi_point_controller.py
@@ -192,6 +192,16 @@ _QUIET_CALLBACKS = MultiPointControllerFunctions(
 )
 
 
+@dataclasses.dataclass(frozen=True)
+class TimePointEstimate:
+    """How long one time point will take, and whether that came from hardware or a model."""
+
+    seconds: float
+    measured: bool
+    per_fov_s: float
+    n_fovs: int
+
+
 @dataclasses.dataclass
 class TimingProbeResult:
     """Outcome of a no-illumination timing probe.  See run_timing_probe()."""
@@ -286,6 +296,14 @@ class MultiPointController:
         self.base_path = None
         self.skip_saving = False
         self.dry_run = False
+
+        # Measured per-FOV duration from run_timing_probe(), with the configuration
+        # fingerprint it was measured against.  In memory only and deliberately not cached to
+        # disk: a per-FOV duration describes this machine right now, and one reloaded from a
+        # previous session would look authoritative while being silently wrong.
+        self._measured_per_fov_s: Optional[float] = None
+        self._measured_key: Optional[tuple] = None
+        self._measured_context: dict = {}
         self.xy_mode = "Current Position"
         self.widget_type = "wellplate"  # "wellplate" or "flexible"
         self.scan_size_mm = 0.0  # For wellplate mode: size of scan area per region
@@ -623,7 +641,95 @@ class MultiPointController:
     _EST_CONTRAST_AF_S = 3.0  # per AF event, contrast-based AF (very rough)
     _EST_TIME_POINT_OVERHEAD_S = 0.5  # folder creation, coordinates.csv, .done file
 
+    def get_timing_measure_key(self) -> tuple:
+        """Everything that changes the PER-FOV cost of an acquisition.
+
+        A measurement whose key no longer matches the current configuration is silently
+        discarded, so the operator can never be shown a stale number as if it were fresh.
+
+        NOTE: the FOV count is deliberately absent.  per_fov_s scales out of the time point
+        model, so adding wells does not invalidate a measurement -- and that is exactly the
+        edit where a good estimate matters most.  It is recorded as context instead.
+        """
+        try:
+            binning = tuple(self.camera.get_binning())
+        except Exception:
+            binning = None
+        return (
+            self.objectiveStore.current_objective,
+            tuple(
+                (config.name, float(config.exposure_time), getattr(config, "emission_filter_position", None))
+                for config in self.selected_configurations
+            ),
+            int(self.NZ),
+            round(float(self.deltaZ), 6),
+            self.z_stacking_config,
+            bool(self.use_piezo),
+            bool(self.do_autofocus),
+            bool(self.do_reflection_af),
+            bool(self.skip_saving),
+            # Move duration depends on how far the stage travels, so geometry is part of the key.
+            round(float(self.deltaX), 6),
+            round(float(self.deltaY), 6),
+            round(float(self.overlap_percent), 3),
+            round(float(self.scan_size_mm), 4),
+            binning,
+            self.base_path,  # a different target volume writes at a different speed
+            control._def.FILE_SAVING_OPTION,
+            bool(control._def.MERGE_CHANNELS),
+        )
+
+    def set_measured_per_fov_s(self, per_fov_s: float, context: Optional[dict] = None) -> None:
+        """Record a measured per-FOV duration, fingerprinted against the current settings.
+
+        Must be called while the controller still holds the user's real configuration --
+        run_timing_probe() restores everything it overrode before reporting back, precisely
+        so the key computed here matches the acquisition the operator is about to start.
+        """
+        self._measured_per_fov_s = float(per_fov_s)
+        self._measured_key = self.get_timing_measure_key()
+        self._measured_context = dict(context or {})
+        self._log.info(f"Measured per-FOV duration: {per_fov_s:.2f} [s]")
+
+    def clear_measured_per_fov_s(self) -> None:
+        self._measured_per_fov_s = None
+        self._measured_key = None
+        self._measured_context = {}
+
+    def get_time_point_estimate(self) -> TimePointEstimate:
+        """How long ONE time point will take, measured if we have a fresh measurement.
+
+        Falls back to the open-loop model (see the _EST_* constants) when no timing probe
+        has been run, or when the configuration has changed since one was.
+        """
+        model_seconds = self._modelled_time_point_duration_s()
+        n_fovs = self._planned_fov_count()
+
+        measured = self._measured_per_fov_s is not None and self._measured_key == self.get_timing_measure_key()
+        if measured:
+            per_fov_s = self._measured_per_fov_s
+            seconds = n_fovs * per_fov_s + self._EST_TIME_POINT_OVERHEAD_S
+        else:
+            per_fov_s = (model_seconds - self._EST_TIME_POINT_OVERHEAD_S) / n_fovs
+            seconds = model_seconds
+        return TimePointEstimate(seconds=seconds, measured=measured, per_fov_s=per_fov_s, n_fovs=n_fovs)
+
+    def _planned_fov_count(self) -> int:
+        return sum(
+            len(region_coords) for (_region_id, region_coords) in self.scanCoordinates.region_fov_coordinates.items()
+        )
+
     def get_estimated_time_point_duration_s(self) -> float:
+        """Seconds for one time point -- measured when available, modelled otherwise.
+
+        Kept as the simple scalar accessor; see get_time_point_estimate() when you need to
+        know whether the number was measured on hardware or merely modelled.
+
+        Raises a ValueError if the class is not configured for a valid acquisition.
+        """
+        return self.get_time_point_estimate().seconds
+
+    def _modelled_time_point_duration_s(self) -> float:
         """
         Return a ROUGH estimate, in seconds, of how long ONE time point of the currently
         configured acquisition will take.
@@ -632,8 +738,8 @@ class MultiPointController:
         channel count and autofocus settings plus a handful of empirically calibrated
         per-operation constants.  It does NOT model stage travel distance, disk or queue
         backpressure, filter wheel moves, fluidics, laser engine warmup, or AF retries.
-        Treat +/- 30% as normal.  It exists only to warn the operator pre-flight when a time
-        point plainly cannot fit inside the requested dt interval.
+        Treat +/- 30% as normal.  run_timing_probe() measures the same quantity on real
+        hardware and is far more accurate; this is the fallback when it has not been run.
 
         Raises a ValueError if the class is not configured for a valid acquisition.
         """

--- a/software/control/core/multi_point_controller.py
+++ b/software/control/core/multi_point_controller.py
@@ -240,6 +240,7 @@ class MultiPointController:
         self.use_manual_focus_map = False
         self.base_path = None
         self.skip_saving = False
+        self.dry_run = False
         self.xy_mode = "Current Position"
         self.widget_type = "wellplate"  # "wellplate" or "flexible"
         self.scan_size_mm = 0.0  # For wellplate mode: size of scan area per region
@@ -446,6 +447,15 @@ class MultiPointController:
 
     def set_skip_saving(self, skip_saving):
         self.skip_saving = skip_saving
+
+    def set_dry_run(self, dry_run: bool):
+        """Dry run: the real acquisition path runs, but the illumination is never opened.
+
+        Set ONLY by run_timing_probe().  The flag on its own does not make a run safe --
+        timing_probe_refusal_reason() holds the guards that do, and _illumination_fuse()
+        is the runtime backstop.
+        """
+        self.dry_run = dry_run
 
     def set_xy_mode(self, xy_mode):
         self.xy_mode = xy_mode
@@ -1113,6 +1123,7 @@ class MultiPointController:
             z_stacking_config=self.z_stacking_config,
             z_range=self.z_range,
             skip_saving=self.skip_saving,
+            dry_run=self.dry_run,
             plate_num_rows=plate_num_rows,
             plate_num_cols=plate_num_cols,
             xy_mode=self.xy_mode,

--- a/software/control/core/multi_point_controller.py
+++ b/software/control/core/multi_point_controller.py
@@ -560,6 +560,67 @@ class MultiPointController:
             # this "not configured" and want it to be a ValueError.
             raise ValueError("Not properly configured for an acquisition, cannot calculate image count.")
 
+    # Rough per-operation costs used by get_estimated_time_point_duration_s().  Calibrated
+    # against a real 4-FOV / 10-z / 1-channel / 500 ms / laser-AF run that took 31.5 [s].
+    _EST_XY_MOVE_OVERHEAD_S = 0.22  # blocking stage.move_x_to + move_y_to, beyond the stabilization sleeps
+    _EST_FRAME_OVERHEAD_S = 0.115  # per frame, beyond the exposure (config switch, trigger, dispatch)
+    _EST_LASER_AF_S = 1.0  # per FOV, laser reflection AF
+    _EST_CONTRAST_AF_S = 3.0  # per AF event, contrast-based AF (very rough)
+    _EST_TIME_POINT_OVERHEAD_S = 0.5  # folder creation, coordinates.csv, .done file
+
+    def get_estimated_time_point_duration_s(self) -> float:
+        """
+        Return a ROUGH estimate, in seconds, of how long ONE time point of the currently
+        configured acquisition will take.
+
+        This is a coarse, open-loop model built from exposure times, FOV count, Z levels,
+        channel count and autofocus settings plus a handful of empirically calibrated
+        per-operation constants.  It does NOT model stage travel distance, disk or queue
+        backpressure, filter wheel moves, fluidics, laser engine warmup, or AF retries.
+        Treat +/- 30% as normal.  It exists only to warn the operator pre-flight when a time
+        point plainly cannot fit inside the requested dt interval.
+
+        Raises a ValueError if the class is not configured for a valid acquisition.
+        """
+        try:
+            n_fovs = sum(
+                len(region_coords)
+                for (_region_id, region_coords) in self.scanCoordinates.region_fov_coordinates.items()
+            )
+            n_channels = len(self.selected_configurations)
+            if n_fovs <= 0 or n_channels <= 0:
+                raise ValueError("Cannot estimate time point duration with no FOVs or no channels selected.")
+
+            # Every channel costs its own exposure plus a fixed per-frame overhead.
+            exposure_s = sum(float(config.exposure_time) / 1000.0 for config in self.selected_configurations)
+            per_z_level_s = exposure_s + n_channels * self._EST_FRAME_OVERHEAD_S
+
+            if self.use_piezo:
+                z_step_s = control._def.MULTIPOINT_PIEZO_DELAY_MS / 1000.0
+            else:
+                z_step_s = control._def.SCAN_STABILIZATION_TIME_MS_Z / 1000.0
+
+            xy_move_s = (
+                control._def.SCAN_STABILIZATION_TIME_MS_X + control._def.SCAN_STABILIZATION_TIME_MS_Y
+            ) / 1000.0 + self._EST_XY_MOVE_OVERHEAD_S
+
+            # Laser AF runs at every FOV.  Contrast AF only runs when the z-stack shape allows
+            # it, and then only once every NUMBER_OF_FOVS_PER_AF FOVs -- see
+            # MultiPointWorker.perform_autofocus.
+            if self.do_reflection_af:
+                af_per_fov_s = self._EST_LASER_AF_S
+            elif self.do_autofocus and (self.NZ == 1 or self.z_stacking_config == "FROM CENTER"):
+                af_per_fov_s = self._EST_CONTRAST_AF_S / max(1, control._def.Acquisition.NUMBER_OF_FOVS_PER_AF)
+            else:
+                af_per_fov_s = 0.0
+
+            per_fov_s = xy_move_s + af_per_fov_s + self.NZ * (z_step_s + per_z_level_s)
+            return n_fovs * per_fov_s + self._EST_TIME_POINT_OVERHEAD_S
+        except AttributeError:
+            # We don't init all fields in __init__, so it's easy to get attribute errors.  We
+            # consider this "not configured" and want it to be a ValueError.
+            raise ValueError("Not properly configured for an acquisition, cannot estimate time point duration.")
+
     def _temporary_get_an_image_hack(self) -> Tuple[np.array, bool]:
         was_streaming = self.camera.get_is_streaming()
         callbacks_were_enabled = self.camera.get_callbacks_enabled()

--- a/software/control/core/multi_point_utils.py
+++ b/software/control/core/multi_point_utils.py
@@ -60,6 +60,9 @@ class AcquisitionParameters:
 
     apply_channel_offset: bool = True
     skip_saving: bool = False
+    # Dry run: every real hardware step (stage, autofocus, camera, disk) runs, but the
+    # illumination is never opened.  See MultiPointWorker._illumination_on_for_frame().
+    dry_run: bool = False
 
     # Plate dimensions (only used when xy_mode is plate-based, e.g. "Select Wells").
     plate_num_rows: int = 8  # For 96-well plate

--- a/software/control/core/multi_point_worker.py
+++ b/software/control/core/multi_point_worker.py
@@ -158,6 +158,11 @@ class MultiPointWorker:
         )
 
         self.time_point = 0
+        # Time-lapse pacing diagnostics.  We never skip a time point: when a round runs past
+        # its dt interval we start the next one immediately and record the overrun here.
+        self._late_time_points = 0
+        self._max_lateness_s = 0.0
+        self._total_lateness_s = 0.0
         self.af_fov_count = 0
         self.num_fovs = 0
         self.total_scans = 0
@@ -463,7 +468,9 @@ class MultiPointWorker:
             start_time = time.perf_counter_ns()
             self.camera.start_streaming()
             this_image_callback_id = self.camera.add_frame_callback(self._image_callback)
-            sleep_time = min(self.dt / 20.0, 0.5)
+            # Poll often enough to stay abort-responsive and keep the watchdog heartbeat alive,
+            # but never faster than 50 ms -- a tiny dt would otherwise busy-spin the wait loop.
+            sleep_time = min(max(self.dt / 20.0, 0.05), 0.5)
 
             # Send Slack acquisition start notification
             if self._slack_notifier is not None:
@@ -491,6 +498,7 @@ class MultiPointWorker:
                     self._log.debug("In run, abort_acquisition_requested=True")
                     break
                 self._run_state_beat()
+                time_point_start = time.time()
 
                 # Gate on laser engine readiness for the channels this acquisition will fire.
                 # Re-checked every timepoint so dt-induced sleep gaps are handled.
@@ -503,26 +511,43 @@ class MultiPointWorker:
                     self.run_single_time_point()
 
                 self.time_point = self.time_point + 1
-                if self.dt == 0:  # continous acquisition
-                    pass
-                else:  # timed acquisition
 
-                    # check if the aquisition has taken longer than dt or integer multiples of dt, if so skip the next time point(s)
-                    while time.time() > self.timestamp_acquisition_started + self.time_point * self.dt:
-                        self._log.info("skip time point " + str(self.time_point + 1))
-                        self.time_point = self.time_point + 1
+                if self.dt == 0:  # continous acquisition - start the next round immediately
+                    continue
 
-                    # check if it has reached Nt
-                    if self.time_point == self.Nt:
-                        break  # no waiting after taking the last time point
+                # Timed acquisition.  dt is a START-TO-START period.  We never skip a time point:
+                # if a round overran dt we start the next one immediately and the run just
+                # stretches out.  Dropping requested time points silently was the old behaviour
+                # and it cost whole acquisitions whenever a round was slower than dt.
+                next_start = self.timestamp_acquisition_started + self.time_point * self.dt
+                lateness_s = time.time() - next_start
+                if lateness_s > 0:
+                    round_s = time.time() - time_point_start
+                    self._late_time_points += 1
+                    self._total_lateness_s += lateness_s
+                    self._max_lateness_s = max(self._max_lateness_s, lateness_s)
+                    tail = (
+                        f"Starting time point {self.time_point + 1}/{self.Nt} immediately; no time points are skipped."
+                        if self.time_point < self.Nt
+                        else "This was the last time point."
+                    )
+                    self._log.warning(
+                        f"Time point {self.time_point}/{self.Nt} overran its {self.dt:g} [s] interval by "
+                        f"{lateness_s:.1f} [s] (the round took {round_s:.1f} [s]). {tail}"
+                    )
 
-                    # wait until it's time to do the next acquisition
-                    while time.time() < self.timestamp_acquisition_started + self.time_point * self.dt:
-                        if self.abort_requested_fn():
-                            self._log.debug("In run wait loop, abort_acquisition_requested=True")
-                            break
-                        self._run_state_beat()
-                        self._sleep(sleep_time)
+                # check if it has reached Nt
+                if self.time_point >= self.Nt:
+                    break  # no waiting after taking the last time point
+
+                # Wait until it's time to do the next acquisition.  If we are already late this
+                # loop is a no-op and the next round starts right away.
+                while time.time() < next_start:
+                    if self.abort_requested_fn():
+                        self._log.debug("In run wait loop, abort_acquisition_requested=True")
+                        break
+                    self._run_state_beat()
+                    self._sleep(sleep_time)
 
             elapsed_time = time.perf_counter_ns() - start_time
             self._log.info("Time taken for acquisition: " + str(elapsed_time / 10**9))
@@ -551,11 +576,19 @@ class MultiPointWorker:
             # Determine why the acquisition ended (drives the watchdog + the in-process finish msg).
             reason = self.end_reason = self._compute_end_reason()
             total_duration = time.time() - self.timestamp_acquisition_started
+            if self._late_time_points:
+                self._log.warning(
+                    f"{self._late_time_points} of {self.time_point} acquired time point(s) ran past the "
+                    f"{self.dt:g} [s] interval (worst overrun {self._max_lateness_s:.1f} [s], "
+                    f"total {self._total_lateness_s:.1f} [s]).  No time points were skipped."
+                )
             self._run_state.end(
                 reason,
                 {
                     "total_images": self.image_count,
                     "total_timepoints": self.time_point,
+                    "late_timepoints": self._late_time_points,
+                    "max_lateness_seconds": round(self._max_lateness_s, 3),
                     "total_duration_seconds": total_duration,
                     "errors_encountered": self._acquisition_error_count,
                 },
@@ -571,6 +604,7 @@ class MultiPointWorker:
                         errors_encountered=self._acquisition_error_count,
                         experiment_id=self.experiment_ID or "unknown",
                         reason=reason,
+                        late_timepoints=self._late_time_points,
                     )
                     self.callbacks.signal_slack_acquisition_finished(stats)
                 except Exception as e:

--- a/software/control/core/multi_point_worker.py
+++ b/software/control/core/multi_point_worker.py
@@ -202,6 +202,9 @@ class MultiPointWorker:
         self._current_round_images = {}
 
         self.skip_saving = acquisition_parameters.skip_saving
+        self._dry_run = acquisition_parameters.dry_run
+        if self._dry_run:
+            self._log.warning("DRY RUN: illumination will not be opened for this acquisition.")
         job_classes = []
         use_ome_tiff = FILE_SAVING_OPTION == FileSavingOption.OME_TIFF
         use_zarr_v3 = FILE_SAVING_OPTION == FileSavingOption.ZARR_V3
@@ -1110,7 +1113,10 @@ class MultiPointWorker:
                     return
 
     def acquire_at_position(self, region_id, current_path, fov):
-        af_succeeded = self.perform_autofocus(region_id, fov)
+        # Timed so the timing probe can separate the autofocus cost from the rest of the FOV;
+        # records ~0 on FOVs where contrast AF is skipped by the NUMBER_OF_FOVS_PER_AF gate.
+        with self._timing.get_timer("perform_autofocus"):
+            af_succeeded = self.perform_autofocus(region_id, fov)
         if not af_succeeded:
             self._log.error(
                 f"Autofocus failed in acquire_at_position.  Continuing to acquire anyway using the current z position (z={self.stage.get_pos().z_mm} [mm])"
@@ -1197,6 +1203,35 @@ class MultiPointWorker:
         self.callbacks.signal_current_configuration(config)
         self.liveController.set_microscope_mode(config)
         self.wait_till_operation_is_completed()
+
+    def _illumination_on_for_frame(self):
+        """Open the illumination for one frame -- or, in a dry run, issue the equal-cost
+        NON-illuminating twin of that command so the per-frame latency is still paid.
+
+        The twin is the same command with the opposite polarity:
+
+          * ShutterControlMode.TTL and LED matrix:
+                microcontroller.turn_off_illumination()   (microcontroller.py:768)
+            instead of
+                microcontroller.turn_on_illumination()    (microcontroller.py:762)
+            Identical packet shape (bytearray(tx_buffer_length), only cmd[1] differs),
+            identical send_command() path, and the caller's existing
+            wait_till_operation_is_completed() blocks on the same ack.  The firmware
+            handlers are mirror images of each other.
+          * ShutterControlMode.Software (LDI): set_shutter_state(ch, on=False) instead of
+            on=True -- one write_and_check either way.  Known bias: on a channel switch the
+            real path also closes the previously active channel first, so it costs one extra
+            serial round trip (~2-5 ms) that we do not.  Negligible against the ~250 ms
+            emission filter move that IS measured.
+
+        Do NOT substitute microcontroller.set_illumination(source, 0): the firmware ends
+        set_illumination() with `if (illumination_is_on) turn_on_illumination();`, which
+        would drive the gate pin HIGH whenever that global happens to be set.
+        """
+        if self._dry_run:
+            self.liveController.turn_off_illumination()
+            return
+        self.liveController.turn_on_illumination()
 
     def perform_autofocus(self, region_id, fov):
         if not self.do_reflection_af:
@@ -1479,15 +1514,27 @@ class MultiPointWorker:
         # trigger acquisition (including turning on the illumination) and read frame
         camera_illumination_time = self.camera.get_exposure_time()
         if self.liveController.trigger_mode == TriggerMode.SOFTWARE:
-            self.liveController.turn_on_illumination()
+            self._illumination_on_for_frame()
             self.wait_till_operation_is_completed()
             camera_illumination_time = None
         elif self.liveController.trigger_mode == TriggerMode.HARDWARE:
             if "Fluorescence" in config.name and ENABLE_NL5 and NL5_USE_DOUT:
+                # nl5.start_acquisition() both fires the laser and triggers the camera, so there
+                # is no dry-run-safe variant.  MultiPointController.timing_probe_refusal_reason()
+                # refuses this case up front; this assert is the tripwire if a future entry point
+                # forgets to ask.
+                assert not self._dry_run, "NL5 DOUT acquisition has no dry-run-safe path"
                 # TODO(imo): This used to use the "reset_image_ready_flag=False" on the read_frame, but oinly the toupcam camera implementation had the
                 #  "reset_image_ready_flag" arg, so this is broken for all other cameras.  Also this used to do some other funky stuff like setting internal camera flags.
                 #   I am pretty sure this is broken!
                 self.microscope.addons.nl5.start_acquisition()
+            elif self._dry_run:
+                # HARDWARE + EDGE only.  illumination_time=None makes the hardware trigger fn
+                # send control_illumination=False, clearing the strobe-control MSB, while the
+                # camera trigger pulse keeps its fixed TRIGGER_PULSE_LENGTH_us width.  Under
+                # HardwareTriggerMode.LEVEL the pulse width IS this value, so zeroing it would
+                # destroy the trigger -- LEVEL is refused before the probe ever starts.
+                camera_illumination_time = None
         # This is some large timeout that we use just so as to not block forever
         with self._timing.get_timer("_ready_for_next_trigger.wait"):
             if not self._ready_for_next_trigger.wait(self._frame_wait_timeout_s()):
@@ -1577,11 +1624,13 @@ class MultiPointWorker:
                 # trigger acquisition (including turning on the illumination)
                 if self.liveController.trigger_mode == TriggerMode.SOFTWARE:
                     # TODO(imo): use illum controller
-                    self.liveController.turn_on_illumination()
+                    self._illumination_on_for_frame()
                     self.wait_till_operation_is_completed()
 
-                # read camera frame
-                self.camera.send_trigger(illumination_time=self.camera.get_exposure_time())
+                # read camera frame.  In a dry run illumination_time=None clears the hardware
+                # strobe-control bit; see acquire_camera_image() for the EDGE/LEVEL caveat.
+                rgb_illumination_time = None if self._dry_run else self.camera.get_exposure_time()
+                self.camera.send_trigger(illumination_time=rgb_illumination_time)
                 image = self.camera.read_frame()
                 if image is None:
                     self._log.warning("self.camera.read_frame() returned None")

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -209,6 +209,9 @@ class QtMultiPointController(MultiPointController, QObject):
     # Unified mosaic/plate view: single signal carrying full per-tile metadata.
     mosaic_tile_update = Signal(object)  # MosaicTileUpdate
     timepoint_finished = Signal(int)  # time_point index that just completed
+    # TimingProbeResult from run_timing_probe().  Emitted from the probe thread; Qt's auto
+    # connection queues it onto the GUI thread, where showing dialogs is safe.
+    timing_probe_finished = Signal(object)
     # Slack notification signals (allows main thread to capture screenshot and maintain ordering)
     signal_slack_timepoint = Signal(object)  # TimepointStats
     signal_slack_acq_finished = Signal(object)  # AcquisitionStats

--- a/software/control/slack_notifier.py
+++ b/software/control/slack_notifier.py
@@ -53,6 +53,8 @@ class AcquisitionStats:
     errors_encountered: int
     experiment_id: str
     reason: str = "completed"
+    # Time points that ran past their dt interval.  They were still acquired, not skipped.
+    late_timepoints: int = 0
 
 
 @dataclass
@@ -570,6 +572,7 @@ class SlackNotifier:
         timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
         status_text = f"with {stats.errors_encountered} errors" if stats.errors_encountered > 0 else "successfully"
+        late_suffix = f" ({stats.late_timepoints} ran past the interval)" if stats.late_timepoints else ""
 
         blocks = [
             {
@@ -584,7 +587,7 @@ class SlackNotifier:
                         f"*Experiment:* {stats.experiment_id}\n"
                         f"*Status:* Finished {status_text}\n"
                         f"*Total Images:* {stats.total_images:,}\n"
-                        f"*Timepoints:* {stats.total_timepoints}\n"
+                        f"*Timepoints:* {stats.total_timepoints}{late_suffix}\n"
                         f"*Duration:* {duration_str}\n"
                         f"*Completed:* {timestamp}"
                     ),

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -1183,6 +1183,11 @@ class _TimingSimulationMixin:
         # rather than in a separate popup.
         self._probe_note = ""
         self._simulation_dialog = None
+        # timing_probe_finished lives on the shared controller, so EVERY multipoint widget
+        # receives it.  Only the one that launched the probe may react -- the same ownership
+        # rule is_current_acquisition_widget enforces for acquisition_finished.  Without it
+        # the other widget also re-enters toggle_acquisition and trips its own start guards.
+        self._timing_simulation_is_mine = False
 
     def _start_timing_simulation(self):
         refusal = self.multipointController.timing_probe_refusal_reason()
@@ -1190,6 +1195,7 @@ class _TimingSimulationMixin:
             error_dialog(f"Cannot simulate: {refusal}", title="Simulate Run")
             return
 
+        self._timing_simulation_is_mine = True
         self.setEnabled_all(False)
         self.btn_startAcquisition.setEnabled(False)
         self._show_simulation_dialog()
@@ -1222,6 +1228,10 @@ class _TimingSimulationMixin:
             self._simulation_dialog = None
 
     def _on_timing_probe_finished(self, result):
+        if not self._timing_simulation_is_mine:
+            return  # another multipoint widget launched this probe; it owns the result
+        self._timing_simulation_is_mine = False
+
         self._hide_simulation_dialog()
         self.setEnabled_all(True)
         self.btn_startAcquisition.setEnabled(True)

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -94,6 +94,52 @@ def check_space_available_with_error_dialog(
     return True
 
 
+def check_time_lapse_pacing_with_dialog(
+    multi_point_controller: MultiPointController, logger: logging.Logger, parent=None
+) -> bool:
+    """Warn (proceed/cancel) when one time point looks longer than the requested dt interval.
+
+    This is advisory, NOT a veto: an overrunning time lapse still acquires every requested
+    time point, it just stretches out.  Returns True to proceed, False if the user cancelled.
+    """
+    Nt = multi_point_controller.Nt
+    dt = multi_point_controller.deltat
+    if Nt <= 1 or dt <= 0:
+        return True  # single time point, or continuous mode - nothing to pace against
+
+    try:
+        estimated_s = multi_point_controller.get_estimated_time_point_duration_s()
+    except Exception:
+        logger.exception("Could not estimate time point duration; skipping the time-lapse pacing check.")
+        return True
+
+    logger.info(f"Time-lapse pacing check: estimated {estimated_s:.1f} [s] per time point, {dt=} [s], {Nt=}")
+    if estimated_s <= dt:
+        return True
+
+    requested_total_min = (dt * (Nt - 1) + estimated_s) / 60.0
+    actual_total_min = (estimated_s * Nt) / 60.0
+    logger.warning(f"Time point estimate ({estimated_s:.1f} s) exceeds dt ({dt:.1f} s) for a {Nt} time point run.")
+    message = (
+        f"Each time point is estimated to take about {estimated_s:.0f} s, which is longer than the "
+        f"requested interval of {dt:.0f} s.\n\n"
+        f"All {Nt} time points will still be acquired - none are skipped - but they will run back to "
+        f"back, so the effective interval will be about {estimated_s:.0f} s and the run will take "
+        f"roughly {actual_total_min:.0f} min instead of {requested_total_min:.0f} min.\n\n"
+        f"This is a rough estimate from exposure times, FOV count, Z levels and autofocus settings; "
+        f"actual timing may differ.\n\n"
+        f"Start the acquisition anyway?"
+    )
+    reply = QMessageBox.question(
+        parent,
+        "Time Point Longer Than Interval",
+        message,
+        QMessageBox.Yes | QMessageBox.No,
+        QMessageBox.Yes,
+    )
+    return reply == QMessageBox.Yes
+
+
 def check_ram_available_with_error_dialog(
     multi_point_controller: MultiPointController,
     logger: logging.Logger,
@@ -6843,6 +6889,13 @@ class FlexibleMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMixi
                 self.btn_startAcquisition.setChecked(False)
                 return
 
+            # Advisory: a time point longer than dt is allowed (nothing is skipped), but the
+            # operator should know the run will stretch out before they commit to it.
+            if not check_time_lapse_pacing_with_dialog(self.multipointController, self._log, self):
+                self._log.info("User cancelled acquisition after the time-lapse pacing warning.")
+                self.btn_startAcquisition.setChecked(False)
+                return
+
             if not check_ram_available_with_error_dialog(
                 self.multipointController, self._log, performance_mode=self.performance_mode
             ):
@@ -9257,6 +9310,13 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMix
             elif not check_space_available_with_error_dialog(self.multipointController, self._log):
                 self.btn_startAcquisition.setChecked(False)
                 self._log.error("Failed to start acquisition.  Not enough disk space available.")
+                return
+
+            # Advisory: a time point longer than dt is allowed (nothing is skipped), but the
+            # operator should know the run will stretch out before they commit to it.
+            if not check_time_lapse_pacing_with_dialog(self.multipointController, self._log, self):
+                self.btn_startAcquisition.setChecked(False)
+                self._log.info("User cancelled acquisition after the time-lapse pacing warning.")
                 return
 
             if not check_ram_available_with_error_dialog(

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -1,4 +1,5 @@
 import configparser
+import enum
 import gc
 import os
 import json
@@ -94,39 +95,89 @@ def check_space_available_with_error_dialog(
     return True
 
 
-def check_time_lapse_pacing_with_dialog(
-    multi_point_controller: MultiPointController, logger: logging.Logger, parent=None
-) -> bool:
-    """Warn (proceed/cancel) when one time point looks longer than the requested dt interval.
+class PacingChoice(enum.Enum):
+    PROCEED = "proceed"
+    SIMULATE = "simulate"
+    CANCEL = "cancel"
 
-    This is advisory, NOT a veto: an overrunning time lapse still acquires every requested
-    time point, it just stretches out.  Returns True to proceed, False if the user cancelled.
+
+def pacing_message(dt: float, estimate, probe_note: str = "") -> str:
+    """One line.  Do not grow this -- the two numbers are what the operator decides on."""
+    if probe_note:
+        return f"{probe_note} Est: {estimate.seconds:.0f} s. Proceed?"
+    label = "Measured" if estimate.measured else "Est"
+    if estimate.seconds > dt:
+        lead = "Measured" if estimate.measured else "Estimated"
+        return f"{lead} loop interval exceeds {dt:.0f} s. {label}: {estimate.seconds:.0f} s. Proceed?"
+    return f"Interval {dt:.0f} s. {label}: {estimate.seconds:.0f} s. Proceed?"
+
+
+def time_lapse_pacing_choice(
+    multi_point_controller: MultiPointController,
+    logger: logging.Logger,
+    parent=None,
+    probe_note: str = "",
+) -> PacingChoice:
+    """Pre-flight pacing dialog, shown for EVERY time lapse (Nt > 1).
+
+    It appears even when the estimate fits inside dt, so the operator always has the option
+    to measure the interval on real hardware instead of trusting the open-loop model.  This
+    is advisory, never a veto: an overrunning time lapse still acquires every requested time
+    point, it just stretches out.
     """
     Nt = multi_point_controller.Nt
     dt = multi_point_controller.deltat
     if Nt <= 1 or dt <= 0:
-        return True  # single time point, or continuous mode - nothing to pace against
+        return PacingChoice.PROCEED  # single time point, or continuous mode - nothing to pace against
 
     try:
-        estimated_s = multi_point_controller.get_estimated_time_point_duration_s()
+        estimate = multi_point_controller.get_time_point_estimate()
     except Exception:
         logger.exception("Could not estimate time point duration; skipping the time-lapse pacing check.")
-        return True
+        return PacingChoice.PROCEED
 
-    logger.info(f"Time-lapse pacing check: estimated {estimated_s:.1f} [s] per time point, {dt=} [s], {Nt=}")
-    if estimated_s <= dt:
-        return True
-
-    logger.warning(f"Time point estimate ({estimated_s:.1f} s) exceeds dt ({dt:.1f} s) for a {Nt} time point run.")
-    message = f"Estimated loop interval exceeds {dt:.0f} s. Est: {estimated_s:.0f} s. Proceed?"
-    reply = QMessageBox.question(
-        parent,
-        "Time Point Longer Than Interval",
-        message,
-        QMessageBox.Yes | QMessageBox.No,
-        QMessageBox.Yes,
+    logger.info(
+        f"Time-lapse pacing check: {'measured' if estimate.measured else 'estimated'} "
+        f"{estimate.seconds:.1f} [s] per time point ({estimate.per_fov_s:.2f} [s]/FOV x {estimate.n_fovs} FOVs), "
+        f"{dt=} [s], {Nt=}"
     )
-    return reply == QMessageBox.Yes
+    if estimate.seconds > dt:
+        logger.warning(
+            f"Time point estimate ({estimate.seconds:.1f} s) exceeds dt ({dt:.1f} s) for a {Nt} time point run."
+        )
+
+    box = QMessageBox(parent)
+    box.setIcon(QMessageBox.Warning if estimate.seconds > dt else QMessageBox.Question)
+    box.setWindowTitle("Time-Lapse Pacing")
+    box.setText(pacing_message(dt, estimate, probe_note))
+
+    simulate_button = None
+    refusal = multi_point_controller.timing_probe_refusal_reason()
+    if refusal is None:
+        simulate_button = box.addButton("Re-simulate" if estimate.measured else "Simulate", QMessageBox.ActionRole)
+    else:
+        logger.info(f"Simulate unavailable: {refusal}")
+    proceed_button = box.addButton("Proceed", QMessageBox.AcceptRole)
+    box.addButton("Cancel", QMessageBox.RejectRole)
+    box.setDefaultButton(proceed_button)
+    box.exec_()
+
+    clicked = box.clickedButton()
+    if simulate_button is not None and clicked is simulate_button:
+        return PacingChoice.SIMULATE
+    return PacingChoice.PROCEED if clicked is proceed_button else PacingChoice.CANCEL
+
+
+def probe_note_for(result) -> str:
+    """Short note for a probe whose measurement must not be trusted, else ''."""
+    if result.aborted:
+        return "Simulation stopped."
+    if not result.ok or not result.per_fov_s:
+        return "Simulation failed."
+    if result.laser_af_failures:
+        # A FOV whose autofocus failed did not do the work a real FOV will do.
+        return "Simulation AF failed."
+    return ""
 
 
 def check_ram_available_with_error_dialog(
@@ -1115,6 +1166,82 @@ class AcquisitionYAMLDropMixin:
     def _apply_yaml_settings(self, yaml_data):
         """Apply parsed YAML settings to widget controls. Override in subclass."""
         raise NotImplementedError("Subclass must implement _apply_yaml_settings()")
+
+
+class _TimingSimulationMixin:
+    """Mixin providing the "simulate run to estimate interval timing" round trip.
+
+    Widgets using this mixin must have ``self.multipointController`` (a
+    QtMultiPointController, for its ``timing_probe_finished`` signal), ``self._log``,
+    ``self.btn_startAcquisition``, and ``setEnabled_all(bool)``.  Call
+    ``_init_timing_simulation()`` from __init__ and connect
+    ``multipointController.timing_probe_finished`` to ``_on_timing_probe_finished``.
+    """
+
+    def _init_timing_simulation(self):
+        # Carried into the next pacing dialog so a failed simulation explains itself there
+        # rather than in a separate popup.
+        self._probe_note = ""
+        self._simulation_dialog = None
+
+    def _start_timing_simulation(self):
+        refusal = self.multipointController.timing_probe_refusal_reason()
+        if refusal:
+            error_dialog(f"Cannot simulate: {refusal}", title="Simulate Run")
+            return
+
+        self.setEnabled_all(False)
+        self.btn_startAcquisition.setEnabled(False)
+        self._show_simulation_dialog()
+
+        refusal = self.multipointController.run_timing_probe(
+            on_finished=self.multipointController.timing_probe_finished.emit
+        )
+        if refusal is not None:
+            # Refused between the check above and the launch (e.g. a run started meanwhile).
+            self._log.warning(f"Timing probe refused at launch: {refusal}")
+            self._on_timing_probe_finished(None)
+
+    def _show_simulation_dialog(self):
+        from qtpy.QtWidgets import QProgressDialog
+        from qtpy.QtCore import Qt
+
+        # Non-modal and always-on-top, matching the laser-engine wait dialog: the operator
+        # must be able to reach the rest of the UI if the probe hangs.
+        self._simulation_dialog = QProgressDialog("Simulating 2 FOVs (no illumination)…", "Stop", 0, 0, self)
+        self._simulation_dialog.setWindowTitle("Simulate Run")
+        self._simulation_dialog.setWindowModality(Qt.NonModal)
+        self._simulation_dialog.setWindowFlags(self._simulation_dialog.windowFlags() | Qt.WindowStaysOnTopHint)
+        self._simulation_dialog.setMinimumDuration(0)
+        self._simulation_dialog.canceled.connect(self.multipointController.request_abort_aquisition)
+        self._simulation_dialog.show()
+
+    def _hide_simulation_dialog(self):
+        if self._simulation_dialog is not None:
+            self._simulation_dialog.close()
+            self._simulation_dialog = None
+
+    def _on_timing_probe_finished(self, result):
+        self._hide_simulation_dialog()
+        self.setEnabled_all(True)
+        self.btn_startAcquisition.setEnabled(True)
+
+        if result is None:
+            self._probe_note = "Simulation failed."
+        else:
+            self._probe_note = probe_note_for(result)
+            if result.usable():
+                self.multipointController.set_measured_per_fov_s(
+                    result.per_fov_s,
+                    context={"n_fovs_probed": result.n_fovs_probed, "note": result.note},
+                )
+                self._log.info(f"Timing simulation measured {result.per_fov_s:.2f} [s] per FOV")
+            else:
+                self._log.warning(f"Timing simulation not usable: {self._probe_note} ({result.note})")
+
+        # Re-open the pacing dialog, now reading "Measured:" (or explaining the failure).
+        self.btn_startAcquisition.setChecked(True)
+        self.toggle_acquisition(True)
 
 
 class _ApplyChannelOffsetMixin:
@@ -6055,7 +6182,7 @@ class WellSelectionWidget(QTableWidget):
         self.setStyleSheet(style)
 
 
-class FlexibleMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMixin, QFrame):
+class FlexibleMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMixin, _TimingSimulationMixin, QFrame):
 
     signal_acquisition_started = Signal(bool)  # true = started, false = finished
     signal_acquisition_channels = Signal(list)  # list channels
@@ -6097,6 +6224,7 @@ class FlexibleMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMixi
         self.setup_connections()
         self.setFrameStyle(QFrame.Panel | QFrame.Raised)
         self.is_current_acquisition_widget = False
+        self._init_timing_simulation()
         self.acquisition_in_place = False
 
     def add_components(self):
@@ -6521,6 +6649,7 @@ class FlexibleMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMixi
         self.btn_setSavingDir.clicked.connect(self.set_saving_dir)
         self.btn_startAcquisition.clicked.connect(self.toggle_acquisition)
         self.multipointController.acquisition_finished.connect(self.acquisition_is_finished)
+        self.multipointController.timing_probe_finished.connect(self._on_timing_probe_finished)
         self.list_configurations.itemSelectionChanged.connect(self.emit_selected_channels)
         # self.combobox_z_stack.currentIndexChanged.connect(self.signal_z_stacking.emit)
 
@@ -6869,19 +6998,26 @@ class FlexibleMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMixi
                 error_dialog(problem)
                 self.btn_startAcquisition.setChecked(False)
                 return
+
+            # Ahead of start_new_experiment(): cancelling or diverting to a simulation here
+            # must not leave an empty timestamped experiment folder behind.
+            choice = time_lapse_pacing_choice(self.multipointController, self._log, self, self._probe_note)
+            self._probe_note = ""
+            if choice is PacingChoice.CANCEL:
+                self._log.info("User cancelled acquisition at the time-lapse pacing dialog.")
+                self.btn_startAcquisition.setChecked(False)
+                return
+            if choice is PacingChoice.SIMULATE:
+                self.btn_startAcquisition.setChecked(False)
+                self._start_timing_simulation()
+                return
+
             self.multipointController.start_new_experiment(self.lineEdit_experimentID.text())
 
             if self.checkbox_skipSaving.isChecked():
                 self._log.info("Skipping disk space check - image saving is disabled")
             elif not check_space_available_with_error_dialog(self.multipointController, self._log):
                 self._log.error("Failed to start acquisition.  Not enough disk space available.")
-                self.btn_startAcquisition.setChecked(False)
-                return
-
-            # Advisory: a time point longer than dt is allowed (nothing is skipped), but the
-            # operator should know the run will stretch out before they commit to it.
-            if not check_time_lapse_pacing_with_dialog(self.multipointController, self._log, self):
-                self._log.info("User cancelled acquisition after the time-lapse pacing warning.")
                 self.btn_startAcquisition.setChecked(False)
                 return
 
@@ -7569,7 +7705,7 @@ class FlexibleMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMixi
                 )
 
 
-class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMixin, QFrame):
+class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMixin, _TimingSimulationMixin, QFrame):
 
     signal_acquisition_started = Signal(bool)
     signal_acquisition_channels = Signal(list)
@@ -7615,6 +7751,7 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMix
         self.manual_shape = None
         self.eta_seconds = 0
         self.is_current_acquisition_widget = False
+        self._init_timing_simulation()
 
         self.shapes_mm = None
 
@@ -8116,6 +8253,7 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMix
         self.checkbox_skipSaving.toggled.connect(self.multipointController.set_skip_saving)
         self.list_configurations.itemSelectionChanged.connect(self.emit_selected_channels)
         self.multipointController.acquisition_finished.connect(self.acquisition_is_finished)
+        self.multipointController.timing_probe_finished.connect(self._on_timing_probe_finished)
         self.multipointController.signal_acquisition_progress.connect(self.update_acquisition_progress)
         self.multipointController.signal_region_progress.connect(self.update_region_progress)
         self.signal_acquisition_started.connect(self.display_progress_bar)
@@ -9292,6 +9430,20 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMix
                 QMessageBox.warning(self, "Warning", problem)
                 self.btn_startAcquisition.setChecked(False)
                 return
+
+            # Ahead of start_new_experiment(): cancelling or diverting to a simulation here
+            # must not leave an empty timestamped experiment folder behind.
+            choice = time_lapse_pacing_choice(self.multipointController, self._log, self, self._probe_note)
+            self._probe_note = ""
+            if choice is PacingChoice.CANCEL:
+                self.btn_startAcquisition.setChecked(False)
+                self._log.info("User cancelled acquisition at the time-lapse pacing dialog.")
+                return
+            if choice is PacingChoice.SIMULATE:
+                self.btn_startAcquisition.setChecked(False)
+                self._start_timing_simulation()
+                return
+
             self.multipointController.start_new_experiment(self.lineEdit_experimentID.text())
 
             if self.checkbox_skipSaving.isChecked():
@@ -9299,13 +9451,6 @@ class WellplateMultiPointWidget(AcquisitionYAMLDropMixin, _ApplyChannelOffsetMix
             elif not check_space_available_with_error_dialog(self.multipointController, self._log):
                 self.btn_startAcquisition.setChecked(False)
                 self._log.error("Failed to start acquisition.  Not enough disk space available.")
-                return
-
-            # Advisory: a time point longer than dt is allowed (nothing is skipped), but the
-            # operator should know the run will stretch out before they commit to it.
-            if not check_time_lapse_pacing_with_dialog(self.multipointController, self._log, self):
-                self.btn_startAcquisition.setChecked(False)
-                self._log.info("User cancelled acquisition after the time-lapse pacing warning.")
                 return
 
             if not check_ram_available_with_error_dialog(

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -117,19 +117,8 @@ def check_time_lapse_pacing_with_dialog(
     if estimated_s <= dt:
         return True
 
-    requested_total_min = (dt * (Nt - 1) + estimated_s) / 60.0
-    actual_total_min = (estimated_s * Nt) / 60.0
     logger.warning(f"Time point estimate ({estimated_s:.1f} s) exceeds dt ({dt:.1f} s) for a {Nt} time point run.")
-    message = (
-        f"Each time point is estimated to take about {estimated_s:.0f} s, which is longer than the "
-        f"requested interval of {dt:.0f} s.\n\n"
-        f"All {Nt} time points will still be acquired - none are skipped - but they will run back to "
-        f"back, so the effective interval will be about {estimated_s:.0f} s and the run will take "
-        f"roughly {actual_total_min:.0f} min instead of {requested_total_min:.0f} min.\n\n"
-        f"This is a rough estimate from exposure times, FOV count, Z levels and autofocus settings; "
-        f"actual timing may differ.\n\n"
-        f"Start the acquisition anyway?"
-    )
+    message = f"Estimated loop interval exceeds {dt:.0f} s. Est: {estimated_s:.0f} s. Proceed?"
     reply = QMessageBox.question(
         parent,
         "Time Point Longer Than Interval",

--- a/software/tests/control/test_time_lapse_pacing.py
+++ b/software/tests/control/test_time_lapse_pacing.py
@@ -5,8 +5,12 @@ requested time points whenever a round took longer than dt.  A real Nt=3 / dt=5 
 whose rounds took 31.5 s produced exactly one time point.
 """
 
+import copy
+import inspect
 import logging
 import os
+import tempfile
+import threading
 import time
 
 import pytest
@@ -145,6 +149,160 @@ def test_real_run_does_open_the_illumination():
     assert spy.lc_on > 0, "a normal acquisition must open the illumination"
     assert spy.lc_on == spy.lc_off, f"illumination left unbalanced: {spy.lc_on} on vs {spy.lc_off} off"
     scope.close()
+
+
+def _run_probe(mpc, timeout_s: float = 120):
+    """Run the timing probe and block until it reports back."""
+    done = threading.Event()
+    captured = {}
+
+    def on_finished(result):
+        captured["result"] = result
+        done.set()
+
+    refusal = mpc.run_timing_probe(on_finished=on_finished)
+    assert refusal is None, f"probe refused unexpectedly: {refusal}"
+    assert done.wait(timeout_s), "timing probe never finished"
+    return captured["result"]
+
+
+def _configure_probeable(mpc, scope, n_x: int = 3, n_y: int = 1):
+    """A valid, probeable acquisition: autofocus off, several FOVs, a scratch save path."""
+    mpc_tests.select_some_configs(mpc, scope.objective_store.current_objective)
+    mpc.set_af_flag(False)
+    mpc.set_reflection_af_flag(False)
+    mpc.set_NZ(1)
+    mpc.set_base_path(tempfile.mkdtemp(prefix="probe_test_"))
+    mpc.scanCoordinates.clear_regions()
+
+    x_min = mpc.stage.get_config().X_AXIS.MIN_POSITION + 0.01
+    y_min = mpc.stage.get_config().Y_AXIS.MIN_POSITION + 0.01
+    z_mid = (mpc.stage.get_config().Z_AXIS.MAX_POSITION - mpc.stage.get_config().Z_AXIS.MIN_POSITION) / 2.0
+    mpc.scanCoordinates.add_flexible_region(1, x_min, y_min, z_mid, n_x, n_y, 0)
+    return mpc
+
+
+def test_timing_probe_runs_the_first_two_planned_fovs():
+    scope = control.microscope.Microscope.build_from_global_config(True)
+    mpc = ts.get_test_multi_point_controller(microscope=scope)
+    _configure_probeable(mpc, scope)
+    assert len(mpc._flatten_planned_fovs()) >= 2
+
+    result = _run_probe(mpc)
+
+    assert result.ok, result.note
+    assert result.n_fovs_probed == 2
+    assert result.per_fov_s > 0
+    # The measured FOV is the second one, so its move is a real inter-FOV hop.
+    assert result.move_s is not None and result.acquire_s is not None
+    scope.close()
+
+
+def test_timing_probe_does_not_mutate_the_scan_plan():
+    """run_acquisition applies the focus map by mutating ScanCoordinates; a probe must not."""
+    scope = control.microscope.Microscope.build_from_global_config(True)
+    mpc = ts.get_test_multi_point_controller(microscope=scope)
+    _configure_probeable(mpc, scope)
+
+    before_fovs = copy.deepcopy(mpc.scanCoordinates.region_fov_coordinates)
+    before_centers = copy.deepcopy(mpc.scanCoordinates.region_centers)
+
+    _run_probe(mpc)
+
+    assert mpc.scanCoordinates.region_fov_coordinates == before_fovs
+    assert mpc.scanCoordinates.region_centers == before_centers
+    scope.close()
+
+
+def test_timing_probe_cleans_up_after_itself():
+    scope = control.microscope.Microscope.build_from_global_config(True)
+    mpc = ts.get_test_multi_point_controller(microscope=scope)
+    _configure_probeable(mpc, scope)
+    mpc.set_Nt(7)
+    mpc.set_deltat(11)
+    before = {"Nt": mpc.Nt, "deltat": mpc.deltat, "experiment_ID": mpc.experiment_ID}
+
+    _run_probe(mpc)
+
+    assert mpc.Nt == before["Nt"], "probe must restore Nt"
+    assert mpc.deltat == before["deltat"], "probe must restore deltat"
+    assert mpc.experiment_ID == before["experiment_ID"], "probe must restore experiment_ID"
+    assert mpc.dry_run is False, "probe must clear the dry_run flag"
+    leftovers = [n for n in os.listdir(mpc.base_path) if n.startswith(mpc._TIMING_PROBE_DIR_PREFIX)]
+    assert leftovers == [], f"probe left folders behind: {leftovers}"
+    scope.close()
+
+
+def test_timing_probe_never_opens_the_illumination():
+    scope = control.microscope.Microscope.build_from_global_config(True)
+    mpc = ts.get_test_multi_point_controller(microscope=scope)
+    _configure_probeable(mpc, scope)
+
+    spy = _IlluminationSpy(mpc.liveController, scope.low_level_drivers.microcontroller)
+    try:
+        result = _run_probe(mpc)
+    finally:
+        spy.restore()
+
+    assert result.ok, result.note
+    assert spy.lc_on == 0, f"LiveController.turn_on_illumination called {spy.lc_on}x during a probe"
+    assert spy.mcu_on == 0, f"Microcontroller.turn_on_illumination called {spy.mcu_on}x during a probe"
+    scope.close()
+
+
+def test_illumination_fuse_raises_then_restores():
+    scope = control.microscope.Microscope.build_from_global_config(True)
+    mpc = ts.get_test_multi_point_controller(microscope=scope)
+
+    with mpc._illumination_fuse():
+        with pytest.raises(RuntimeError, match="attempted to open illumination"):
+            mpc.liveController.turn_on_illumination()
+        with pytest.raises(RuntimeError, match="attempted to open illumination"):
+            scope.low_level_drivers.microcontroller.turn_on_illumination()
+
+    # Restored to the real bound methods, not left shadowed by the raising stubs.
+    assert inspect.ismethod(mpc.liveController.turn_on_illumination)
+    assert inspect.ismethod(scope.low_level_drivers.microcontroller.turn_on_illumination)
+    scope.close()
+
+
+def test_timing_probe_refusals():
+    scope = control.microscope.Microscope.build_from_global_config(True)
+    mpc = ts.get_test_multi_point_controller(microscope=scope)
+
+    # Nothing configured yet: no channels, no FOVs.
+    mpc.scanCoordinates.clear_regions()
+    mpc.set_selected_configurations([])
+    assert mpc.timing_probe_refusal_reason() is not None
+
+    _configure_probeable(mpc, scope)
+    assert mpc.timing_probe_refusal_reason() is None
+
+    # Contrast autofocus cannot run dark.
+    mpc.set_af_flag(True)
+    mpc.set_reflection_af_flag(False)
+    reason = mpc.timing_probe_refusal_reason()
+    assert reason is not None and "Contrast autofocus" in reason
+    # ...and run_timing_probe refuses rather than starting a thread.
+    assert mpc.run_timing_probe(on_finished=lambda _r: None) == reason
+    mpc.set_af_flag(False)
+
+    mpc.protocol_info = {"name": "demo", "round": "R01"}
+    assert mpc.timing_probe_refusal_reason() is not None
+    mpc.protocol_info = None
+
+    assert mpc.timing_probe_refusal_reason() is None
+    scope.close()
+
+
+def test_probe_result_usable_only_when_representative():
+    from control.core.multi_point_controller import TimingProbeResult
+
+    assert TimingProbeResult(ok=True, per_fov_s=7.0).usable()
+    assert not TimingProbeResult(ok=False, per_fov_s=7.0).usable()
+    assert not TimingProbeResult(ok=True, per_fov_s=7.0, aborted=True).usable()
+    assert not TimingProbeResult(ok=True, per_fov_s=7.0, laser_af_failures=1).usable()
+    assert not TimingProbeResult(ok=True, per_fov_s=None).usable()
 
 
 def test_all_time_points_run_when_rounds_overrun_dt():

--- a/software/tests/control/test_time_lapse_pacing.py
+++ b/software/tests/control/test_time_lapse_pacing.py
@@ -295,6 +295,94 @@ def test_timing_probe_refusals():
     scope.close()
 
 
+def test_measurement_feeds_the_estimate():
+    scope = control.microscope.Microscope.build_from_global_config(True)
+    mpc = ts.get_test_multi_point_controller(microscope=scope)
+    _configure_probeable(mpc, scope)
+
+    modelled = mpc.get_time_point_estimate()
+    assert modelled.measured is False
+    assert modelled.n_fovs == len(mpc._flatten_planned_fovs())
+
+    mpc.set_measured_per_fov_s(7.0)
+    measured = mpc.get_time_point_estimate()
+
+    assert measured.measured is True
+    assert measured.per_fov_s == 7.0
+    assert measured.seconds == pytest.approx(measured.n_fovs * 7.0 + mpc._EST_TIME_POINT_OVERHEAD_S)
+    # The scalar accessor follows the measurement too.
+    assert mpc.get_estimated_time_point_duration_s() == pytest.approx(measured.seconds)
+    scope.close()
+
+
+def test_measurement_is_discarded_when_the_per_fov_cost_changes():
+    scope = control.microscope.Microscope.build_from_global_config(True)
+    mpc = ts.get_test_multi_point_controller(microscope=scope)
+    _configure_probeable(mpc, scope)
+
+    for mutate in (
+        lambda: mpc.set_NZ(mpc.NZ + 1),
+        lambda: mpc.set_deltaZ(mpc.deltaZ * 1000 + 1),
+        lambda: mpc.set_reflection_af_flag(not mpc.do_reflection_af),
+        lambda: mpc.set_overlap_percent(mpc.overlap_percent + 5),
+        lambda: mpc.set_skip_saving(not mpc.skip_saving),
+        lambda: mpc.set_base_path(tempfile.mkdtemp(prefix="probe_other_")),
+    ):
+        mpc.set_measured_per_fov_s(7.0)
+        assert mpc.get_time_point_estimate().measured is True
+        mutate()
+        assert mpc.get_time_point_estimate().measured is False, f"stale measurement survived {mutate}"
+
+    # Changing an exposure time must also invalidate it.
+    mpc.set_measured_per_fov_s(7.0)
+    assert mpc.get_time_point_estimate().measured is True
+    mpc.selected_configurations[0].exposure_time = mpc.selected_configurations[0].exposure_time + 10
+    assert mpc.get_time_point_estimate().measured is False
+    scope.close()
+
+
+def test_measurement_survives_adding_fovs():
+    """per_fov_s scales out of the model, so more wells must NOT discard the measurement.
+
+    This is the edit where a good estimate matters most -- growing the plate is exactly
+    when the operator needs to know the loop no longer fits.
+    """
+    scope = control.microscope.Microscope.build_from_global_config(True)
+    mpc = ts.get_test_multi_point_controller(microscope=scope)
+    _configure_probeable(mpc, scope)
+
+    mpc.set_measured_per_fov_s(7.0)
+    before = mpc.get_time_point_estimate()
+    assert before.measured is True
+
+    x_min = mpc.stage.get_config().X_AXIS.MIN_POSITION + 0.01
+    y_min = mpc.stage.get_config().Y_AXIS.MIN_POSITION + 0.01
+    z_mid = (mpc.stage.get_config().Z_AXIS.MAX_POSITION - mpc.stage.get_config().Z_AXIS.MIN_POSITION) / 2.0
+    mpc.scanCoordinates.add_flexible_region(99, x_min + 2, y_min + 2, z_mid, 3, 1, 0)
+
+    after = mpc.get_time_point_estimate()
+    assert after.measured is True, "adding FOVs must not discard a valid per-FOV measurement"
+    assert after.n_fovs > before.n_fovs
+    assert after.seconds > before.seconds
+    scope.close()
+
+
+def test_clearing_the_measurement_falls_back_to_the_model():
+    scope = control.microscope.Microscope.build_from_global_config(True)
+    mpc = ts.get_test_multi_point_controller(microscope=scope)
+    _configure_probeable(mpc, scope)
+
+    modelled_seconds = mpc.get_time_point_estimate().seconds
+    mpc.set_measured_per_fov_s(7.0)
+    assert mpc.get_time_point_estimate().measured is True
+
+    mpc.clear_measured_per_fov_s()
+    fallback = mpc.get_time_point_estimate()
+    assert fallback.measured is False
+    assert fallback.seconds == pytest.approx(modelled_seconds)
+    scope.close()
+
+
 def test_probe_result_usable_only_when_representative():
     from control.core.multi_point_controller import TimingProbeResult
 

--- a/software/tests/control/test_time_lapse_pacing.py
+++ b/software/tests/control/test_time_lapse_pacing.py
@@ -1,0 +1,230 @@
+"""Tests for time-lapse pacing: every requested time point must be acquired.
+
+Regression cover for the old skip-if-behind-schedule logic, which silently dropped
+requested time points whenever a round took longer than dt.  A real Nt=3 / dt=5 s run
+whose rounds took 31.5 s produced exactly one time point.
+"""
+
+import logging
+import os
+import time
+
+import pytest
+
+import control._def
+import control.microscope
+from control.core.multi_point_controller import MultiPointController
+
+import tests.control.test_stubs as ts
+
+# Imported as a module, not by name: pytest warns when it sees a `Test*` class with an
+# __init__ in a test module's namespace and tries to collect it.
+import tests.control.test_MultiPointController as mpc_tests
+
+
+def _configure_single_fov(mpc: MultiPointController, nz: int = 1, n_channels: int = 1):
+    """Give the controller the minimum valid acquisition: one region, one FOV."""
+    all_configuration_names = [
+        config.name for config in mpc.liveController.get_channels(mpc.objectiveStore.current_objective)
+    ]
+    assert len(all_configuration_names) >= n_channels
+
+    mpc.set_NZ(nz)
+    mpc.set_selected_configurations(all_configuration_names[0:n_channels])
+    mpc.scanCoordinates.clear_regions()
+
+    # NOTE: If the coordinates aren't in the valid range for our stage, regions silently fail to add.
+    x_min = mpc.stage.get_config().X_AXIS.MIN_POSITION + 0.01
+    y_min = mpc.stage.get_config().Y_AXIS.MIN_POSITION + 0.01
+    z_mid = (mpc.stage.get_config().Z_AXIS.MAX_POSITION - mpc.stage.get_config().Z_AXIS.MIN_POSITION) / 2.0
+    mpc.scanCoordinates.add_flexible_region(1, x_min, y_min, z_mid, 1, 1, 0)
+    return all_configuration_names
+
+
+def _run_time_lapse(nt: int, dt: float):
+    """Run a full simulated acquisition with the given time-lapse settings."""
+    control._def.MERGE_CHANNELS = False
+    scope = control.microscope.Microscope.build_from_global_config(True)
+    tt = mpc_tests.TestAcquisitionTracker()
+    mpc = ts.get_test_multi_point_controller(microscope=scope, callbacks=tt.get_callbacks())
+
+    mpc_tests.add_some_coordinates(mpc)
+    mpc_tests.select_some_configs(mpc, scope.objective_store.current_objective)
+    mpc.set_Nt(nt)
+    mpc.set_deltat(dt)
+
+    started = time.time()
+    mpc.run_acquisition()
+    assert tt.started_event.wait(30)
+    assert tt.finished_event.wait(120)
+    elapsed = time.time() - started
+
+    worker = mpc.multiPointWorker
+    return mpc, tt, worker, elapsed, scope
+
+
+def test_all_time_points_run_when_rounds_overrun_dt():
+    """The regression: a round slower than dt must NOT cost us the remaining time points.
+
+    dt is deliberately tiny so every round overruns it.  The old skip-if-behind logic
+    turned this into a single time point.
+    """
+    nt = 3
+    mpc, tt, worker, _elapsed, scope = _run_time_lapse(nt=nt, dt=0.01)
+
+    # get_acquisition_image_count() multiplies by Nt, so this only holds if every round ran.
+    assert tt.image_count == mpc.get_acquisition_image_count()
+    assert worker.time_point == nt, "time_point must land exactly on Nt, never overshoot"
+    assert worker._late_time_points > 0, "rounds should have been recorded as late"
+
+    # Every time point must have produced its own output folder.
+    for time_point in range(nt):
+        folder = os.path.join(worker.experiment_path, f"{time_point:0{control._def.FILE_ID_PADDING}}")
+        assert os.path.isdir(folder), f"missing output folder for time point {time_point}"
+        assert os.path.isfile(os.path.join(folder, "coordinates.csv"))
+
+    scope.close()
+
+
+def test_continuous_mode_runs_all_time_points_without_waiting():
+    """dt == 0 is continuous acquisition: all rounds, back to back, nothing flagged late."""
+    nt = 2
+    mpc, tt, worker, _elapsed, scope = _run_time_lapse(nt=nt, dt=0)
+
+    assert tt.image_count == mpc.get_acquisition_image_count()
+    assert worker.time_point == nt
+    assert worker._late_time_points == 0, "continuous mode has no interval to run past"
+
+    scope.close()
+
+
+def test_start_to_start_pacing_is_honored_when_rounds_are_fast():
+    """A dt longer than the round must actually delay the next round by the remainder."""
+    nt = 2
+    dt = 6.0
+    mpc, tt, worker, elapsed, scope = _run_time_lapse(nt=nt, dt=dt)
+
+    assert tt.image_count == mpc.get_acquisition_image_count()
+    assert worker.time_point == nt
+
+    if worker._late_time_points == 0:
+        # Rounds fit inside dt, so round 2 started one full dt after the acquisition began.
+        assert elapsed >= dt, f"start-to-start pacing not honored: {elapsed=} < {dt=}"
+    else:
+        pytest.skip("simulated rounds were slower than dt; pacing not exercised")
+
+    scope.close()
+
+
+def test_time_point_duration_estimate_scales_with_acquisition_size():
+    scope = control.microscope.Microscope.build_from_global_config(True)
+    mpc = ts.get_test_multi_point_controller(microscope=scope)
+
+    mpc.set_reflection_af_flag(False)
+    mpc.set_af_flag(False)
+    all_configuration_names = _configure_single_fov(mpc, nz=1, n_channels=1)
+
+    one_fov_one_z = mpc.get_estimated_time_point_duration_s()
+    assert one_fov_one_z > 0
+
+    # More z levels costs strictly more, and the per-z cost is linear.
+    mpc.set_NZ(2)
+    two_z = mpc.get_estimated_time_point_duration_s()
+    mpc.set_NZ(3)
+    three_z = mpc.get_estimated_time_point_duration_s()
+    assert two_z > one_fov_one_z
+    assert three_z - two_z == pytest.approx(two_z - one_fov_one_z, rel=1e-6)
+
+    # More FOVs costs strictly more.
+    mpc.set_NZ(1)
+    x_min = mpc.stage.get_config().X_AXIS.MIN_POSITION + 0.01
+    y_min = mpc.stage.get_config().Y_AXIS.MIN_POSITION + 0.01
+    z_mid = (mpc.stage.get_config().Z_AXIS.MAX_POSITION - mpc.stage.get_config().Z_AXIS.MIN_POSITION) / 2.0
+    mpc.scanCoordinates.add_flexible_region(2, x_min + 1, y_min + 1, z_mid, 1, 1, 0)
+    assert mpc.get_estimated_time_point_duration_s() > one_fov_one_z
+
+    # Autofocus costs strictly more.
+    before_af = mpc.get_estimated_time_point_duration_s()
+    mpc.set_reflection_af_flag(True)
+    assert mpc.get_estimated_time_point_duration_s() > before_af
+
+    scope.close()
+
+
+def test_time_point_duration_estimate_requires_configuration():
+    scope = control.microscope.Microscope.build_from_global_config(True)
+    mpc = ts.get_test_multi_point_controller(microscope=scope)
+
+    mpc.scanCoordinates.clear_regions()
+    mpc.set_selected_configurations([])
+    with pytest.raises(ValueError):
+        mpc.get_estimated_time_point_duration_s()
+
+    scope.close()
+
+
+def test_pacing_dialog_is_skipped_when_there_is_nothing_to_warn_about():
+    """The helper must return True without ever constructing a dialog in these cases.
+
+    Qt is not driven here on purpose: every branch under test returns before the
+    QMessageBox call, so reaching one would raise instead of silently passing.
+    """
+    from control.widgets import check_time_lapse_pacing_with_dialog
+
+    scope = control.microscope.Microscope.build_from_global_config(True)
+    mpc = ts.get_test_multi_point_controller(microscope=scope)
+    logger = logging.getLogger("test_pacing_dialog")
+
+    _configure_single_fov(mpc, nz=1, n_channels=1)
+    mpc.set_reflection_af_flag(False)
+    mpc.set_af_flag(False)
+
+    # Single time point: no interval to pace against.
+    mpc.set_Nt(1)
+    mpc.set_deltat(10)
+    assert check_time_lapse_pacing_with_dialog(mpc, logger) is True
+
+    # Continuous mode: dt == 0 means "as fast as possible", nothing to warn about.
+    mpc.set_Nt(5)
+    mpc.set_deltat(0)
+    assert check_time_lapse_pacing_with_dialog(mpc, logger) is True
+
+    # dt comfortably larger than the estimate: the run fits its schedule.
+    mpc.set_deltat(mpc.get_estimated_time_point_duration_s() * 100)
+    assert check_time_lapse_pacing_with_dialog(mpc, logger) is True
+
+    # An estimator failure must not block the acquisition.
+    mpc.set_deltat(0.001)
+    mpc.scanCoordinates.clear_regions()  # makes get_estimated_time_point_duration_s raise
+    assert check_time_lapse_pacing_with_dialog(mpc, logger) is True
+
+    scope.close()
+
+
+def test_time_point_duration_estimate_matches_reference_run():
+    """The constants are calibrated against a real run; keep them honest.
+
+    Reference: 4 FOVs x 10 z x 1 channel @ 500 ms exposure, laser AF on, took 31.5 s
+    (Downloads\\z_and_time_2026-07-31_15-56-18.823673).
+    """
+    scope = control.microscope.Microscope.build_from_global_config(True)
+    mpc = ts.get_test_multi_point_controller(microscope=scope)
+
+    all_configuration_names = _configure_single_fov(mpc, nz=10, n_channels=1)
+    mpc.set_reflection_af_flag(True)
+    mpc.set_af_flag(False)
+    mpc.set_use_piezo(False)
+    mpc.selected_configurations[0].exposure_time = 500.0
+
+    # Add 3 more single-FOV regions to reach the reference run's 4 FOVs.
+    x_min = mpc.stage.get_config().X_AXIS.MIN_POSITION + 0.01
+    y_min = mpc.stage.get_config().Y_AXIS.MIN_POSITION + 0.01
+    z_mid = (mpc.stage.get_config().Z_AXIS.MAX_POSITION - mpc.stage.get_config().Z_AXIS.MIN_POSITION) / 2.0
+    for i in range(1, 4):
+        mpc.scanCoordinates.add_flexible_region(i + 1, x_min + i, y_min + i, z_mid, 1, 1, 0)
+
+    estimated = mpc.get_estimated_time_point_duration_s()
+    # Within 30% of the measured 31.5 s -- the docstring's stated accuracy.
+    assert estimated == pytest.approx(31.5, rel=0.3)
+
+    scope.close()

--- a/software/tests/control/test_time_lapse_pacing.py
+++ b/software/tests/control/test_time_lapse_pacing.py
@@ -493,13 +493,13 @@ def test_time_point_duration_estimate_requires_configuration():
     scope.close()
 
 
-def test_pacing_dialog_is_skipped_when_there_is_nothing_to_warn_about():
-    """The helper must return True without ever constructing a dialog in these cases.
+def test_pacing_dialog_is_skipped_when_there_is_no_time_series():
+    """The helper must return PROCEED without ever constructing a dialog in these cases.
 
-    Qt is not driven here on purpose: every branch under test returns before the
-    QMessageBox call, so reaching one would raise instead of silently passing.
+    Qt is not driven here on purpose: every branch under test returns before the QMessageBox
+    is built, so reaching one would raise instead of silently passing.
     """
-    from control.widgets import check_time_lapse_pacing_with_dialog
+    from control.widgets import time_lapse_pacing_choice, PacingChoice
 
     scope = control.microscope.Microscope.build_from_global_config(True)
     mpc = ts.get_test_multi_point_controller(microscope=scope)
@@ -512,23 +512,46 @@ def test_pacing_dialog_is_skipped_when_there_is_nothing_to_warn_about():
     # Single time point: no interval to pace against.
     mpc.set_Nt(1)
     mpc.set_deltat(10)
-    assert check_time_lapse_pacing_with_dialog(mpc, logger) is True
+    assert time_lapse_pacing_choice(mpc, logger) is PacingChoice.PROCEED
 
-    # Continuous mode: dt == 0 means "as fast as possible", nothing to warn about.
+    # Continuous mode: dt == 0 means "as fast as possible", nothing to pace against.
     mpc.set_Nt(5)
     mpc.set_deltat(0)
-    assert check_time_lapse_pacing_with_dialog(mpc, logger) is True
-
-    # dt comfortably larger than the estimate: the run fits its schedule.
-    mpc.set_deltat(mpc.get_estimated_time_point_duration_s() * 100)
-    assert check_time_lapse_pacing_with_dialog(mpc, logger) is True
+    assert time_lapse_pacing_choice(mpc, logger) is PacingChoice.PROCEED
 
     # An estimator failure must not block the acquisition.
     mpc.set_deltat(0.001)
-    mpc.scanCoordinates.clear_regions()  # makes get_estimated_time_point_duration_s raise
-    assert check_time_lapse_pacing_with_dialog(mpc, logger) is True
+    mpc.scanCoordinates.clear_regions()  # makes the estimate raise
+    assert time_lapse_pacing_choice(mpc, logger) is PacingChoice.PROCEED
 
     scope.close()
+
+
+def test_pacing_message_text():
+    """Pin the operator-facing strings.  They are deliberately terse; keep them that way."""
+    from control.widgets import pacing_message
+    from control.core.multi_point_controller import TimePointEstimate
+
+    estimated = TimePointEstimate(seconds=32.0, measured=False, per_fov_s=8.0, n_fovs=4)
+    measured = TimePointEstimate(seconds=34.0, measured=True, per_fov_s=8.5, n_fovs=4)
+
+    # Unchanged from the shipped wording, so the common case reads exactly as before.
+    assert pacing_message(5, estimated) == "Estimated loop interval exceeds 5 s. Est: 32 s. Proceed?"
+    assert pacing_message(60, estimated) == "Interval 60 s. Est: 32 s. Proceed?"
+    assert pacing_message(5, measured) == "Measured loop interval exceeds 5 s. Measured: 34 s. Proceed?"
+    assert pacing_message(60, measured) == "Interval 60 s. Measured: 34 s. Proceed?"
+    # A failed probe explains itself in the same one-liner.
+    assert pacing_message(5, estimated, "Simulation failed.") == "Simulation failed. Est: 32 s. Proceed?"
+
+
+def test_probe_note_only_set_for_unusable_results():
+    from control.widgets import probe_note_for
+    from control.core.multi_point_controller import TimingProbeResult
+
+    assert probe_note_for(TimingProbeResult(ok=True, per_fov_s=7.0)) == ""
+    assert probe_note_for(TimingProbeResult(ok=True, per_fov_s=7.0, aborted=True)) == "Simulation stopped."
+    assert probe_note_for(TimingProbeResult(ok=False)) == "Simulation failed."
+    assert probe_note_for(TimingProbeResult(ok=True, per_fov_s=7.0, laser_af_failures=2)) == "Simulation AF failed."
 
 
 def test_time_point_duration_estimate_matches_reference_run():

--- a/software/tests/control/test_time_lapse_pacing.py
+++ b/software/tests/control/test_time_lapse_pacing.py
@@ -41,7 +41,44 @@ def _configure_single_fov(mpc: MultiPointController, nz: int = 1, n_channels: in
     return all_configuration_names
 
 
-def _run_time_lapse(nt: int, dt: float):
+class _IlluminationSpy:
+    """Counts every illumination on/off call at both the LiveController and MCU level.
+
+    Wraps rather than replaces, so the real hardware path still executes and the timing
+    behaviour under test is the behaviour that ships.
+    """
+
+    def __init__(self, live_controller, microcontroller):
+        self.lc_on = 0
+        self.lc_off = 0
+        self.mcu_on = 0
+        self.mcu_off = 0
+        self._targets = []
+        for obj, name, counter in (
+            (live_controller, "turn_on_illumination", "lc_on"),
+            (live_controller, "turn_off_illumination", "lc_off"),
+            (microcontroller, "turn_on_illumination", "mcu_on"),
+            (microcontroller, "turn_off_illumination", "mcu_off"),
+        ):
+            self._targets.append((obj, name, getattr(obj, name)))
+            setattr(obj, name, self._wrap(getattr(obj, name), counter))
+
+    def _wrap(self, original, counter):
+        def wrapper(*args, **kwargs):
+            setattr(self, counter, getattr(self, counter) + 1)
+            return original(*args, **kwargs)
+
+        return wrapper
+
+    def restore(self):
+        for obj, name, original in self._targets:
+            try:
+                delattr(obj, name)
+            except AttributeError:
+                setattr(obj, name, original)
+
+
+def _run_time_lapse(nt: int, dt: float, dry_run: bool = False, spy: bool = False):
     """Run a full simulated acquisition with the given time-lapse settings."""
     control._def.MERGE_CHANNELS = False
     scope = control.microscope.Microscope.build_from_global_config(True)
@@ -52,6 +89,10 @@ def _run_time_lapse(nt: int, dt: float):
     mpc_tests.select_some_configs(mpc, scope.objective_store.current_objective)
     mpc.set_Nt(nt)
     mpc.set_deltat(dt)
+    mpc.set_dry_run(dry_run)
+
+    if spy:
+        tt.illumination_spy = _IlluminationSpy(mpc.liveController, scope.low_level_drivers.microcontroller)
 
     started = time.time()
     mpc.run_acquisition()
@@ -61,6 +102,49 @@ def _run_time_lapse(nt: int, dt: float):
 
     worker = mpc.multiPointWorker
     return mpc, tt, worker, elapsed, scope
+
+
+def test_dry_run_flag_reaches_the_worker():
+    scope = control.microscope.Microscope.build_from_global_config(True)
+    mpc = ts.get_test_multi_point_controller(microscope=scope)
+    _configure_single_fov(mpc)
+
+    assert mpc.dry_run is False
+    mpc.set_dry_run(True)
+    assert mpc.dry_run is True
+
+    mpc, tt, worker, _elapsed, scope2 = _run_time_lapse(nt=1, dt=0, dry_run=True)
+    assert worker._dry_run is True
+    scope.close()
+    scope2.close()
+
+
+def test_dry_run_never_opens_the_illumination():
+    """The load-bearing safety test.
+
+    A dry run must not open the light on ANY path.  If this regresses, an operator running
+    a timing simulation silently photobleaches their sample with no error message.
+    """
+    mpc, tt, worker, _elapsed, scope = _run_time_lapse(nt=1, dt=0, dry_run=True, spy=True)
+    spy = tt.illumination_spy
+    spy.restore()
+
+    assert spy.lc_on == 0, f"LiveController.turn_on_illumination called {spy.lc_on}x during a dry run"
+    assert spy.mcu_on == 0, f"Microcontroller.turn_on_illumination called {spy.mcu_on}x during a dry run"
+    # Every frame still pays the round trip -- twice, since the "on" is substituted by an "off".
+    assert spy.lc_off > 0, "the equal-cost substitute command was never issued"
+    scope.close()
+
+
+def test_real_run_does_open_the_illumination():
+    """Counterpart to the dry-run test: proves the spy would have caught a leak."""
+    mpc, tt, worker, _elapsed, scope = _run_time_lapse(nt=1, dt=0, dry_run=False, spy=True)
+    spy = tt.illumination_spy
+    spy.restore()
+
+    assert spy.lc_on > 0, "a normal acquisition must open the illumination"
+    assert spy.lc_on == spy.lc_off, f"illumination left unbalanced: {spy.lc_on} on vs {spy.lc_off} off"
+    scope.close()
 
 
 def test_all_time_points_run_when_rounds_overrun_dt():

--- a/software/tests/control/test_timing_probe_gui_roundtrip.py
+++ b/software/tests/control/test_timing_probe_gui_roundtrip.py
@@ -1,0 +1,116 @@
+"""The Simulate round trip must leave the widget able to start an acquisition.
+
+After a timing probe the widget re-enters toggle_acquisition() to re-show the pacing
+dialog with the measured number.  That path runs the same guard clauses an operator's
+click does, so anything the probe disturbs -- notably the channel selection, which
+channel_sequence stores as the QListWidget's selection -- surfaces as a spurious
+"Please select at least one imaging channel" dialog.
+"""
+
+import pytest
+from qtpy.QtWidgets import QMessageBox
+
+import control._def
+import control.gui_hcs
+import control.microscope
+
+
+@pytest.fixture
+def confirm_exit_yes(monkeypatch):
+    def confirm_exit(parent, title, text, *args, **kwargs):
+        if title == "Confirm Exit":
+            return QMessageBox.Yes
+        raise RuntimeError(f"Unexpected QMessageBox: {title} - {text}")
+
+    monkeypatch.setattr(QMessageBox, "question", confirm_exit)
+
+
+def _select_first_channel(widget):
+    items = [widget.list_configurations.item(i) for i in range(widget.list_configurations.count())]
+    assert items, "no channels available to select"
+    items[0].setSelected(True)
+    return items[0].text()
+
+
+@pytest.mark.parametrize("widget_attr", ["wellplateMultiPointWidget", "flexibleMultiPointWidget"])
+def test_enable_disable_preserves_channel_selection(qtbot, confirm_exit_yes, widget_attr):
+    """setEnabled_all() is what the probe brackets its run with; it must not clear selection."""
+    scope = control.microscope.Microscope.build_from_global_config(True)
+    win = control.gui_hcs.HighContentScreeningGui(microscope=scope, is_simulation=True)
+    qtbot.add_widget(win)
+
+    widget = getattr(win, widget_attr)
+    name = _select_first_channel(widget)
+    assert widget.channel_sequence.ordered_selected_names() == [name]
+
+    widget.setEnabled_all(False)
+    widget.setEnabled_all(True)
+
+    assert widget.list_configurations.selectedItems(), (
+        "setEnabled_all() cleared the channel selection; the acquisition start guard "
+        "would reject the run with 'Please select at least one imaging channel'"
+    )
+    assert widget.channel_sequence.ordered_selected_names() == [name]
+
+
+def test_probe_result_only_reaches_the_widget_that_launched_it(qtbot, confirm_exit_yes, monkeypatch):
+    """timing_probe_finished is a controller signal, so both multipoint widgets receive it.
+
+    Regression: with no ownership guard the widget that did NOT start the probe also
+    re-entered toggle_acquisition, hit its own empty channel list, and popped
+    "Please select at least one imaging channel" on top of the real dialog.
+    """
+    from control.core.multi_point_controller import TimingProbeResult
+
+    scope = control.microscope.Microscope.build_from_global_config(True)
+    win = control.gui_hcs.HighContentScreeningGui(microscope=scope, is_simulation=True)
+    qtbot.add_widget(win)
+
+    owner = win.wellplateMultiPointWidget
+    bystander = win.flexibleMultiPointWidget
+    _select_first_channel(owner)
+
+    reentered = []
+    monkeypatch.setattr(owner, "toggle_acquisition", lambda pressed: reentered.append("owner"))
+    monkeypatch.setattr(bystander, "toggle_acquisition", lambda pressed: reentered.append("bystander"))
+
+    # The owner claims the probe, exactly as _start_timing_simulation() does.
+    owner._timing_simulation_is_mine = True
+    result = TimingProbeResult(ok=True, per_fov_s=7.0, n_fovs_probed=2)
+
+    # Both widgets are connected to the signal, so both handlers run.
+    owner._on_timing_probe_finished(result)
+    bystander._on_timing_probe_finished(result)
+
+    assert reentered == ["owner"], f"expected only the launching widget to react, got {reentered}"
+
+
+@pytest.mark.parametrize("widget_attr", ["wellplateMultiPointWidget", "flexibleMultiPointWidget"])
+def test_probe_finished_does_not_lose_the_channel_selection(qtbot, confirm_exit_yes, monkeypatch, widget_attr):
+    """The full post-probe handler must leave the widget startable."""
+    from control.core.multi_point_controller import TimingProbeResult
+
+    scope = control.microscope.Microscope.build_from_global_config(True)
+    win = control.gui_hcs.HighContentScreeningGui(microscope=scope, is_simulation=True)
+    qtbot.add_widget(win)
+
+    widget = getattr(win, widget_attr)
+    name = _select_first_channel(widget)
+
+    # Stop the re-entry into toggle_acquisition from actually starting anything; we only
+    # care about the widget state the handler leaves behind.
+    reentered = {}
+
+    def fake_toggle(pressed):
+        reentered["selected"] = [i.text() for i in widget.list_configurations.selectedItems()]
+
+    monkeypatch.setattr(widget, "toggle_acquisition", fake_toggle)
+
+    widget._timing_simulation_is_mine = True
+    widget._on_timing_probe_finished(TimingProbeResult(ok=True, per_fov_s=7.0, n_fovs_probed=2))
+
+    assert reentered.get("selected") == [name], (
+        f"channel selection was {reentered.get('selected')} when the post-probe handler re-entered "
+        "toggle_acquisition; the start guard would reject the run"
+    )
+    assert widget.channel_sequence.ordered_selected_names() == [name]

--- a/software/tests/control/test_widget_name_resolution.py
+++ b/software/tests/control/test_widget_name_resolution.py
@@ -1,0 +1,96 @@
+"""Static guard: every global name a start path calls must actually exist.
+
+A merge once left two pre-flight blocks in toggle_acquisition -- the new pacing call
+and the old one whose function had been renamed away. Starting any acquisition raised
+NameError after the experiment folder was already created, while every test suite
+stayed green: nothing invokes toggle_acquisition, so a dangling name in the widget's
+start path is invisible to the rest of the tests.
+
+This walks the AST instead of executing anything, so it is fast and needs no hardware,
+no Qt event loop, and no new dependency.
+"""
+
+import ast
+import builtins
+import os
+
+import pytest
+
+WIDGETS_PATH = os.path.join(os.path.dirname(__file__), "..", "..", "control", "widgets.py")
+
+# The methods an operator's click actually runs. A dangling name in any of these takes
+# the instrument down, so they are worth pinning even though the check is general.
+CRITICAL_METHODS = [
+    ("FlexibleMultiPointWidget", "toggle_acquisition"),
+    ("WellplateMultiPointWidget", "toggle_acquisition"),
+    ("FlexibleMultiPointWidget", "on_snap_images"),
+    ("WellplateMultiPointWidget", "on_snap_images"),
+    ("_TimingSimulationMixin", "_start_timing_simulation"),
+    ("_TimingSimulationMixin", "_on_timing_probe_finished"),
+]
+
+
+def _module_ast():
+    with open(WIDGETS_PATH, encoding="utf-8") as handle:
+        return ast.parse(handle.read(), filename="widgets.py")
+
+
+def _module_level_names():
+    """The real module namespace, which is what NameError is resolved against.
+
+    Taken from the imported module rather than reconstructed from the AST: widgets.py
+    uses star imports from qtpy, whose contents cannot be known statically.
+    """
+    import control.widgets
+
+    return set(vars(control.widgets)) | set(dir(builtins))
+
+
+def _find_method(tree, class_name, method_name):
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for item in node.body:
+                if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)) and item.name == method_name:
+                    return item
+    return None
+
+
+def _locally_bound(func_node):
+    """Names bound inside the function: args, assignments, comprehensions, handlers."""
+    bound = set()
+    args = func_node.args
+    for arg in list(args.args) + list(args.posonlyargs) + list(args.kwonlyargs):
+        bound.add(arg.arg)
+    if args.vararg:
+        bound.add(args.vararg.arg)
+    if args.kwarg:
+        bound.add(args.kwarg.arg)
+    for node in ast.walk(func_node):
+        if isinstance(node, ast.Name) and isinstance(node.ctx, (ast.Store, ast.Del)):
+            bound.add(node.id)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            bound.add(node.name)
+        elif isinstance(node, ast.ExceptHandler) and node.name:
+            bound.add(node.name)
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            for alias in node.names:
+                bound.add((alias.asname or alias.name).split(".")[0])
+        elif isinstance(node, ast.arg):
+            bound.add(node.arg)
+    return bound
+
+
+@pytest.mark.parametrize("class_name,method_name", CRITICAL_METHODS)
+def test_start_path_names_all_resolve(class_name, method_name):
+    tree = _module_ast()
+    method = _find_method(tree, class_name, method_name)
+    assert method is not None, f"{class_name}.{method_name} not found in widgets.py"
+
+    known = _module_level_names() | _locally_bound(method)
+    referenced = {node.id for node in ast.walk(method) if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load)}
+
+    unresolved = sorted(referenced - known)
+    assert not unresolved, (
+        f"{class_name}.{method_name} references name(s) that do not exist at module level: {unresolved}. "
+        "This is the shape of bug that takes acquisition down at runtime while the suites stay green."
+    )


### PR DESCRIPTION
Eight commits, nine files. Split out of a customer build branch; cut from current master and contains nothing else.

**The bug.** The time-lapse loop dropped any time point whose scheduled wall-clock slot had already passed. A round slower than `dt` collapsed the whole run: with `Nt=3` and `dt=5 s`, a 31.5 s round skipped time points 2 and 3 in under a millisecond and wrote only the `0/` folder, announced by nothing louder than an INFO line. Zarr had already sized its T axis to `Nt`, so the skipped points were silently blank.

`dt` stays a start-to-start period; a round that finishes early still waits out the remainder. What changes is the overrun case — the next round starts immediately and the run stretches, rather than losing data to stay on a grid the hardware cannot keep. The break condition moves from `== Nt` to `>= Nt` (the skip loop could overshoot, which also overstated `total_timepoints` to the watchdog and Slack).

**The rest** is about telling the operator before they commit: `run_timing_probe()` measures real per-FOV duration on hardware, `dry_run` suppresses illumination so the probe does not bleach the sample, and the pacing dialog offers a simulated run when the estimate exceeds `dt`. Advisory, never a veto.

Two review notes:

- The illumination fuse makes every illumination-opening path *raise* during a dry run rather than trusting a flag. Suppression by flag is only as good as the last refactor and the failure mode is silent.
- `ea74623a` also set `deltat` explicitly in the old fluidics path. That widget was removed by #625, so that hunk is dropped here — the headless `ProtocolRunner` owns round pacing now.