### PR TITLE
fix(celesta): add HTTP timeout so an unreachable laser engine cannot hang startup

### DIFF
--- a/software/control/celesta.py
+++ b/software/control/celesta.py
@@ -16,15 +16,22 @@ import squid.logging
 
 log = squid.logging.get_logger(__name__)
 
+# Per-request HTTP timeout. Without one, urlopen() blocks indefinitely when the
+# Celesta is unplugged, powered off, or on a different subnet, which hangs
+# Microscope.build_from_global_config() before the GUI window ever appears.
+DEFAULT_TIMEOUT_S = 5.0
 
-def lumencor_httpcommand(command="GET IP", ip="192.168.201.200"):
+
+def lumencor_httpcommand(command="GET IP", ip="192.168.201.200", timeout=DEFAULT_TIMEOUT_S):
     """
     Sends commands to the lumencor system via http.
     Plese find commands here:
     http://lumencor.com/wp-content/uploads/sites/11/2019/01/57-10018.pdf
+
+    ``timeout`` (seconds) bounds both the TCP connect and the response read.
     """
     command_full = r"http://" + ip + "/service/?command=" + command.replace(" ", "%20")
-    with urllib.request.urlopen(command_full) as response:
+    with urllib.request.urlopen(command_full, timeout=timeout) as response:
         message = eval(response.read())  # the default is conveniently JSON so eval creates dictionary
     return message
 
@@ -41,6 +48,7 @@ class CELESTA(LightSource):
         """
         self.on = False
         self.ip = kwds.get("ip", "192.168.201.200")
+        self.timeout = kwds.get("timeout", DEFAULT_TIMEOUT_S)
         [self.pmin, self.pmax] = 0, 1000
         try:
             # See if the system returns back the right IP.
@@ -51,7 +59,7 @@ class CELESTA(LightSource):
         except:
             log.error(traceback.format_exc())
             self.live = False
-            log.error("Failed to connect to Lumencor Laser at ip: 192.168.201.200")
+            log.error(f"Failed to connect to Lumencor Laser at ip: {self.ip} (timeout={self.timeout}s)")
 
         if self.live:
             [self.pmin, self.pmax] = self.get_intensity_range()
@@ -75,6 +83,9 @@ class CELESTA(LightSource):
             750: 6,
         }
 
+    def _command(self, command):
+        return lumencor_httpcommand(command=command, ip=self.ip, timeout=self.timeout)
+
     def initialize(self):
         pass
 
@@ -86,27 +97,27 @@ class CELESTA(LightSource):
 
     def get_number_lasers(self):
         """Return the number of lasers the current lumencor system can control"""
-        self.message = lumencor_httpcommand(command="GET CHMAP", ip=self.ip)
+        self.message = self._command("GET CHMAP")
         if self.message["message"][0] == "A":
             return len(self.message["message"].split(" ")) - 2
         return 0
 
     def get_color(self, laser_id):
         """Returns the color of the current laser"""
-        self.message = lumencor_httpcommand(command="GET CHMAP", ip=self.ip)
+        self.message = self._command("GET CHMAP")
         colors = self.message["message"].split(" ")[2:]
         log.info(colors)
         return colors[int(laser_id)]
 
     def get_IP(self):
-        self.message = lumencor_httpcommand(command="GET IP", ip=self.ip)
+        self.message = self._command("GET IP")
         return self.message
 
     def get_shutter_control_mode(self):
         """
         Return True/False the lasers can be controlled with TTL.
         """
-        self.message = lumencor_httpcommand(command="GET TTLENABLE", ip=self.ip)
+        self.message = self._command("GET TTLENABLE")
         response = self.message["message"]
         if response[-1] == "1":
             return ShutterControlMode.TTL
@@ -121,13 +132,13 @@ class CELESTA(LightSource):
             ttl_enable = "1"
         else:
             ttl_enable = "0"
-        self.message = lumencor_httpcommand(command="SET TTLENABLE " + ttl_enable, ip=self.ip)
+        self.message = self._command("SET TTLENABLE " + ttl_enable)
 
     def get_shutter_state(self, laser_id):
         """
         Return True/False the laser is on/off.
         """
-        self.message = lumencor_httpcommand(command="GET CH " + str(laser_id), ip=self.ip)
+        self.message = self._command("GET CH " + str(laser_id))
         response = self.message["message"]
         self.on = response[-1] == "1"
         return self.on
@@ -137,7 +148,7 @@ class CELESTA(LightSource):
         Return [minimum power, maximum power].
         """
         max_int = 1000  # default
-        self.message = lumencor_httpcommand(command="GET MAXINT", ip=self.ip)
+        self.message = self._command("GET MAXINT")
         if self.message["message"][0] == "A":
             max_int = float(self.message["message"].split(" ")[-1])
         return [0, max_int]
@@ -146,7 +157,7 @@ class CELESTA(LightSource):
         """
         Return the current laser power.
         """
-        self.message = lumencor_httpcommand(command="GET CHINT " + str(laser_id), ip=self.ip)
+        self.message = self._command("GET CHINT " + str(laser_id))
         log.debug("command = 'GET CHINT " + str(laser_id) + "'")
         response = self.message["message"]
         power = float(response.split(" ")[-1])
@@ -158,19 +169,17 @@ class CELESTA(LightSource):
         Turn the laser on/off.
         """
         if on:
-            self.message = lumencor_httpcommand(command="SET CH " + str(laser_id) + " 1", ip=self.ip)
+            self.message = self._command("SET CH " + str(laser_id) + " 1")
             self.on = True
         else:
-            self.message = lumencor_httpcommand(command="SET CH " + str(laser_id) + " 0", ip=self.ip)
+            self.message = self._command("SET CH " + str(laser_id) + " 0")
             self.on = False
         log.debug(f"Turning On/Off {self.on} {self.message}")
 
     def set_intensity(self, laser_id, intensity):
         log.debug(f"Setting intensity to {intensity}")
         power_in_mw = self.pmax * intensity / 100
-        self.message = lumencor_httpcommand(
-            command="SET CHINT " + str(laser_id) + " " + str(int(power_in_mw)), ip=self.ip
-        )
+        self.message = self._command("SET CHINT " + str(laser_id) + " " + str(int(power_in_mw)))
         if self.message["message"][0] == "A":
             return True
         return False

--- a/software/control/celesta.py
+++ b/software/control/celesta.py
@@ -16,9 +16,7 @@ import squid.logging
 
 log = squid.logging.get_logger(__name__)
 
-# Per-request HTTP timeout. Without one, urlopen() blocks indefinitely when the
-# Celesta is unplugged, powered off, or on a different subnet, which hangs
-# Microscope.build_from_global_config() before the GUI window ever appears.
+# urlopen() has no default timeout; an unreachable Celesta would otherwise hang GUI startup.
 DEFAULT_TIMEOUT_S = 5.0
 
 
@@ -42,14 +40,15 @@ class CELESTA(LightSource):
     Please connect the provided cat5e, RJ45 ethernet cable between the PC and Lumencor system.
     """
 
-    def __init__(self, **kwds):
+    def __init__(self, ip="192.168.201.200", timeout=DEFAULT_TIMEOUT_S):
         """
         Connect to the Lumencor system via HTTP and check if you get the right response.
         """
         self.on = False
-        self.ip = kwds.get("ip", "192.168.201.200")
-        self.timeout = kwds.get("timeout", DEFAULT_TIMEOUT_S)
+        self.ip = ip
+        self.timeout = timeout
         [self.pmin, self.pmax] = 0, 1000
+        self.live = True  # until the probe below fails; _command() then refuses further requests
         try:
             # See if the system returns back the right IP.
             self.message = self.get_IP()
@@ -84,6 +83,8 @@ class CELESTA(LightSource):
         }
 
     def _command(self, command):
+        if not self.live:
+            raise ConnectionError(f"Celesta at {self.ip} is offline (startup probe failed); not sending {command!r}")
         return lumencor_httpcommand(command=command, ip=self.ip, timeout=self.timeout)
 
     def initialize(self):

--- a/software/tests/control/test_celesta.py
+++ b/software/tests/control/test_celesta.py
@@ -1,0 +1,95 @@
+"""Tests for the Lumencor Celesta HTTP driver."""
+
+import socket
+
+import pytest
+
+import control.celesta as celesta
+
+
+class _FakeResponse:
+    def __init__(self, payload: bytes):
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self):
+        return self._payload
+
+
+def test_httpcommand_passes_a_timeout_to_urlopen(monkeypatch):
+    seen = {}
+
+    def fake_urlopen(url, *args, **kwargs):
+        seen["url"] = url
+        seen["timeout"] = kwargs.get("timeout")
+        return _FakeResponse(b"{'message': 'A IP 192.168.201.200'}")
+
+    monkeypatch.setattr(celesta.urllib.request, "urlopen", fake_urlopen)
+
+    msg = celesta.lumencor_httpcommand(command="GET IP", ip="192.168.201.200")
+
+    assert msg == {"message": "A IP 192.168.201.200"}
+    assert seen["url"] == "http://192.168.201.200/service/?command=GET%20IP"
+    assert seen["timeout"] is not None, "urlopen must be given a timeout so an unreachable Celesta cannot hang startup"
+    assert 0 < seen["timeout"] <= 30
+
+
+def test_httpcommand_honours_explicit_timeout(monkeypatch):
+    seen = {}
+
+    def fake_urlopen(url, *args, **kwargs):
+        seen["timeout"] = kwargs.get("timeout")
+        return _FakeResponse(b"{'message': 'A IP 192.168.201.200'}")
+
+    monkeypatch.setattr(celesta.urllib.request, "urlopen", fake_urlopen)
+
+    celesta.lumencor_httpcommand(command="GET IP", ip="192.168.201.200", timeout=1.5)
+
+    assert seen["timeout"] == 1.5
+
+
+def test_celesta_init_marks_device_offline_when_connection_times_out(monkeypatch):
+    def hanging_urlopen(url, *args, **kwargs):
+        raise socket.timeout("timed out")
+
+    monkeypatch.setattr(celesta.urllib.request, "urlopen", hanging_urlopen)
+
+    dev = celesta.CELESTA()
+
+    assert dev.live is False
+    assert dev.get_status() is False
+
+
+def test_celesta_init_uses_configured_timeout_for_every_request(monkeypatch):
+    timeouts = []
+
+    responses = {
+        "GET IP": b"{'message': 'A IP 192.168.201.200'}",
+        "GET CHMAP": b"{'message': 'A CHMAP 405 445 488 518 545 640 730'}",
+        "GET MAXINT": b"{'message': 'A MAXINT 1000'}",
+    }
+
+    def fake_urlopen(url, *args, **kwargs):
+        timeouts.append(kwargs.get("timeout"))
+        command = url.split("command=")[1].replace("%20", " ")
+        if command.startswith("GET CH "):
+            return _FakeResponse(b"{'message': 'A CH 0'}")
+        if command.startswith("SET CH "):
+            return _FakeResponse(b"{'message': 'A CH 0'}")
+        if command.startswith("SET TTLENABLE "):
+            return _FakeResponse(b"{'message': 'A TTLENABLE " + command[-1:].encode() + b"'}")
+        return _FakeResponse(responses[command])
+
+    monkeypatch.setattr(celesta.urllib.request, "urlopen", fake_urlopen)
+
+    dev = celesta.CELESTA(timeout=2.0)
+
+    assert dev.live is True
+    assert dev.n_lasers == 7
+    assert timeouts, "expected at least one HTTP request during init"
+    assert all(t == 2.0 for t in timeouts)

--- a/software/tests/control/test_celesta.py
+++ b/software/tests/control/test_celesta.py
@@ -1,95 +1,66 @@
 """Tests for the Lumencor Celesta HTTP driver."""
 
-import socket
+import io
 
 import pytest
 
 import control.celesta as celesta
 
-
-class _FakeResponse:
-    def __init__(self, payload: bytes):
-        self._payload = payload
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *exc):
-        return False
-
-    def read(self):
-        return self._payload
+IP_REPLY = b"{'message': 'A IP 192.168.201.200'}"
 
 
-def test_httpcommand_passes_a_timeout_to_urlopen(monkeypatch):
+@pytest.mark.parametrize("kwargs, expected", [({}, celesta.DEFAULT_TIMEOUT_S), ({"timeout": 1.5}, 1.5)])
+def test_httpcommand_passes_timeout_to_urlopen(monkeypatch, kwargs, expected):
     seen = {}
 
-    def fake_urlopen(url, *args, **kwargs):
-        seen["url"] = url
-        seen["timeout"] = kwargs.get("timeout")
-        return _FakeResponse(b"{'message': 'A IP 192.168.201.200'}")
+    def fake_urlopen(url, data=None, timeout=None, *args, **kw):
+        seen["url"], seen["timeout"] = url, timeout
+        return io.BytesIO(IP_REPLY)
 
-    monkeypatch.setattr(celesta.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
 
-    msg = celesta.lumencor_httpcommand(command="GET IP", ip="192.168.201.200")
+    msg = celesta.lumencor_httpcommand(command="GET IP", ip="192.168.201.200", **kwargs)
 
     assert msg == {"message": "A IP 192.168.201.200"}
     assert seen["url"] == "http://192.168.201.200/service/?command=GET%20IP"
-    assert seen["timeout"] is not None, "urlopen must be given a timeout so an unreachable Celesta cannot hang startup"
-    assert 0 < seen["timeout"] <= 30
+    assert seen["timeout"] == expected
 
 
-def test_httpcommand_honours_explicit_timeout(monkeypatch):
-    seen = {}
+def test_offline_celesta_stops_after_one_timeout(monkeypatch):
+    calls = []
 
-    def fake_urlopen(url, *args, **kwargs):
-        seen["timeout"] = kwargs.get("timeout")
-        return _FakeResponse(b"{'message': 'A IP 192.168.201.200'}")
+    def hanging_urlopen(url, data=None, timeout=None, *args, **kw):
+        calls.append(url)
+        raise TimeoutError("timed out")
 
-    monkeypatch.setattr(celesta.urllib.request, "urlopen", fake_urlopen)
-
-    celesta.lumencor_httpcommand(command="GET IP", ip="192.168.201.200", timeout=1.5)
-
-    assert seen["timeout"] == 1.5
-
-
-def test_celesta_init_marks_device_offline_when_connection_times_out(monkeypatch):
-    def hanging_urlopen(url, *args, **kwargs):
-        raise socket.timeout("timed out")
-
-    monkeypatch.setattr(celesta.urllib.request, "urlopen", hanging_urlopen)
+    monkeypatch.setattr("urllib.request.urlopen", hanging_urlopen)
 
     dev = celesta.CELESTA()
 
-    assert dev.live is False
     assert dev.get_status() is False
+    assert len(calls) == 1  # only the GET IP probe; nothing more is attempted once the device is known offline
+    with pytest.raises(ConnectionError):
+        dev.set_intensity(0, 10)
+    assert len(calls) == 1
 
 
 def test_celesta_init_uses_configured_timeout_for_every_request(monkeypatch):
     timeouts = []
-
     responses = {
-        "GET IP": b"{'message': 'A IP 192.168.201.200'}",
+        "GET IP": IP_REPLY,
         "GET CHMAP": b"{'message': 'A CHMAP 405 445 488 518 545 640 730'}",
         "GET MAXINT": b"{'message': 'A MAXINT 1000'}",
     }
 
-    def fake_urlopen(url, *args, **kwargs):
-        timeouts.append(kwargs.get("timeout"))
+    def fake_urlopen(url, data=None, timeout=None, *args, **kw):
+        timeouts.append(timeout)
         command = url.split("command=")[1].replace("%20", " ")
-        if command.startswith("GET CH "):
-            return _FakeResponse(b"{'message': 'A CH 0'}")
-        if command.startswith("SET CH "):
-            return _FakeResponse(b"{'message': 'A CH 0'}")
-        if command.startswith("SET TTLENABLE "):
-            return _FakeResponse(b"{'message': 'A TTLENABLE " + command[-1:].encode() + b"'}")
-        return _FakeResponse(responses[command])
+        # GET CH / SET CH / SET TTLENABLE replies are only inspected for a leading "A" or trailing "0"/"1".
+        return io.BytesIO(responses.get(command, b"{'message': 'A 0'}"))
 
-    monkeypatch.setattr(celesta.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
 
     dev = celesta.CELESTA(timeout=2.0)
 
-    assert dev.live is True
-    assert dev.n_lasers == 7
-    assert timeouts, "expected at least one HTTP request during init"
-    assert all(t == 2.0 for t in timeouts)
+    assert dev.get_status() is True
+    assert set(timeouts) == {2.0}


### PR DESCRIPTION
## Problem

On a Squid with a Lumencor Celesta (`USE_CELESTA_ETHERNET_CONTROL = True`), startup hung after the Toupcam began streaming. The last lines in the console were the camera's `frame N (CONTINUOUS)` diagnostics and nothing else ever appeared.

`Microscope.build_from_global_config` constructs `CELESTA()` right after the camera. That driver's HTTP helper called `urllib.request.urlopen()` with **no timeout**, so when the Celesta is unplugged, powered off, or the PC's NIC is not on the `192.168.201.x` subnet, the first `GET IP` request blocks indefinitely and the GUI window never opens.

## Fix

`control/celesta.py`:
- `lumencor_httpcommand()` takes a `timeout=` argument (default `DEFAULT_TIMEOUT_S = 5.0`) and passes it to `urlopen()`, bounding both the TCP connect and the response read.
- `CELESTA(ip=..., timeout=...)` has an explicit signature (was `**kwds`) and routes every command through a single `_command()` helper, so the timeout applies to all requests uniformly.
- Once the startup probe (`GET IP`) fails, `_command()` raises `ConnectionError` naming the device and the refused command instead of issuing more requests. The illumination controller's first call therefore fails immediately rather than spending a second timeout and surfacing a raw `URLError`.
- The connection-failure log reports the real IP and timeout.

No behavior change when the Celesta is reachable.

When it is **not** reachable, startup now fails after one 5 s timeout with `Failed to connect to Lumencor Laser at ip: 192.168.201.200 (timeout=5.0s)` followed by a `ConnectionError` from the illumination controller, instead of hanging. Letting the GUI come up with the laser offline is out of scope here and would be a follow-up.

## Tests

`tests/control/test_celesta.py` (`urlopen` monkeypatched, no network):
- default and explicit timeout reach `urlopen` (parametrized)
- an offline device makes exactly one HTTP attempt during init, and later calls raise `ConnectionError` without touching the network
- the configured timeout reaches every request made during a successful init

```
python3 -m pytest tests/control/test_celesta.py -q   # 4 passed
black --config pyproject.toml --check control/celesta.py tests/control/test_celesta.py   # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCmWuptseJKs9AfLrVLkRR
