### PR TITLE
test: clean up simulated-acquisition output instead of littering /tmp

### DIFF
--- a/software/tests/conftest.py
+++ b/software/tests/conftest.py
@@ -12,6 +12,7 @@ finalization).
 
 import logging
 import os
+import shutil
 import sys
 import tempfile
 from unittest.mock import patch
@@ -21,6 +22,8 @@ import pytest
 import control.microcontroller
 import control.microscope
 from control.core.multi_point_controller import MultiPointController
+
+import tests.control.test_stubs
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +36,8 @@ _CLEANUP_STATE_DIR = os.path.join(tempfile.gettempdir(), f"squid-test-watchdog-c
 
 def pytest_sessionfinish(session, exitstatus):
     session.config._squid_exitstatus = int(exitstatus)
+    # Nothing reads the watchdog cleanup breadcrumbs after the session.
+    shutil.rmtree(_CLEANUP_STATE_DIR, ignore_errors=True)
 
 
 def pytest_unconfigure(config):
@@ -120,3 +125,8 @@ def cleanup_leaked_hardware(monkeypatch):
     for micro in reversed(microcontrollers):
         if not micro.terminate_reading_received_packet_thread:
             _close_quietly(micro, "Microcontroller")
+
+    # Last, after every writer above is closed: delete the simulated-acquisition
+    # output this test produced (~180 MB per acquisition; it used to accumulate
+    # in /tmp across runs until the disk filled).
+    tests.control.test_stubs.cleanup_stub_acquisition_dirs()

--- a/software/tests/control/gui_test_stubs.py
+++ b/software/tests/control/gui_test_stubs.py
@@ -39,7 +39,7 @@ def get_test_qt_multi_point_controller(microscope: Microscope) -> QtMultiPointCo
         laser_autofocus_controller=ts.get_test_laser_autofocus_controller(microscope),
     )
 
-    multi_point_controller.set_base_path("/tmp/")
+    multi_point_controller.set_base_path(ts.new_acquisition_base_path())
     multi_point_controller.start_new_experiment("unit test experiment (qt)")
 
     return multi_point_controller

--- a/software/tests/control/test_stub_acquisition_cleanup.py
+++ b/software/tests/control/test_stub_acquisition_cleanup.py
@@ -1,0 +1,35 @@
+"""The stub multipoint controllers must not litter /tmp with acquisition data.
+
+Simulated acquisitions write real image data (~180 MB per run). The stub
+factories used to point them at a literal "/tmp/", where the output accumulated
+across runs until the disk filled. They now write under a registered temp dir
+that the suite deletes at test teardown (see the autouse fixture in
+tests/conftest.py).
+"""
+
+import os
+import tempfile
+
+import control.microscope
+import tests.control.test_stubs as ts
+
+
+def test_stub_controller_writes_under_a_registered_temp_dir():
+    scope = control.microscope.Microscope.build_from_global_config(True)
+    mpc = ts.get_test_multi_point_controller(microscope=scope)
+
+    assert mpc.base_path != "/tmp/"
+    assert mpc.base_path.startswith(tempfile.gettempdir())
+    assert os.path.isdir(mpc.base_path)
+    assert mpc.base_path in ts._acquisition_output_dirs
+
+
+def test_cleanup_removes_registered_dirs():
+    scope = control.microscope.Microscope.build_from_global_config(True)
+    mpc = ts.get_test_multi_point_controller(microscope=scope)
+    base_path = mpc.base_path
+
+    ts.cleanup_stub_acquisition_dirs()
+
+    assert not os.path.exists(base_path)
+    assert base_path not in ts._acquisition_output_dirs

--- a/software/tests/control/test_stubs.py
+++ b/software/tests/control/test_stubs.py
@@ -1,3 +1,6 @@
+import shutil
+import tempfile
+
 from control._def import OBJECTIVES, DEFAULT_OBJECTIVE
 from control.core.auto_focus_controller import AutoFocusController
 from control.core.laser_auto_focus_controller import LaserAutofocusController
@@ -9,6 +12,23 @@ from control.core.scan_coordinates import ScanCoordinates
 from control.microcontroller import Microcontroller
 from control.microscope import Microscope
 from squid.abc import AbstractStage, AbstractCamera
+
+# Simulated acquisitions write real image data (~180 MB per run). Every base dir a
+# stub controller writes into is registered here so the autouse fixture in
+# tests/conftest.py can delete it at test teardown - pointing them at a literal
+# "/tmp/" used to accumulate output across runs until the disk filled.
+_acquisition_output_dirs: list = []
+
+
+def new_acquisition_base_path() -> str:
+    base_path = tempfile.mkdtemp(prefix="squid_unit_test_acquisition_")
+    _acquisition_output_dirs.append(base_path)
+    return base_path
+
+
+def cleanup_stub_acquisition_dirs():
+    while _acquisition_output_dirs:
+        shutil.rmtree(_acquisition_output_dirs.pop(), ignore_errors=True)
 
 
 def get_test_live_controller(microscope: Microscope, starting_objective) -> LiveController:
@@ -85,7 +105,7 @@ def get_test_multi_point_controller(
         laser_autofocus_controller=get_test_laser_autofocus_controller(microscope),
     )
 
-    multi_point_controller.set_base_path("/tmp/")
+    multi_point_controller.set_base_path(new_acquisition_base_path())
     multi_point_controller.start_new_experiment("unit test experiment")
 
     return multi_point_controller


### PR DESCRIPTION
## Problem

`get_test_multi_point_controller` and `get_test_qt_multi_point_controller` point simulated acquisitions at a literal `"/tmp/"`. Every test that runs an acquisition leaves ~180 MB of simulated image data in `/tmp/unit_test_experiment_*` forever. Accumulated runs filled an entire 782 GB disk on a dev machine on 2026-09-05 (38 GB of test output going back days).

## Fix

- The stub factories create the acquisition base dir with `tempfile.mkdtemp(prefix="squid_unit_test_acquisition_")` and register it in `test_stubs._acquisition_output_dirs`.
- `cleanup_leaked_hardware` (the existing autouse teardown fixture in `tests/conftest.py`) deletes the registered dirs at the end of each test — after controllers/microscopes are closed, so no writer is alive when the tree is removed. Peak disk usage is now one test's output instead of an unbounded accumulation.
- The watchdog breadcrumb dir (`squid-test-watchdog-cleanup-<pid>`, written during leaked-acquisition cleanup, never read) is removed at session finish.

## Testing

- New `tests/control/test_stub_acquisition_cleanup.py` covers the registration and the cleanup.
- Full suite (CI selection): **1791 passed, 9 skipped, 1 xfailed** — and `/tmp` contains no `unit_test_experiment_*`, `squid_unit_test_acquisition_*`, or watchdog-cleanup leftovers afterwards (verified in the same shell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)