### PR TITLE
chore: add CODEOWNERS and a PR template for the review process

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Review routing. GitHub requests a review from the owner of every changed path.
+# Default: the maintainer of master reviews and merges software changes.
+*                                           @Alpaca233
+
+# Firmware and the host <-> MCU protocol: Hongquan reviews.
+/firmware/                                  @hongquanli
+/software/control/microcontroller.py        @hongquanli
+/software/control/firmware_sim_serial.py    @hongquanli

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## What
+
+
+
+## Why
+
+
+
+## Gate
+
+The flag, INI setting, or machine config that enables this, or "always on, because ...":
+
+
+
+## Evidence
+
+- [ ] CI green on the head commit (one rerun is allowed for the exit-time segfault flake)
+- [ ] Rebased on master within the last 7 days
+- [ ] Tests added or updated:
+- [ ] Hardware: machine, camera, and what was run, or "simulation only, because ...":
+
+## Size
+
+- [ ] Under 1,000 changed lines, or the AI-docs design doc is linked here:
+- [ ] Not stacked on another PR, or the base PR is named here and this merges into that branch first:


### PR DESCRIPTION
## What

- `.github/CODEOWNERS`: every PR requests a review from @Alpaca233 (maintainer of master); `firmware/`, `control/microcontroller.py` and `control/firmware_sim_serial.py` request @hongquanli.
- `.github/pull_request_template.md`: the ready-for-review checklist (what, why, the flag or config that gates the change, CI and hardware evidence, size and stacking).

## Why

61 PRs were open on 2026-09-08 and 44 of them had never been reviewed, because nobody was assigned. CODEOWNERS makes GitHub do the assignment. The template makes "ready for review" mean the same thing for everyone.

Process design with the merge order for the open backlog: AI-docs `Squid/to-do/2026-09-09-pr-backlog-and-customer-lanes-design.md` (approved 2026-09-08).

## Test plan

- [ ] After merge, open any PR touching `firmware/` and confirm both reviewers are requested.
- [ ] Open a PR and confirm the template pre-fills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135ZEPVUoAwjCfCQCjpPcnU
