### PR TITLE
build: stop installing basicpy/aicsimageio, which break the NumPy 2 stack

### DIFF
--- a/software/setup_22.04.sh
+++ b/software/setup_22.04.sh
@@ -72,17 +72,23 @@ sudo apt remove -y python3-pyqt5 python3-pyqt5.qtsvg 2>/dev/null || true
 pip3 uninstall -y PyQt5 PyQt5-Qt5 PyQt5-sip 2>/dev/null || true
 pip3 install "PyQt6==6.11.0" "PyQt6-Qt6==6.11.2" "PyQt6-sip==13.12.0"
 
-# install libraries. No "numpy<2" pin: napari 0.7 only needs numpy>=1.24, but the rest of
-# the current stack (opencv-python 5.x, pyqtgraph 0.14, ...) targets NumPy 2 and the
-# pinned-back packages aicsimageio drags in (tifffile 2023.2, zarr 2.15, lxml 4.9) were
-# verified to work with it.
+# install libraries. No "numpy<2" pin: napari 0.7 only needs numpy>=1.24, and the rest of
+# the current stack (opencv-python 5.x, pyqtgraph 0.14, ...) targets NumPy 2.
+#
+# aicsimageio and basicpy are deliberately NOT installed. basicpy pins scipy<1.13
+# (peng-lab/BaSiCPy#173) and scipy 1.12 ships no NumPy-2 wheel, so pip resolves the whole
+# environment back to numpy 1.26 -- which then violates napari's scipy>=1.14 and
+# opencv 5.x's numpy>=2, leaving `pip check` failing and napari unimportable. Their only
+# consumer is control/stitcher.py, which nothing in the application imports; stitching
+# lives in the separate Cephla-Lab/image-stitcher repo. If you need that module, install
+# these two into a dedicated venv rather than this one.
 pip3 install pyqtgraph qtpy pyserial pandas imageio crc==1.3.0 lxml numpy tifffile scipy pyreadline3
 pip3 install opencv-python-headless opencv-contrib-python-headless
 # napari pinned to a tested release (patch releases change its vispy/Qt constraints). The
 # [pyqt6] extra is what makes pip enforce napari's Qt blocklist against the PyQt6 above.
 # tensorstore is required by control/ndviewer_light and by tests/control/core/test_zarr_writer.py,
 # which begins with pytest.importorskip("tensorstore") -- without it ~79 zarr tests silently skip.
-pip3 install "napari[pyqt6]==0.7.1" scikit-image dask_image ome_zarr tensorstore aicsimageio basicpy pytest pytest-qt pytest-xvfb gitpython matplotlib pydantic_xml pyvisa hidapi filelock lxml_html_clean psutil mcp ndv
+pip3 install "napari[pyqt6]==0.7.1" scikit-image dask_image ome_zarr tensorstore pytest pytest-qt pytest-xvfb gitpython matplotlib pydantic_xml pyvisa hidapi filelock lxml_html_clean psutil mcp ndv
 
 # Optional: PI V-308 / C-414 focus stage (USE_PI_FOCUS_STAGE). Safe to skip if unused;
 # squid.stage.pi imports it lazily and only needs it to connect to real hardware, so


### PR DESCRIPTION
> **Stacked on #622.** Base is `feat/pyqt6-napari07-migration-v2` so the diff stays to a single file. Retarget to `master` once #622 lands.

## Problem

The current install line produces a **broken environment**. `basicpy` pins `scipy<1.13` ([peng-lab/BaSiCPy#173](https://github.com/peng-lab/BaSiCPy/issues/173)), and scipy 1.12 ships no NumPy-2 wheel — so pip resolves the whole environment back to numpy 1.26.

After running `setup_22.04.sh` as written:

```
$ pip check
napari 0.7.1 has requirement scipy>=1.14.0, but you have scipy 1.12.0.
ome-zarr-models 1.8.0 has requirement zarr>=3.1.1, but you have zarr 2.15.0.
opencv-contrib-python-headless 5.0.0.93 has requirement numpy>=2, but you have numpy 1.26.4.
opencv-python-headless 5.0.0.93 has requirement numpy>=2, but you have numpy 1.26.4.
pydantic-zarr 0.10.0 has requirement numpy>=2.0.0, but you have numpy 1.26.4.
```

napari then fails to import. The comment being replaced states that the pinned-back packages "were verified to work" with NumPy 2 — that does not hold once `basicpy` is in the resolution.

This isn't a "prefer newer packages" cleanup: **you cannot have both** `basicpy` and a working napari in one environment, because their scipy constraints don't intersect.

## Why removal is safe

`basicpy` and `aicsimageio` are imported by exactly one file, `control/stitcher.py`, and **nothing imports that module**:

- no static import — `control.stitcher` / `import stitcher` match nowhere
- no dynamic import — the only `__import__` uses are the MCP server's sandbox builtins and a test mock
- `tools/stitcher.py` defines its **own**, unrelated `Stitcher` class and imports neither package

Stitching now lives in the separate [image-stitcher](https://github.com/Cephla-Lab/image-stitcher) repo, which the README already points users to.

No code is deleted: `control/stitcher.py` stays on disk and remains usable from a dedicated venv, as the new comment explains.

## Alternative

If you'd rather keep it installable in-tree, a `[stitching]` extras group would work as well — happy to rework it that way. Flagging this as the judgment call in the change, since it reverses an existing claim in the script.

## Verification

With these two dropped, `pip check` reports **no broken requirements**, and the suite runs **1634 passed, 0 failed, 12 skipped** under Python 3.12 / PyQt6 6.11.0 / napari 0.7.1.
