### PR TITLE
feat(fluidics-gui): option to power the TEC down when a run finishes

### DIFF
--- a/software/control/core/fluidics_protocol/library_port.py
+++ b/software/control/core/fluidics_protocol/library_port.py
@@ -129,3 +129,10 @@ class LibraryFluidicsPort:
         for channel, (target, on) in enumerate(zip(state.targets, state.output_enabled), start=1):
             tc.set_target_temperature(channel, target)
             tc.set_output_enabled(channel, on)
+
+    def disable_tec(self) -> None:
+        tc = self._system.devices.temperature_controller
+        if tc is None:
+            return
+        for channel in range(1, tc.channels + 1):
+            tc.set_output_enabled(channel, False)

--- a/software/control/core/fluidics_protocol/ports.py
+++ b/software/control/core/fluidics_protocol/ports.py
@@ -45,6 +45,8 @@ class FluidicsPort(Protocol):
 
     def restore_tec(self, state: TecState) -> None: ...
 
+    def disable_tec(self) -> None: ...  # switch every channel's TEC output off
+
 
 @dataclass
 class ImagingRequest:

--- a/software/control/core/fluidics_protocol/runner.py
+++ b/software/control/core/fluidics_protocol/runner.py
@@ -81,9 +81,11 @@ class ProtocolRunner:
         manifest: Optional[RunManifest] = None,
         heartbeat_s: float = 5.0,
         poll_s: float = 0.05,
+        disable_tec_at_end: bool = False,
     ):
         self._log = squid.logging.get_logger(__name__)
         self._resolved = resolved
+        self._disable_tec_at_end = disable_tec_at_end
         self._steps = resolved.steps
         self.run_dir = Path(run_dir)
         self._imaging = imaging
@@ -245,6 +247,8 @@ class ProtocolRunner:
         self._log.info(f"Protocol run '{self._manifest.run_name}' started: {len(self._steps)} steps in {self.run_dir}")
 
     def _close_run(self, outcome: str) -> None:
+        if self._disable_tec_at_end:  # the operator asked for the TEC to power down when the run ends
+            self._safe(self._fluidics.disable_tec, "turning off the TEC at the end of the run")
         with self._lock:
             self._outcome = outcome
             self._manifest.status = outcome

--- a/software/control/widgets_fluidics/dialogs.py
+++ b/software/control/widgets_fluidics/dialogs.py
@@ -7,6 +7,7 @@ from typing import List, Optional
 
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
+    QCheckBox,
     QComboBox,
     QDialog,
     QDialogButtonBox,
@@ -161,9 +162,10 @@ def pick_coordinates_source(parent) -> Optional[str]:
 class PreflightDialog(QDialog):
     """The one gate before a run: problems block Start; otherwise the summary asks for confirmation."""
 
-    def __init__(self, problems: List[str], summary_lines: List[str], parent=None):
+    def __init__(self, problems: List[str], summary_lines: List[str], parent=None, tec_option: bool = False):
         super().__init__(parent)
         self.setWindowTitle("Start run")
+        self.disable_tec_checkbox = None
         layout = QVBoxLayout()
         if problems:
             headline = QLabel(f"{len(problems)} problem(s) must be fixed before this protocol can run:")
@@ -177,6 +179,10 @@ class PreflightDialog(QDialog):
         text.setReadOnly(True)
         layout.addWidget(text)
 
+        if tec_option and not problems:
+            self.disable_tec_checkbox = QCheckBox("Turn off temperature control (TEC) when the run finishes")
+            layout.addWidget(self.disable_tec_checkbox)
+
         self.buttons = QDialogButtonBox()
         self.start_button = QPushButton("Start")
         self.buttons.addButton(self.start_button, QDialogButtonBox.AcceptRole)
@@ -186,6 +192,9 @@ class PreflightDialog(QDialog):
         self.buttons.rejected.connect(self.reject)
         layout.addWidget(self.buttons)
         self.setLayout(layout)
+
+    def disable_tec_at_end(self) -> bool:
+        return self.disable_tec_checkbox is not None and self.disable_tec_checkbox.isChecked()
 
 
 class RecoveryDialog(QDialog):

--- a/software/control/widgets_fluidics/protocol_widget.py
+++ b/software/control/widgets_fluidics/protocol_widget.py
@@ -266,7 +266,8 @@ class FluidicsProtocolWidget(QFrame):
             f"est. {_hms(resolved.total_estimate_s)} (imaging priced at a rough 1 s/FOV)",
             f"run folder: {os.path.join(save_to, run_name)}_<start time>",
         ]
-        if PreflightDialog([], summary, self).exec_() != QDialog.Accepted:
+        preflight = PreflightDialog([], summary, self, tec_option=True)
+        if preflight.exec_() != QDialog.Accepted:
             return
         try:
             run_dir = manifest_io.create_run_dir(save_to, run_name)
@@ -282,6 +283,7 @@ class FluidicsProtocolWidget(QFrame):
                 fluidics=self.fluidics_port,
                 run_name=run_name,
                 listener=self._bridge.listener,
+                disable_tec_at_end=preflight.disable_tec_at_end(),
             ),
             resolved,
         )

--- a/software/tests/control/core/fluidics_protocol/fakes.py
+++ b/software/tests/control/core/fluidics_protocol/fakes.py
@@ -88,6 +88,7 @@ class FakeFluidicsPort:
         self.validated: List[List[dict]] = []
         self.make_safe_calls = 0
         self.restored: List[TecState] = []
+        self.tec_disabled = False
         self._tec = tec
 
     def validate(self, rows):
@@ -135,6 +136,9 @@ class FakeFluidicsPort:
 
     def restore_tec(self, state):
         self.restored.append(state)
+
+    def disable_tec(self):
+        self.tec_disabled = True
 
 
 class FakeHandle:

--- a/software/tests/control/core/fluidics_protocol/test_runner.py
+++ b/software/tests/control/core/fluidics_protocol/test_runner.py
@@ -120,6 +120,27 @@ def test_progress_fraction_prices_elapsed_over_the_estimate(tmp_path):
     assert runner._progress_fraction(50.0) is None
 
 
+def test_disable_tec_at_end_powers_the_tec_down_on_a_normal_finish(tmp_path):
+    fluidics = FakeFluidicsPort()
+    imaging = FakeImagingPort()
+    resolved = resolve_protocol(_protocol(), tmp_path, fluidics=fluidics)
+    run_dir = manifest_io.create_run_dir(tmp_path, "liver")
+    runner = ProtocolRunner(
+        resolved, run_dir, imaging, fluidics, run_name="liver", poll_s=0.01, disable_tec_at_end=True
+    )
+    runner.start()
+    assert runner.wait(10) and runner.outcome == "finished"
+    assert fluidics.tec_disabled is True
+
+
+def test_tec_is_left_alone_at_end_without_the_option(tmp_path):
+    fluidics = FakeFluidicsPort()
+    runner, *_ = _runner(tmp_path, fluidics=fluidics)
+    runner.start()
+    assert runner.wait(10) and runner.outcome == "finished"
+    assert fluidics.tec_disabled is False
+
+
 def test_24_rounds_complete_in_seconds(tmp_path):
     runner, fluidics, imaging, run_dir = _runner(tmp_path, rounds=24)
     runner.start()

--- a/software/tests/control/widgets_fluidics/test_system_panel_and_dialogs.py
+++ b/software/tests/control/widgets_fluidics/test_system_panel_and_dialogs.py
@@ -100,6 +100,22 @@ def test_preflight_dialog_blocks_start_on_problems(qtbot):
     assert ready.start_button.isEnabled()
 
 
+def test_preflight_dialog_offers_the_tec_off_option_on_the_confirm_path(qtbot):
+    plain = PreflightDialog([], ["ready"])
+    qtbot.addWidget(plain)
+    assert plain.disable_tec_checkbox is None and plain.disable_tec_at_end() is False
+
+    ready = PreflightDialog([], ["ready"], tec_option=True)
+    qtbot.addWidget(ready)
+    assert ready.disable_tec_checkbox is not None and ready.disable_tec_at_end() is False
+    ready.disable_tec_checkbox.setChecked(True)
+    assert ready.disable_tec_at_end() is True
+
+    blocked = PreflightDialog(["bad"], [], tec_option=True)  # confirm-path affordance only
+    qtbot.addWidget(blocked)
+    assert blocked.disable_tec_checkbox is None
+
+
 def test_recovery_dialog_names_the_cursor_step(qtbot):
     manifest = RunManifest(
         run_name="liver",


### PR DESCRIPTION
Follow-up to #637.

## Problem

A normal run finish never touched the TEC. `make_safe` (which switches every channel's TEC output off) runs only on abort/failure, so a temperature a `set_temperature` step turned on stayed on after the run ended, with no way to power it down from the GUI.

## Change

A per-run **"Turn off temperature control (TEC) when the run finishes"** checkbox on the Start-run dialog (defaults off). When checked, the runner switches every channel's TEC output off in `_close_run` on a normal finish. Abort/failure already power it down via `make_safe`, so the option only changes the normal-finish path.

Entirely **Squid-side** — a new `FluidicsPort.disable_tec()` implemented on the library port (`set_output_enabled(False)` per channel). No fluidics-library change.

## Tests

- `test_runner.py`: with the option set the TEC is powered down at a normal finish; without it the TEC is left alone.
- `test_system_panel_and_dialogs.py`: the checkbox appears only on the confirm path and `disable_tec_at_end()` reflects it.
- Full fluidics suite green locally (121 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)