### PR TITLE
fix(fluidics-gui): default imaging folder, live progress bar, TEC output-enable re-pin

### DIFF
--- a/software/control/core/fluidics_protocol/runner.py
+++ b/software/control/core/fluidics_protocol/runner.py
@@ -57,6 +57,7 @@ class RunnerSnapshot:
     hold: Optional[Hold]
     outcome: Optional[str]
     elapsed_s: float
+    progress_fraction: Optional[float]  # 0..1 how-far-through, or None when there's no estimate to go on
 
 
 @dataclass
@@ -148,6 +149,7 @@ class ProtocolRunner:
 
     def snapshot(self) -> RunnerSnapshot:
         with self._lock:
+            elapsed = time.time() - self._manifest.started_at
             return RunnerSnapshot(
                 state=self._state,
                 step_index=self._current_step,
@@ -155,8 +157,20 @@ class ProtocolRunner:
                 total_steps=len(self._steps),
                 hold=self._hold,
                 outcome=self._outcome,
-                elapsed_s=time.time() - self._manifest.started_at,
+                elapsed_s=elapsed,
+                progress_fraction=self._progress_fraction(elapsed),
             )
+
+    def _progress_fraction(self, elapsed_s: float) -> Optional[float]:
+        """How far through the run, 0..1, or None when there's no time estimate to go on (the
+        view then falls back to counting completed steps). Priced off the rough total estimate,
+        so hold just under full until the run actually ends."""
+        if self._state is RunnerState.ENDED:
+            return 1.0
+        estimate = self._resolved.total_estimate_s
+        if estimate and estimate > 0:
+            return min(0.99, elapsed_s / estimate)
+        return None
 
     def start(self) -> None:
         if self._thread is not None:

--- a/software/control/widgets_fluidics/protocol_tab.py
+++ b/software/control/widgets_fluidics/protocol_tab.py
@@ -540,7 +540,9 @@ class ProtocolTab(QWidget):
         index = self._selected_row_index()
         at = index + 1 if index is not None else len(self._protocol.sequences)
         round_label = self._selected_round()
-        self._protocol.sequences.insert(at, {"type": IMAGING_TYPE, "name": "image", "round": round_label, "folder": ""})
+        self._protocol.sequences.insert(
+            at, {"type": IMAGING_TYPE, "name": "image", "round": round_label, "folder": "image"}
+        )
         self._mark_changed()
 
     def _duplicate_row(self) -> None:

--- a/software/control/widgets_fluidics/protocol_widget.py
+++ b/software/control/widgets_fluidics/protocol_widget.py
@@ -356,17 +356,13 @@ class FluidicsProtocolWidget(QFrame):
         self.running_box.setHidden(not active)
         self.held_box.hide()
 
-    def _render_progress(self, snap, estimate) -> None:
-        """Drive the bar off elapsed-vs-estimate -- the same ratio shown beside it -- so it keeps
-        moving through a long imaging step, which the completed-steps count alone would sit at 0%
-        for. The estimate is rough, so hold just under full until the run actually ends. With no
-        estimate (an unpriced plan), fall back to counting completed steps."""
-        if snap.state is RunnerState.ENDED:
+    def _render_progress(self, snap) -> None:
+        """Map the run's progress fraction (elapsed vs. the rough estimate, held just under full
+        until it ends -- so the bar keeps moving through a long imaging step) onto the bar. With
+        no fraction (an unpriced plan), fall back to counting completed steps."""
+        if snap.progress_fraction is not None:
             self.progress_bar.setRange(0, 100)
-            self.progress_bar.setValue(100)
-        elif estimate and estimate > 0:
-            self.progress_bar.setRange(0, 100)
-            self.progress_bar.setValue(min(99, int(100 * snap.elapsed_s / estimate)))
+            self.progress_bar.setValue(round(100 * snap.progress_fraction))
         elif snap.step_index is not None:
             self.progress_bar.setMaximum(snap.total_steps)
             done = snap.step_index + (0 if snap.outcome is None else 1)
@@ -563,9 +559,9 @@ class FluidicsProtocolWidget(QFrame):
             snap = runner.snapshot()
             self.state_label.setText(f"State: {snap.state.value}")
             self._render_running()
+            self._render_progress(snap)
             # imaging is priced at a rough 1 s/FOV (see IMAGING_SECONDS_PER_FOV); the total is a ballpark
             estimate = self._resolved.total_estimate_s if self._resolved else None
-            self._render_progress(snap, estimate)
             self.elapsed_label.setText(f"elapsed {_hms(snap.elapsed_s)} / est. {_hms(estimate)}")
             self.folder_label.setText(str(runner.run_dir))
             if snap.state in (RunnerState.PAUSE_REQUESTED, RunnerState.PAUSED):

--- a/software/control/widgets_fluidics/protocol_widget.py
+++ b/software/control/widgets_fluidics/protocol_widget.py
@@ -356,6 +356,22 @@ class FluidicsProtocolWidget(QFrame):
         self.running_box.setHidden(not active)
         self.held_box.hide()
 
+    def _render_progress(self, snap, estimate) -> None:
+        """Drive the bar off elapsed-vs-estimate -- the same ratio shown beside it -- so it keeps
+        moving through a long imaging step, which the completed-steps count alone would sit at 0%
+        for. The estimate is rough, so hold just under full until the run actually ends. With no
+        estimate (an unpriced plan), fall back to counting completed steps."""
+        if snap.state is RunnerState.ENDED:
+            self.progress_bar.setRange(0, 100)
+            self.progress_bar.setValue(100)
+        elif estimate and estimate > 0:
+            self.progress_bar.setRange(0, 100)
+            self.progress_bar.setValue(min(99, int(100 * snap.elapsed_s / estimate)))
+        elif snap.step_index is not None:
+            self.progress_bar.setMaximum(snap.total_steps)
+            done = snap.step_index + (0 if snap.outcome is None else 1)
+            self.progress_bar.setValue(min(done, snap.total_steps))
+
     def _render_running(self) -> None:
         self.round_label.setText(f"Round: {self._current_round}")
         self.sequence_label.setText(f"Sequence: {self._current_sequence}")
@@ -547,11 +563,9 @@ class FluidicsProtocolWidget(QFrame):
             snap = runner.snapshot()
             self.state_label.setText(f"State: {snap.state.value}")
             self._render_running()
-            if snap.step_index is not None:
-                self.progress_bar.setMaximum(snap.total_steps)
-                self.progress_bar.setValue(min(snap.step_index + (0 if snap.outcome is None else 1), snap.total_steps))
             # imaging is priced at a rough 1 s/FOV (see IMAGING_SECONDS_PER_FOV); the total is a ballpark
             estimate = self._resolved.total_estimate_s if self._resolved else None
+            self._render_progress(snap, estimate)
             self.elapsed_label.setText(f"elapsed {_hms(snap.elapsed_s)} / est. {_hms(estimate)}")
             self.folder_label.setText(str(runner.run_dir))
             if snap.state in (RunnerState.PAUSE_REQUESTED, RunnerState.PAUSED):

--- a/software/tests/control/core/fluidics_protocol/test_runner.py
+++ b/software/tests/control/core/fluidics_protocol/test_runner.py
@@ -1,5 +1,6 @@
 import json
 import os
+from types import SimpleNamespace
 
 import pytest
 
@@ -101,6 +102,22 @@ def test_happy_path_runs_every_step_and_leaves_the_documented_run_folder(tmp_pat
     assert imaging.requests[0].settings.channels == ["A"] and imaging.requests[0].coordinates.fov_count == 1
     kinds = [type(e).__name__ for e in events]
     assert kinds[0] == "StateChanged" and kinds[-1] == "RunFinished" and kinds.count("StepStarted") == 4
+
+
+def test_progress_fraction_prices_elapsed_over_the_estimate(tmp_path):
+    # the snapshot owns "how far through the run" so it's testable without the GUI: elapsed over
+    # the rough total estimate, held just under full until the run ends, None when there's no estimate.
+    runner, *_ = _runner(tmp_path)
+    runner._resolved = SimpleNamespace(total_estimate_s=200.0)
+    runner._state = RunnerState.RUNNING
+    assert runner._progress_fraction(0.0) == 0.0
+    assert runner._progress_fraction(100.0) == 0.5
+    assert runner._progress_fraction(1000.0) == 0.99  # capped until the run actually ends
+    runner._state = RunnerState.ENDED
+    assert runner._progress_fraction(0.0) == 1.0
+    runner._resolved = SimpleNamespace(total_estimate_s=None)  # an unpriced plan
+    runner._state = RunnerState.RUNNING
+    assert runner._progress_fraction(50.0) is None
 
 
 def test_24_rounds_complete_in_seconds(tmp_path):

--- a/software/tests/control/widgets_fluidics/test_protocol_tab.py
+++ b/software/tests/control/widgets_fluidics/test_protocol_tab.py
@@ -134,13 +134,13 @@ def test_field_edit_updates_the_model_and_apply_to_all(tab, qtbot):
     qtbot.wait(20)  # let the queued re-render run
 
 
-def test_add_imaging_leaves_the_folder_for_the_operator(tab):
+def test_add_imaging_defaults_the_folder_to_image(tab):
     tab.tree.clearSelection()
     tab._add_imaging()
     row = tab.protocol.sequences[-1]
-    assert row["type"] == "imaging" and row["round"] == "R02"
-    assert row["folder"] == ""  # no auto-naming; the operator types the folder name
-    assert "✗" in tab.validation_label.text()  # an empty folder is flagged until named
+    assert row["type"] == "imaging"
+    assert row["folder"] == "image"  # a usable default so the folder field is never blank
+    # (the row is still flagged until the operator assigns acquisition settings — that's separate)
 
 
 def test_collision_in_the_derived_folder_marks_the_row_invalid(tab):

--- a/software/tests/control/widgets_fluidics/test_protocol_widget.py
+++ b/software/tests/control/widgets_fluidics/test_protocol_widget.py
@@ -328,3 +328,39 @@ def test_running_card_shows_elapsed_and_estimate(qtbot, widget):
     w._refresh()
     assert "elapsed 00:01:05" in w.elapsed_label.text()
     assert "est. 01:02:03" in w.elapsed_label.text()
+
+
+def test_progress_bar_advances_with_elapsed_not_step_count(qtbot, widget):
+    # the reported bug: during a long imaging step (step_index stuck at 0) the bar sat at 0%.
+    from control.core.fluidics_protocol.events import RunnerState
+
+    w, *_ = widget
+    w._resolved = SimpleNamespace(total_estimate_s=200.0)
+
+    def snap(elapsed, state=RunnerState.RUNNING):
+        return SimpleNamespace(state=state, step_index=0, total_steps=5, elapsed_s=elapsed, outcome=None, attempt=1)
+
+    w.runner = SimpleNamespace(snapshot=lambda: snap(0.0), run_dir="/tmp/run")
+    w._refresh()
+    assert w.progress_bar.value() == 0
+    w.runner.snapshot = lambda: snap(100.0)  # half the estimate, still on step 0
+    w._refresh()
+    assert w.progress_bar.value() == 50  # moved even though the step index did not
+    w.runner.snapshot = lambda: snap(100.0, RunnerState.ENDED)
+    w._refresh()
+    assert w.progress_bar.value() == 100  # the finished run reads full
+
+
+def test_progress_bar_falls_back_to_steps_without_an_estimate(qtbot, widget):
+    from control.core.fluidics_protocol.events import RunnerState
+
+    w, *_ = widget
+    w._resolved = SimpleNamespace(total_estimate_s=None)  # unpriced plan
+    w.runner = SimpleNamespace(
+        snapshot=lambda: SimpleNamespace(
+            state=RunnerState.RUNNING, step_index=2, total_steps=4, elapsed_s=9.0, outcome=None, attempt=1
+        ),
+        run_dir="/tmp/run",
+    )
+    w._refresh()
+    assert w.progress_bar.maximum() == 4 and w.progress_bar.value() == 2

--- a/software/tests/control/widgets_fluidics/test_protocol_widget.py
+++ b/software/tests/control/widgets_fluidics/test_protocol_widget.py
@@ -316,11 +316,9 @@ def test_running_shows_round_and_advances_the_sequence_highlight(qtbot, widget):
 
 
 def test_running_card_shows_elapsed_and_estimate(qtbot, widget):
-    from control.core.fluidics_protocol.events import RunnerState
-
     w, *_ = widget
     snap = SimpleNamespace(
-        state=RunnerState.RUNNING, step_index=0, total_steps=2, elapsed_s=65, outcome=None, attempt=1
+        state=RunnerState.RUNNING, step_index=0, total_steps=2, elapsed_s=65, outcome=None, progress_fraction=None
     )
     w.runner = SimpleNamespace(snapshot=lambda: snap, run_dir="/tmp/run")
     # imaging priced at a rough 1 s/FOV, so the running card shows the fluidics+imaging total
@@ -330,35 +328,33 @@ def test_running_card_shows_elapsed_and_estimate(qtbot, widget):
     assert "est. 01:02:03" in w.elapsed_label.text()
 
 
-def test_progress_bar_advances_with_elapsed_not_step_count(qtbot, widget):
+def test_progress_bar_follows_the_run_progress_fraction(qtbot, widget):
     # the reported bug: during a long imaging step (step_index stuck at 0) the bar sat at 0%.
-    from control.core.fluidics_protocol.events import RunnerState
-
+    # the bar now maps the snapshot's progress fraction, which advances with elapsed time.
     w, *_ = widget
-    w._resolved = SimpleNamespace(total_estimate_s=200.0)
 
-    def snap(elapsed, state=RunnerState.RUNNING):
-        return SimpleNamespace(state=state, step_index=0, total_steps=5, elapsed_s=elapsed, outcome=None, attempt=1)
+    def snap(fraction, state=RunnerState.RUNNING):
+        return SimpleNamespace(
+            state=state, step_index=0, total_steps=5, elapsed_s=0.0, outcome=None, progress_fraction=fraction
+        )
 
     w.runner = SimpleNamespace(snapshot=lambda: snap(0.0), run_dir="/tmp/run")
     w._refresh()
     assert w.progress_bar.value() == 0
-    w.runner.snapshot = lambda: snap(100.0)  # half the estimate, still on step 0
+    w.runner.snapshot = lambda: snap(0.5)  # halfway, still on step 0
     w._refresh()
     assert w.progress_bar.value() == 50  # moved even though the step index did not
-    w.runner.snapshot = lambda: snap(100.0, RunnerState.ENDED)
+    w.runner.snapshot = lambda: snap(1.0, RunnerState.ENDED)
     w._refresh()
     assert w.progress_bar.value() == 100  # the finished run reads full
 
 
 def test_progress_bar_falls_back_to_steps_without_an_estimate(qtbot, widget):
-    from control.core.fluidics_protocol.events import RunnerState
-
+    # progress_fraction is None (an unpriced plan), so the bar counts completed steps instead
     w, *_ = widget
-    w._resolved = SimpleNamespace(total_estimate_s=None)  # unpriced plan
     w.runner = SimpleNamespace(
         snapshot=lambda: SimpleNamespace(
-            state=RunnerState.RUNNING, step_index=2, total_steps=4, elapsed_s=9.0, outcome=None, attempt=1
+            state=RunnerState.RUNNING, step_index=2, total_steps=4, elapsed_s=9.0, outcome=None, progress_fraction=None
         ),
         run_dir="/tmp/run",
     )


### PR DESCRIPTION
Follow-ups on the merged phase-2 fluidics GUI (#626), from a round of hardware/simulation testing. Three small changes:

### 1. A new imaging sequence defaults its folder to `image`
Adding an imaging sequence left the folder field blank, so the row read as having no folder name. It now defaults to `image` (the output folder is still derived as `{round}_image`); the operator only needs to assign acquisition settings, not invent a folder name.

### 2. The run progress bar advances during long steps
The bar counted only completed steps, so a long imaging step — which dominates a run's wall time and is just one step — left it near 0% for most of the run. It now tracks **elapsed / estimate** (the same rough ratio shown in the text beside it), so it moves continuously; it holds just under full until the run ends, and falls back to the completed-steps count when a plan has no time estimate.

*Caveat:* imaging is priced at a rough 1 s/FOV, so if real acquisition is much slower the bar reaches 99% and waits there until the run finishes. A more accurate bar would need per-FOV progress surfaced from the acquisition engine into the runner — a larger change, deferred.

### 3. Re-pin the fluidics library to the merged `main` (TEC output-enable)
Squid-Fluidics [#54](https://github.com/Cephla-Lab/Squid-Fluidics/pull/54) merged: the automated run path (`sequence_utils.set_temperature`) now asserts the TEC output (`TCSW=1`) alongside the setpoint, so a protocol temperature step actually drives the TEC instead of timing out after ~300 s. Re-pin `fluidics_v2` from `78bddda` to `f3a7b62`. (The manual Temperature widget is unchanged — its separate Output ON toggle still applies; that was an explicit "run path only" choice.)

## Tests
- Added: progress bar advances with elapsed while the step index is stuck (the exact reported symptom), and falls back to steps without an estimate; imaging-folder default is `image`.
- Full fluidics suite green locally (117 passed); the library side is covered by #54 (106 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)